### PR TITLE
feat: Add basic file management operations to vault tool (move, rename, copy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Obsidian MCP Plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.13] - 2025-01-11
 
 ### Added
 - **File Management Operations**: New vault actions for organizing files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Obsidian MCP Plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **File Management Operations**: New vault actions for organizing files
+  - `move` - Move files to new locations with automatic link updates
+  - `rename` - Rename files in place with automatic link updates
+  - `copy` - Create copies of files with optional overwrite
+  - All operations include semantic workflow hints for next actions
+  - Uses native Obsidian file manager when available for link preservation
+  - Fallback to copy/delete for environments without direct API access
+
 ## [0.5.12] - 2025-07-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Obsidian MCP Plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.13] - 2025-01-11
+## [0.5.13] - 2025-07-10
 
 ### Added
 - **File Management Operations**: New vault actions for organizing files

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ Enable multiple AI agents to work with your vault simultaneously without blockin
 - **delete** - Delete files and folders
 - **search** - Enhanced search with Obsidian operators
 - **fragments** - Get relevant excerpts from files
+- **move** - Move files to new locations (preserves links)
+- **rename** - Rename files in place (preserves links)
+- **copy** - Create copies of files
 
 **Search Operators**:
 - `file:` - Search by filename or extension (e.g., `file:.png`)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "semantic-vault-mcp",
   "name": "Semantic Notes Vault MCP",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "minAppVersion": "0.15.0",
   "description": "Semantic MCP server providing AI tools with direct vault access via HTTP transport",
   "author": "Aaron Bockelie",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-mcp-plugin",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "Semantic MCP server plugin providing AI tools with direct Obsidian vault access via HTTP transport",
   "main": "main.js",
   "scripts": {

--- a/src/tools/semantic-tools.ts
+++ b/src/tools/semantic-tools.ts
@@ -141,7 +141,7 @@ function filterImageFilesFromSearchResults(searchResult: any): any {
 
 function getOperationDescription(operation: string): string {
   const descriptions: Record<string, string> = {
-    vault: '📁 File operations - list, read, create, update, delete, search, fragments (extract snippets from large files). Search supports operators: file:, path:, content:, tag:. OR for multiple terms. "quoted phrases". /regex/. Results ranked by relevance.',
+    vault: '📁 File operations - list, read, create, update, delete, search, fragments, move, rename, copy. Search supports operators: file:, path:, content:, tag:. OR for multiple terms. "quoted phrases". /regex/. Results ranked by relevance.',
     edit: '✏️ Edit files - window: find/replace with fuzzy matching, append: add to end, patch: modify headings/blocks/frontmatter, at_line: insert at line number, from_buffer: reuse previous window content',
     view: '👁️ View content - file: entire document, window: ~20 lines around point, active: current editor file, open_in_obsidian: launch in app',
     workflow: '💡 Get contextual suggestions for next actions based on current state',
@@ -153,7 +153,7 @@ function getOperationDescription(operation: string): string {
 
 function getActionsForOperation(operation: string): string[] {
   const actions: Record<string, string[]> = {
-    vault: ['list', 'read', 'create', 'update', 'delete', 'search', 'fragments'],
+    vault: ['list', 'read', 'create', 'update', 'delete', 'search', 'fragments', 'move', 'rename', 'copy'],
     edit: ['window', 'append', 'patch', 'at_line', 'from_buffer'],
     view: ['file', 'window', 'active', 'open_in_obsidian'],
     workflow: ['suggest'],
@@ -215,6 +215,18 @@ function getParametersForOperation(operation: string): Record<string, any> {
       includeContent: {
         type: 'boolean',
         description: 'Include file content in search results (slower but more thorough)'
+      },
+      destination: {
+        type: 'string',
+        description: 'Destination path for move/copy operations'
+      },
+      newName: {
+        type: 'string',
+        description: 'New filename for rename operation (without path)'
+      },
+      overwrite: {
+        type: 'boolean',
+        description: 'Whether to overwrite if destination exists (default: false)'
       },
       ...contentParam
     },

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
 // Version is injected at build time by sync-version.mjs
 export function getVersion(): string {
-  return '0.5.12';
+  return '0.5.13';
 }


### PR DESCRIPTION
## Summary
- Implements move, rename, and copy operations for the vault tool as requested in #5
- Provides native Obsidian integration for preserving links during file operations
- Includes semantic workflow hints to guide users on next actions

## Implementation Details

### New Actions Added
1. **move** - Move files to new locations
   - Uses Obsidian's `fileManager.renameFile()` when available (preserves links)
   - Falls back to copy/delete when Obsidian API not available
   - Supports overwrite protection with optional `overwrite` parameter

2. **rename** - Rename files in place
   - Convenience wrapper around move for same-directory operations
   - Preserves links through Obsidian's native rename functionality
   - Validates new filename doesn't already exist

3. **copy** - Create copies of files
   - Creates exact duplicate at specified location
   - Automatically creates parent directories as needed
   - Supports overwrite with explicit parameter

### Key Features
- ✅ Semantic workflow hints after each operation
- ✅ Proper error handling with recovery suggestions
- ✅ Directory creation handled automatically
- ✅ Image file detection prevents corruption
- ✅ Consistent with existing vault operation patterns

## Test Plan
- [x] Build and lint pass
- [x] Existing tests pass
- [ ] Manual testing in Obsidian:
  - [ ] Move file within same folder
  - [ ] Move file to different folder
  - [ ] Rename file
  - [ ] Copy file
  - [ ] Test overwrite protection
  - [ ] Verify link preservation

Resolves #5

🤖 Generated with [Claude Code](https://claude.ai/code)