### PR TITLE
Replace hard-coded server names with dynamic vault names in MCP configuration examples

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1127,7 +1127,7 @@ class MCPSettingTab extends PluginSettingTab {
 		
 		const configJson = this.plugin.settings.dangerouslyDisableAuth ? {
 			"mcpServers": {
-				"obsidian": {
+				[this.app.vault.getName()]: {
 					"transport": {
 						"type": "http",
 						"url": `http://localhost:${this.plugin.settings.httpPort}/mcp`
@@ -1136,7 +1136,7 @@ class MCPSettingTab extends PluginSettingTab {
 			}
 		} : {
 			"mcpServers": {
-				"obsidian": {
+				[this.app.vault.getName()]: {
 					"transport": {
 						"type": "http",
 						"url": `http://obsidian:${this.plugin.settings.apiKey}@localhost:${this.plugin.settings.httpPort}/mcp`
@@ -1160,7 +1160,7 @@ class MCPSettingTab extends PluginSettingTab {
 		
 		const remoteJson = this.plugin.settings.dangerouslyDisableAuth ? {
 			"mcpServers": {
-				"obsidian-vault": {
+				[this.app.vault.getName()]: {
 					"command": "npx",
 					"args": [
 						"mcp-remote",
@@ -1170,7 +1170,7 @@ class MCPSettingTab extends PluginSettingTab {
 			}
 		} : {
 			"mcpServers": {
-				"obsidian-vault": {
+				[this.app.vault.getName()]: {
 					"command": "npx",
 					"args": [
 						"mcp-remote",
@@ -1197,7 +1197,7 @@ class MCPSettingTab extends PluginSettingTab {
 		
 		const windowsJson = this.plugin.settings.dangerouslyDisableAuth ? {
 			"mcpServers": {
-				"obsidian-vault": {
+				[this.app.vault.getName()]: {
 					"command": "npx",
 					"args": [
 						"mcp-remote",
@@ -1207,7 +1207,7 @@ class MCPSettingTab extends PluginSettingTab {
 			}
 		} : {
 			"mcpServers": {
-				"obsidian-vault": {
+				[this.app.vault.getName()]: {
 					"command": "npx",
 					"args": [
 						"mcp-remote",


### PR DESCRIPTION
## Summary
- Replaces hard-coded "obsidian-vault" references with dynamic vault names in MCP configuration examples
- Improves user experience by showing actual vault names in setup instructions
- Addresses issue #20 by making configuration examples more intuitive and vault-specific

## Changes
- Updated settings tab to display current vault name in MCP configuration examples
- Enhanced user guidance with personalized setup instructions
- Maintains backward compatibility with existing configurations

## Test plan
- [x] Verified dynamic vault name appears correctly in settings
- [x] Tested with different vault names
- [x] Confirmed configuration examples work as expected
- [x] BRAT installation and updates working properly

Resolves #20