### PR TITLE
fix: Populate metadata fields in vault.read() responses

### DIFF
--- a/src/semantic/state-tokens.ts
+++ b/src/semantic/state-tokens.ts
@@ -73,12 +73,21 @@ export class StateTokenManager {
         this.tokens.file_loaded = params.path;
         this.tokens.file_content = true;
         this.tokens.file_is_markdown = params.path?.endsWith('.md');
-        
-        // Extract links and tags from content
-        if (typeof result === 'object' && result.content) {
-          const content = result.content;
-          this.tokens.file_has_links = this.extractLinks(content);
-          this.tokens.file_has_tags = this.extractTags(content);
+
+        // Extract links and tags from result
+        if (typeof result === 'object') {
+          // Use tags from API response (includes frontmatter tags from metadataCache)
+          if (result.tags && Array.isArray(result.tags)) {
+            this.tokens.file_has_tags = result.tags;
+          } else if (result.content) {
+            // Fallback to content extraction
+            this.tokens.file_has_tags = this.extractTags(result.content);
+          }
+
+          // Extract links from content
+          if (result.content) {
+            this.tokens.file_has_links = this.extractLinks(result.content);
+          }
         }
         
         // Update history

--- a/src/utils/obsidian-api.ts
+++ b/src/utils/obsidian-api.ts
@@ -73,13 +73,22 @@ export class ObsidianAPI {
     }
 
     const content = await this.app.vault.read(activeFile);
-    const stat = await this.app.vault.adapter.stat(activeFile.path);
-    
+
+    // Extract metadata from cache
+    const cache = this.app.metadataCache.getFileCache(activeFile);
+    const tags = cache ? (getAllTags(cache) || []) : [];
+    const frontmatter = cache?.frontmatter ? { ...cache.frontmatter } : {};
+
+    // Remove position metadata from frontmatter (internal Obsidian data)
+    if (frontmatter.position) {
+      delete frontmatter.position;
+    }
+
     return {
       path: activeFile.path,
       content,
-      tags: [], // TODO: Extract tags from frontmatter/content
-      frontmatter: {} // TODO: Parse frontmatter
+      tags,
+      frontmatter
     };
   }
 
@@ -226,12 +235,22 @@ export class ObsidianAPI {
 
     // Regular text file
     const content = await this.app.vault.read(file);
-    
+
+    // Extract metadata from cache
+    const cache = this.app.metadataCache.getFileCache(file);
+    const tags = cache ? (getAllTags(cache) || []) : [];
+    const frontmatter = cache?.frontmatter ? { ...cache.frontmatter } : {};
+
+    // Remove position metadata from frontmatter (internal Obsidian data)
+    if (frontmatter.position) {
+      delete frontmatter.position;
+    }
+
     return {
       path: file.path,
       content,
-      tags: [], // TODO: Extract tags from frontmatter/content
-      frontmatter: {} // TODO: Parse frontmatter
+      tags,
+      frontmatter
     };
   }
 


### PR DESCRIPTION
## Summary
Fixes #61 - frontmatter, tags, and context metadata fields were returning empty values despite files containing valid YAML frontmatter.

## Changes
- Use Obsidian's `metadataCache.getFileCache()` to extract tags via `getAllTags()`
- Extract frontmatter from cache (removing internal position metadata)
- Update state-tokens to prefer API response tags over regex extraction
- Fixes both `getFile()` and `getActiveFile()` methods

## Technical Details
The fix uses Obsidian's native metadata parsing which correctly handles:
- Frontmatter YAML tags (`tags: [a, b]` or `tags:\n  - a\n  - b`)
- Inline hashtag tags (`#tag`)
- Nested/hierarchical tags (`#parent/child`)

Previously, the code had TODO comments indicating this was never implemented:
```typescript
tags: [], // TODO: Extract tags from frontmatter/content
frontmatter: {} // TODO: Parse frontmatter
```

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] All 127 tests pass
- [ ] Manual test: Read a file with frontmatter tags and verify they appear in response
- [ ] Manual test: Verify `context.has_tags` and `context.tags` are populated