### PR TITLE
fix(system): report both HTTP and HTTPS ports in system info

### DIFF
--- a/src/formatters/system.ts
+++ b/src/formatters/system.ts
@@ -26,6 +26,10 @@ export interface SystemInfoResponse {
   mcp?: {
     running?: boolean;
     port?: number;
+    httpEnabled?: boolean;
+    httpsEnabled?: boolean;
+    httpPort?: number;
+    httpsPort?: number;
     connections?: number;
     vault?: string;
   };
@@ -64,7 +68,16 @@ export function formatSystemInfo(response: SystemInfoResponse): string {
     if (response.mcp) {
       lines.push(header(2, 'MCP Server'));
       lines.push(property('Running', response.mcp.running ? 'Yes' : 'No', 0));
-      if (response.mcp.port) {
+      if (response.mcp.httpPort !== undefined) {
+        const httpStatus = response.mcp.httpEnabled === false ? ' (disabled)' : '';
+        lines.push(property('HTTP Port', response.mcp.httpPort.toString() + httpStatus, 0));
+      }
+      if (response.mcp.httpsPort !== undefined) {
+        const httpsStatus = response.mcp.httpsEnabled === false ? ' (disabled)' : '';
+        lines.push(property('HTTPS Port', response.mcp.httpsPort.toString() + httpsStatus, 0));
+      }
+      // Legacy: single port field
+      if (response.mcp.port && response.mcp.httpPort === undefined) {
         lines.push(property('Port', response.mcp.port.toString(), 0));
       }
       if (response.mcp.connections !== undefined) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,10 @@ interface MCPPluginSettings {
 interface MCPServerInfo {
 	version: string;
 	running: boolean;
-	port: number;
+	httpEnabled: boolean;
+	httpsEnabled: boolean;
+	httpPort: number;
+	httpsPort: number;
 	vaultName: string;
 	vaultPath: string;
 	toolsCount: number;
@@ -336,7 +339,10 @@ export default class ObsidianMCPPlugin extends Plugin {
 		return {
 			version: getVersion(),
 			running: this.mcpServer?.isServerRunning() || false,
-			port: this.settings.httpPort,
+			httpEnabled: this.settings.httpEnabled,
+			httpsEnabled: this.settings.httpsEnabled,
+			httpPort: this.settings.httpPort,
+			httpsPort: this.settings.httpsPort,
 			vaultName: this.app.vault.getName(),
 			vaultPath: this.getVaultPath(),
 			toolsCount: 6,
@@ -585,7 +591,7 @@ class MCPSettingTab extends PluginSettingTab {
 			
 			createStatusItem('Status', info.running ? 'Running' : 'Stopped', 
 				info.running ? 'success' : 'error');
-			createStatusItem('Port', info.port.toString());
+			createStatusItem('Port', (info.httpsEnabled ? info.httpsPort : info.httpPort).toString());
 			createStatusItem('Vault', info.vaultName);
 			if (info.vaultPath) {
 				createStatusItem('Path', info.vaultPath.length > 50 ? '...' + info.vaultPath.slice(-47) : info.vaultPath);
@@ -1590,7 +1596,7 @@ class MCPSettingTab extends PluginSettingTab {
 					valueSpan.classList.remove('mcp-status-value', 'success', 'error');
 					valueSpan.classList.add('mcp-status-value', info.running ? 'success' : 'error');
 				} else if (text.includes('Port:') && valueSpan) {
-					valueSpan.textContent = info.port.toString();
+					valueSpan.textContent = (info.httpsEnabled ? info.httpsPort : info.httpPort).toString();
 				} else if (text.includes('Connections:') && valueSpan) {
 					valueSpan.textContent = info.connections.toString();
 				}
@@ -1604,7 +1610,7 @@ class MCPSettingTab extends PluginSettingTab {
 			if (codeBlock && info) {
 				// Get correct protocol and port based on HTTPS setting
 				const protocol = this.plugin.settings.httpsEnabled ? 'https' : 'http';
-				const port = this.plugin.settings.httpsEnabled ? this.plugin.settings.httpsPort : info.port;
+				const port = this.plugin.settings.httpsEnabled ? this.plugin.settings.httpsPort : info.httpPort;
 				const baseUrl = `${protocol}://localhost:${port}`;
 				
 				const claudeCommand = this.plugin.settings.dangerouslyDisableAuth ? 
@@ -1628,7 +1634,7 @@ class MCPSettingTab extends PluginSettingTab {
 					el.textContent = info.connections.toString();
 					break;
 				case 'server-port':
-					el.textContent = info.port.toString();
+					el.textContent = (info.httpsEnabled ? info.httpsPort : info.httpPort).toString();
 					break;
 			}
 		}

--- a/src/utils/obsidian-api.ts
+++ b/src/utils/obsidian-api.ts
@@ -21,7 +21,10 @@ interface ObsidianAPIMCPServerInfo {
 export interface ObsidianAPIPluginRef {
   settings?: {
     validation?: Partial<ValidationConfig>;
+    httpEnabled?: boolean;
+    httpsEnabled?: boolean;
     httpPort?: number;
+    httpsPort?: number;
   };
   ignoreManager?: MCPIgnoreManager;
   mcpServer?: ObsidianAPIMCPServerInfo;
@@ -121,7 +124,10 @@ export class ObsidianAPI {
         ...baseInfo,
         mcp: {
           running: mcpServer.isServerRunning(),
-          port: pluginSettings?.httpPort ?? 3001,
+          httpEnabled: pluginSettings?.httpEnabled,
+          httpsEnabled: pluginSettings?.httpsEnabled,
+          httpPort: pluginSettings?.httpPort,
+          httpsPort: pluginSettings?.httpsPort,
           connections: mcpServer.getConnectionCount() || 0,
           vault: this.app.vault.getName()
         },


### PR DESCRIPTION
## Summary

- `system info` always reported `httpPort` even when only HTTPS was bound
- Now exposes `httpEnabled`, `httpsEnabled`, `httpPort`, and `httpsPort` in both the API response and settings UI
- Formatter renders both listeners with enabled/disabled status
- Legacy single-port responses still handled for backward compatibility

## Files changed

- `src/formatters/system.ts` — formatter renders both ports with status
- `src/main.ts` — exposes both port/enabled fields in system info response
- `src/utils/obsidian-api.ts` — adds HTTPS port/enabled to API layer

## Test plan

- [x] Enable only HTTP → `system info` shows HTTP enabled, HTTPS disabled
- [x] Enable only HTTPS → `system info` shows HTTPS enabled, HTTP disabled
- [x] Enable both → both shown with correct ports
- [x] Existing clients that read `httpPort` still work (backward compat)

### Test results (0.11.16-local.1)

HTTP-only:
```json
{"httpEnabled": true, "httpsEnabled": false, "httpPort": 3001, "httpsPort": 3443}
```

HTTPS-only:
```json
{"httpEnabled": false, "httpsEnabled": true, "httpPort": 3001, "httpsPort": 3443}
```

Both enabled:
```json
{"httpEnabled": true, "httpsEnabled": true, "httpPort": 3001, "httpsPort": 3443}
```