### PR TITLE
fix(session): heal stale MCP sessions instead of returning HTTP 400

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ test-concurrent-sessions.js
 
 # Claude configuration directory
 .claude/
+
+# Serena AI directory
+.serena/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thanks for your interest in contributing! Since this is a small project, we keep
    - What actually happened
    - Steps to reproduce
 
-2. **Want to fix something?** 
+2. **Want to fix something?**
    - Fork the repo
    - Make your changes
    - Test locally with BRAT
@@ -49,6 +49,7 @@ npm test
 ## Commit Messages
 
 Keep them clear and descriptive:
+
 - `fix: Prevent path traversal in file operations`
 - `feat: Add rate limiting to API endpoints`
 - `docs: Update security guidelines`
@@ -57,6 +58,7 @@ Keep them clear and descriptive:
 ## Current Focus Areas
 
 Check our [GitHub Issues](https://github.com/aaronsb/obsidian-mcp-plugin/issues) for:
+
 - 🔴 Security vulnerabilities (highest priority)
 - 🟠 Input validation improvements
 - 🟡 Code quality refactoring

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-mcp-plugin",
-  "version": "0.11.15",
+  "version": "0.11.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-mcp-plugin",
-      "version": "0.11.15",
+      "version": "0.11.16",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import { App, Notice } from 'obsidian';
 import { createServer as createHttpServer, Server, IncomingMessage, ServerResponse } from 'http';
 import { Server as HttpsServer } from 'https';
+import { PassThrough } from 'stream';
 import { Server as MCPServer } from '@modelcontextprotocol/sdk/server/index.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import {
@@ -59,22 +60,6 @@ interface ServerWithTimeouts {
   setTimeout: (msecs: number) => unknown;
 }
 
-/** Null response shim for internal initialize calls */
-interface NullResponse {
-  writeHead: (status: number, headers?: Record<string, string>) => void;
-  setHeader: (k: string, v: string) => void;
-  getHeader: (k: string) => string | undefined;
-  statusCode: number;
-  headersSent: boolean;
-  write: (chunk: unknown) => void;
-  end: (data?: unknown) => void;
-  on: (event: string, handler: (...args: unknown[]) => void) => void;
-  once: (event: string, handler: (...args: unknown[]) => void) => void;
-  status: (v: number) => NullResponse;
-  json: (body: unknown) => void;
-  send: (body?: unknown) => void;
-}
-
 /** Connection pool stats response */
 interface ConnectionPoolStatsResponse {
   enabled: boolean;
@@ -108,6 +93,7 @@ export class MCPHttpServer {
   private sessionManager?: SessionManager;
   private certificateManager: CertificateManager | null;
   private isHttps: boolean = false;
+  private startTime: number = Date.now();
 
   constructor(obsidianApp: App, port: number = 3001, plugin?: MCPPluginRef) {
     this.obsidianApp = obsidianApp;
@@ -360,7 +346,13 @@ export class MCPHttpServer {
 
     // Handle session deletion
     this.app.delete('/mcp', (req, res) => {
-      const sessionId = req.headers['mcp-session-id'] as string;
+      let sessionId = req.headers['mcp-session-id'] as string;
+
+      // Resolve alias if the session ID is stale
+      if (sessionId && !this.transports.has(sessionId) && this.sessionManager) {
+        const aliasTarget = this.sessionManager.resolveAlias(sessionId);
+        if (aliasTarget) sessionId = aliasTarget;
+      }
 
       if (sessionId && this.transports.has(sessionId)) {
         const transport = this.transports.get(sessionId)!;
@@ -379,12 +371,17 @@ export class MCPHttpServer {
     try {
       const request = req.body as JsonRpcRequest | undefined;
 
-      // Get or create session ID
-      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+      // Get session ID from header; may be resolved via alias below
+      let sessionId = req.headers['mcp-session-id'] as string | undefined;
+      const originalSessionId = sessionId; // preserve for alias tracking
       Debug.log(`📨 MCP Request: ${request?.method ?? 'unknown'}${sessionId ? ` [Session: ${sessionId}]` : ''}`, request?.params);
+
       // Quick path: lightweight ping to keep session alive
       if (request?.method === 'session/ping' || request?.method === 'status/ping') {
         if (sessionId && this.sessionManager) {
+          // Try alias resolution for pings too
+          const aliasTarget = this.sessionManager.resolveAlias(sessionId);
+          if (aliasTarget) sessionId = aliasTarget;
           this.sessionManager.touchSession(sessionId);
         }
         if (sessionId) {
@@ -393,40 +390,30 @@ export class MCPHttpServer {
         res.status(200).json({ jsonrpc: '2.0', id: request?.id ?? null, result: { ok: true, sessionId: sessionId || null } });
         return;
       }
+
+      // Resolve session aliases before the main branching logic.
+      // If the client sends a stale session ID that was previously healed,
+      // the alias resolves it to the active session without re-running compat init.
+      let resolvedFromAlias = false;
+      if (sessionId && this.sessionManager && !this.transports.has(sessionId)) {
+        const aliasTarget = this.sessionManager.resolveAlias(sessionId);
+        if (aliasTarget && this.transports.has(aliasTarget)) {
+          Debug.log(`🔗 Resolved session alias: ${sessionId} → ${aliasTarget}`);
+          sessionId = aliasTarget;
+          resolvedFromAlias = true;
+        }
+      }
+
       let transport: StreamableHTTPServerTransport | undefined;
       let effectiveSessionId!: string; // will be set in the branches below
       if (sessionId) {
         effectiveSessionId = sessionId;
       }
-          let mcpServer: MCPServer;
+      let mcpServer: MCPServer;
 
-      // Helper: create a null response shim so we can send an internal initialize
-      const createNullRes = (): NullResponse => {
-        const headers: Record<string, string> = {};
-        let sent = false;
-        let code = 200;
-        const resp: NullResponse = {
-          // Node-style response interface (minimal no-op implementation)
-          writeHead: (_status: number, _headers?: Record<string, string>) => { code = _status; sent = true; },
-          setHeader: (k: string, v: string) => { headers[k] = v; },
-          getHeader: (k: string) => headers[k],
-          get statusCode() { return code; },
-          set statusCode(v: number) { code = v; },
-          get headersSent() { return sent; },
-          write: (_chunk: unknown) => { /* no-op */ },
-          end: (_data?: unknown) => { sent = true; },
-          on: (_event: string, _handler: (...args: unknown[]) => void) => { /* no-op */ },
-          once: (_event: string, _handler: (...args: unknown[]) => void) => { /* no-op */ },
-          // Express-like helpers (used by some wrappers)
-          status: (v: number) => { code = v; return resp; },
-          json: (_body: unknown) => { sent = true; },
-          send: (_body?: unknown) => { sent = true; },
-        };
-        return resp;
-      };
       // When a non-initialize request arrives without an active transport,
-      // we return a JSON-RPC error instructing the client to initialize using
-      // the provided session ID. This avoids fragile internal auto-initialize.
+      // we attempt an internal compat-initialize. If that fails, we return
+      // a structured JSON-RPC error instead of a vague HTTP 400.
       let requireInitializeNotice = false;
 
       // Helper: register transport with lifecycle hooks
@@ -459,18 +446,20 @@ export class MCPHttpServer {
       if (sessionId && this.transports.has(sessionId)) {
           // Use existing transport for this session
           transport = this.transports.get(sessionId)!;
-          
+
           // Get the server for this session (it should already exist)
           mcpServer = this.mcpServerPool.getOrCreateServer(sessionId);
-          
+
           // Update session activity
           if (this.sessionManager) {
             this.sessionManager.touchSession(sessionId);
           }
         } else if (sessionId && this.sessionManager) {
-          // Session ID provided but no active transport
-          // Only allow re-create on initialize; otherwise signal explicit session expiration
+          // Session ID provided but no active transport.
+          // For initialize requests: recreate transport directly.
+          // For non-initialize: create transport and attempt compat init.
           if (isInitializeRequest(request)) {
+            // Initialize always recovers — ignore stale session state
             const session = this.sessionManager.getOrCreateSession(sessionId);
             mcpServer = this.mcpServerPool.getOrCreateServer(sessionId);
             effectiveSessionId = sessionId;
@@ -483,8 +472,8 @@ export class MCPHttpServer {
             this.connectionCount++;
             Debug.log(`♻️ Recreated transport for session ${sessionId} (requests: ${session.requestCount})`);
           } else {
-            // Create transport and require client initialize on next call
-            const newSessionId = sessionId; // reuse provided id (guaranteed by branch)
+            // Create transport and attempt compat init below
+            const newSessionId = sessionId;
             mcpServer = this.mcpServerPool.getOrCreateServer(newSessionId);
             effectiveSessionId = newSessionId;
             transport = new StreamableHTTPServerTransport({
@@ -499,29 +488,29 @@ export class MCPHttpServer {
         } else if (!sessionId && isInitializeRequest(request)) {
           // New initialization request - create new transport with session
           effectiveSessionId = randomUUID();
-          
+
           // Get or create server for this session
           mcpServer = this.mcpServerPool.getOrCreateServer(effectiveSessionId);
-          
+
           transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => effectiveSessionId
           });
-          
+
           // Connect the MCP server to this transport
           await mcpServer.connect(transport);
-          
+
           // Store the transport for future requests
           this.transports.set(effectiveSessionId, transport);
           attachTransportHandlers(effectiveSessionId, transport);
           this.connectionCount++;
-          
+
           // Register session with manager if enabled
           if (this.sessionManager) {
             this.sessionManager.getOrCreateSession(effectiveSessionId);
           }
         } else {
           // No or unknown session on non-initialize request.
-          // Generate a session (or reuse provided) and require client initialize next.
+          // Generate a session (or reuse provided) and attempt compat init.
           const newSessionId = sessionId ?? randomUUID();
           mcpServer = this.mcpServerPool.getOrCreateServer(newSessionId);
           effectiveSessionId = newSessionId;
@@ -536,21 +525,14 @@ export class MCPHttpServer {
         }
 
       // Compatibility: if we just created a transport for a non-initialize call,
-      // attempt a safe, internal initialize to avoid client retry loops.
+      // attempt a proper internal initialize using real Node.js HTTP objects
+      // so the SDK's transport transitions to _initialized=true.
       if (requireInitializeNotice && transport && !isInitializeRequest(request)) {
-        // Clone req to ensure session header is present for compat initialize
-        const compatReq = {
-          ...req,
-          headers: {
-            ...req.headers,
-            'mcp-session-id': effectiveSessionId
-          }
-        } as unknown as IncomingMessage;
         const versionsToTry = ['2025-06-18', '2024-11-05', '1.0'];
         let initOk = false;
         for (const ver of versionsToTry) {
           try {
-            const initReq = {
+            const initBody = {
               jsonrpc: '2.0',
               id: '__compat_init__',
               method: 'initialize',
@@ -559,35 +541,57 @@ export class MCPHttpServer {
                 capabilities: {},
                 clientInfo: { name: 'obsidian-mcp-compat', version: getVersion() }
               }
-            } as unknown;
-            await transport.handleRequest(compatReq, createNullRes() as unknown as ServerResponse, initReq);
-            initOk = true;
-            Debug.log(`Compat initialize succeeded with protocolVersion=${ver}`);
-            break;
+            };
+            const { req: initReq, res: initRes } = this.createCompatInitPair(effectiveSessionId, initBody);
+            await transport.handleRequest(initReq, initRes, initBody);
+            // Verify the init actually succeeded by checking response status
+            if (initRes.statusCode >= 200 && initRes.statusCode < 300) {
+              initOk = true;
+              Debug.log(`♻️ Session healed: compat initialize succeeded (protocolVersion=${ver}, session=${effectiveSessionId})`);
+              break;
+            } else {
+              Debug.log(`⚠️ Compat initialize returned status ${initRes.statusCode} (protocolVersion=${ver})`);
+            }
           } catch (e) {
-            Debug.error(`Compat initialize attempt failed (protocolVersion=${ver}):`, e);
+            Debug.error(`⚠️ Compat initialize attempt failed (protocolVersion=${ver}):`, e);
           }
         }
-        // Fail-open: even if initialize failed, proceed with the original request
-        // to avoid client retry loops. The transport/server may still reject it,
-        // but this gives us a concrete server error to act on.
-        requireInitializeNotice = false;
-        if (!initOk) {
-          Debug.log('Compat initialize failed; proceeding without explicit initialize (fail-open).');
+        if (initOk) {
+          requireInitializeNotice = false;
+          // Create alias so subsequent requests with the original stale ID
+          // resolve directly without re-running compat init
+          if (originalSessionId && originalSessionId !== effectiveSessionId && this.sessionManager) {
+            this.sessionManager.createAlias(originalSessionId, effectiveSessionId);
+          }
+          // Register the healed session with the session manager
+          if (this.sessionManager) {
+            this.sessionManager.getOrCreateSession(effectiveSessionId);
+          }
+        } else {
+          Debug.log(`⚠️ Session recovery failed for ${request?.method ?? 'unknown'} (session=${effectiveSessionId})`);
         }
       }
 
+      // Always set canonical session ID header so clients can converge
+      if (effectiveSessionId) {
+        res.setHeader('Mcp-Session-Id', effectiveSessionId);
+      }
+
       // If initialization is still required and this isn't an initialize request,
-      // instruct the client to initialize for this session.
+      // return a structured JSON-RPC error with recovery instructions.
       if (requireInitializeNotice && !isInitializeRequest(request)) {
         const id = request?.id ?? null;
-        res.setHeader('Mcp-Session-Id', effectiveSessionId);
-        res.status(400).json({
+        res.status(200).json({
           jsonrpc: '2.0',
           error: {
-            code: -32000,
-            message: 'Bad Request: Server not initialized',
-            data: { sessionId: effectiveSessionId }
+            code: -32001,
+            message: 'MCP session expired or unknown',
+            data: {
+              reason: 'unknown_session',
+              recoverable: true,
+              retry: 'initialize',
+              sessionId: effectiveSessionId
+            }
           },
           id
         });
@@ -597,12 +601,18 @@ export class MCPHttpServer {
       // Safety: ensure we have a transport before forwarding
       if (!transport) {
         const id = request?.id ?? null;
-        if (effectiveSessionId) {
-          res.setHeader('Mcp-Session-Id', effectiveSessionId);
-        }
         res.status(200).json({
           jsonrpc: '2.0',
-          error: { code: -32001, message: 'No active transport/session. Please initialize and retry.', data: effectiveSessionId ? { sessionId: effectiveSessionId } : undefined },
+          error: {
+            code: -32001,
+            message: 'MCP session expired or unknown',
+            data: {
+              reason: 'no_transport',
+              recoverable: true,
+              retry: 'initialize',
+              sessionId: effectiveSessionId || undefined
+            }
+          },
           id
         });
         return;
@@ -614,8 +624,13 @@ export class MCPHttpServer {
         res as unknown as ServerResponse,
         request as unknown
       );
-      
-      Debug.log('📤 MCP Response sent via transport');
+
+      // If the response was handled by an alias-resolved session, log it
+      if (resolvedFromAlias) {
+        Debug.log(`📤 MCP Response sent via alias-resolved session (original=${originalSessionId})`);
+      } else {
+        Debug.log('📤 MCP Response sent via transport');
+      }
 
     } catch (error) {
       Debug.error('❌ MCP request error:', error);
@@ -630,6 +645,33 @@ export class MCPHttpServer {
         });
       }
     }
+  }
+
+  /**
+   * Create a proper Node.js IncomingMessage/ServerResponse pair for internal
+   * compat-initialize calls. The SDK's StreamableHTTPServerTransport uses
+   * Hono's getRequestListener which requires real Node.js HTTP objects —
+   * a minimal shim is insufficient.
+   */
+  private createCompatInitPair(sessionId: string, body: unknown): { req: IncomingMessage; res: ServerResponse } {
+    const socket = new PassThrough() as unknown as import('net').Socket;
+    const initReq = new IncomingMessage(socket);
+    initReq.method = 'POST';
+    initReq.url = '/mcp';
+    initReq.headers = {
+      'content-type': 'application/json',
+      'mcp-session-id': sessionId
+    };
+    // Push the body as stream data so the request is readable
+    const bodyStr = JSON.stringify(body);
+    initReq.push(bodyStr);
+    initReq.push(null);
+
+    const initRes = new ServerResponse(initReq);
+    // Pipe response output to a PassThrough to prevent writing to a real socket
+    initRes.assignSocket(new PassThrough() as unknown as import('net').Socket);
+
+    return { req: initReq, res: initRes };
   }
 
 
@@ -748,6 +790,14 @@ export class MCPHttpServer {
 
   getPort(): number {
     return this.port;
+  }
+
+  getStartTime(): number {
+    return this.startTime;
+  }
+
+  getSessionManager(): SessionManager | undefined {
+    return this.sessionManager;
   }
 
   isServerRunning(): boolean {

--- a/src/utils/obsidian-api.ts
+++ b/src/utils/obsidian-api.ts
@@ -15,6 +15,8 @@ import { InputValidator, ValidationException, ValidationConfig } from '../valida
 interface ObsidianAPIMCPServerInfo {
   isServerRunning(): boolean;
   getConnectionCount(): number;
+  getStartTime?(): number;
+  getSessionManager?(): { getStats(): { activeSessions: number; totalRequests: number }; getAliasCount(): number } | undefined;
 }
 
 /** Minimal plugin interface for ObsidianAPI dependency */
@@ -117,13 +119,23 @@ export class ObsidianAPI {
     if (this.plugin?.mcpServer) {
       const mcpServer = this.plugin.mcpServer;
       const pluginSettings = this.plugin.settings;
+      const sessionManager = mcpServer.getSessionManager?.();
+      const sessionStats = sessionManager?.getStats();
       return {
         ...baseInfo,
         mcp: {
           running: mcpServer.isServerRunning(),
           port: pluginSettings?.httpPort ?? 3001,
           connections: mcpServer.getConnectionCount() || 0,
-          vault: this.app.vault.getName()
+          vault: this.app.vault.getName(),
+          ...(mcpServer.getStartTime && { serverUptime: Math.round((Date.now() - mcpServer.getStartTime()) / 1000) }),
+          ...(sessionStats && {
+            sessionHealth: {
+              activeSessions: sessionStats.activeSessions,
+              totalRequests: sessionStats.totalRequests,
+              activeAliases: sessionManager?.getAliasCount() ?? 0
+            }
+          })
         },
         ...(dailyNotesFolder !== undefined && { dailyNotesFolder })
       };

--- a/src/utils/session-manager.ts
+++ b/src/utils/session-manager.ts
@@ -18,9 +18,16 @@ export interface SessionManagerOptions {
 /**
  * Manages MCP session lifecycle with automatic timeout and recycling
  */
+/** Short-lived mapping from a stale session ID to its replacement */
+interface SessionAlias {
+  targetSessionId: string;
+  expiresAt: number;
+}
+
 export class SessionManager extends EventEmitter {
   private sessions: Map<string, SessionInfo> = new Map();
   private sessionOrder: string[] = []; // Track session order for LRU eviction
+  private aliases: Map<string, SessionAlias> = new Map();
   private options: SessionManagerOptions;
   private cleanupInterval?: ReturnType<typeof setInterval>;
 
@@ -55,6 +62,7 @@ export class SessionManager extends EventEmitter {
     }
     this.sessions.clear();
     this.sessionOrder = [];
+    this.aliases.clear();
     Debug.log('🔐 Session manager stopped');
   }
 
@@ -164,6 +172,44 @@ export class SessionManager extends EventEmitter {
   }
 
   /**
+   * Create a short-lived alias mapping an old (stale) session ID to a new one.
+   * Allows clients that cache old session IDs to converge on the new session.
+   */
+  createAlias(oldSessionId: string, newSessionId: string, ttlMs: number = 300_000): void {
+    this.aliases.set(oldSessionId, {
+      targetSessionId: newSessionId,
+      expiresAt: Date.now() + ttlMs
+    });
+    Debug.log(`🔗 Session alias created: ${oldSessionId} → ${newSessionId} (TTL: ${Math.round(ttlMs / 1000)}s)`);
+  }
+
+  /**
+   * Resolve a session alias. Returns the target session ID if the alias exists
+   * and has not expired, otherwise undefined. Expired aliases are removed on access.
+   */
+  resolveAlias(sessionId: string): string | undefined {
+    const alias = this.aliases.get(sessionId);
+    if (!alias) return undefined;
+    if (Date.now() > alias.expiresAt) {
+      this.aliases.delete(sessionId);
+      return undefined;
+    }
+    return alias.targetSessionId;
+  }
+
+  /**
+   * Get the number of active (non-expired) aliases.
+   */
+  getAliasCount(): number {
+    const now = Date.now();
+    let count = 0;
+    for (const alias of this.aliases.values()) {
+      if (now <= alias.expiresAt) count++;
+    }
+    return count;
+  }
+
+  /**
    * Get session statistics
    */
   getStats(): {
@@ -244,7 +290,7 @@ export class SessionManager extends EventEmitter {
 
     for (const [sessionId, session] of this.sessions) {
       const idleTime = now - session.lastActivityAt;
-      
+
       if (idleTime > this.options.sessionTimeout) {
         expiredSessions.push(sessionId);
       }
@@ -252,10 +298,24 @@ export class SessionManager extends EventEmitter {
 
     if (expiredSessions.length > 0) {
       Debug.log(`🧹 Cleaning up ${expiredSessions.length} expired sessions`);
-      
+
       for (const sessionId of expiredSessions) {
         this.evictSession(sessionId, 'timeout');
       }
+    }
+
+    // Sweep expired aliases
+    const expiredAliases: string[] = [];
+    for (const [aliasId, alias] of this.aliases) {
+      if (now > alias.expiresAt) {
+        expiredAliases.push(aliasId);
+      }
+    }
+    for (const aliasId of expiredAliases) {
+      this.aliases.delete(aliasId);
+    }
+    if (expiredAliases.length > 0) {
+      Debug.log(`🧹 Cleaned up ${expiredAliases.length} expired session aliases`);
     }
   }
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -23,18 +23,40 @@ describe('MCPHttpServer', () => {
     } as any;
   });
 
-  test('should create server instance', () => {
-    const server = new MCPHttpServer(mockApp, 3001);
-    expect(server).toBeInstanceOf(MCPHttpServer);
-    expect(server.getPort()).toBe(3001);
-    expect(server.isServerRunning()).toBe(false);
+  describe('instantiation', () => {
+    test('should create server instance', () => {
+      const server = new MCPHttpServer(mockApp, 3001);
+      expect(server).toBeInstanceOf(MCPHttpServer);
+      expect(server.getPort()).toBe(3001);
+      expect(server.isServerRunning()).toBe(false);
+    });
+
+    test('should get correct port', () => {
+      const server = new MCPHttpServer(mockApp, 4001);
+      expect(server.getPort()).toBe(4001);
+    });
+
+    test('should have a start time', () => {
+      const before = Date.now();
+      const server = new MCPHttpServer(mockApp, 3001);
+      const after = Date.now();
+      expect(server.getStartTime()).toBeGreaterThanOrEqual(before);
+      expect(server.getStartTime()).toBeLessThanOrEqual(after);
+    });
+
+    test('should expose session manager', () => {
+      const server = new MCPHttpServer(mockApp, 3001);
+      // Session manager is created during setupRoutes, which happens in constructor
+      // It may or may not be available depending on initialization
+      const sm = server.getSessionManager();
+      // SessionManager should exist after construction
+      expect(sm).toBeDefined();
+    });
   });
 
-  test('should get correct port', () => {
-    const server = new MCPHttpServer(mockApp, 4001);
-    expect(server.getPort()).toBe(4001);
-  });
-
-  // Note: Actual server start/stop tests would require more complex mocking
-  // of Express and network interfaces. For now, we test the basic instantiation.
+  // Note: Full HTTP request/response tests require the server to be started,
+  // which needs Express and network interfaces. The session recovery logic
+  // is tested at the SessionManager level in session-manager.test.ts.
+  // Integration tests for the full HTTP flow should be done manually
+  // against a running Obsidian instance.
 });

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -1,0 +1,156 @@
+import { SessionManager } from '../src/utils/session-manager';
+
+// Suppress Debug output during tests
+jest.mock('../src/utils/debug', () => ({
+  Debug: {
+    log: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('SessionManager', () => {
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    manager = new SessionManager({
+      maxSessions: 3,
+      sessionTimeout: 1000, // 1 second for fast tests
+      checkInterval: 60000, // don't auto-run cleanup
+    });
+  });
+
+  afterEach(() => {
+    manager.stop();
+  });
+
+  describe('session lifecycle', () => {
+    test('getOrCreateSession creates a new session', () => {
+      const session = manager.getOrCreateSession('sess-1');
+      expect(session.sessionId).toBe('sess-1');
+      expect(session.requestCount).toBe(1);
+      expect(session.createdAt).toBeGreaterThan(0);
+      expect(session.lastActivityAt).toBe(session.createdAt);
+    });
+
+    test('getOrCreateSession returns existing session and increments requestCount', () => {
+      manager.getOrCreateSession('sess-1');
+      const session = manager.getOrCreateSession('sess-1');
+      expect(session.requestCount).toBe(2);
+    });
+
+    test('touchSession updates lastActivityAt', () => {
+      const session = manager.getOrCreateSession('sess-1');
+      const originalActivity = session.lastActivityAt;
+      // Small delay to ensure time difference
+      manager.touchSession('sess-1');
+      expect(session.lastActivityAt).toBeGreaterThanOrEqual(originalActivity);
+      expect(session.requestCount).toBe(2);
+    });
+
+    test('touchSession is no-op for unknown session', () => {
+      // Should not throw
+      manager.touchSession('nonexistent');
+    });
+
+    test('removeSession removes an existing session', () => {
+      manager.getOrCreateSession('sess-1');
+      expect(manager.removeSession('sess-1')).toBe(true);
+      expect(manager.getSession('sess-1')).toBeUndefined();
+    });
+
+    test('removeSession returns false for unknown session', () => {
+      expect(manager.removeSession('nonexistent')).toBe(false);
+    });
+
+    test('isSessionValid returns true for fresh session', () => {
+      manager.getOrCreateSession('sess-1');
+      expect(manager.isSessionValid('sess-1')).toBe(true);
+    });
+
+    test('isSessionValid returns false for unknown session', () => {
+      expect(manager.isSessionValid('nonexistent')).toBe(false);
+    });
+
+    test('LRU eviction when capacity reached', () => {
+      const evicted: string[] = [];
+      manager.on('session-evicted', ({ session }) => {
+        evicted.push(session.sessionId);
+      });
+
+      manager.getOrCreateSession('sess-1');
+      manager.getOrCreateSession('sess-2');
+      manager.getOrCreateSession('sess-3');
+      // This should evict sess-1 (LRU)
+      manager.getOrCreateSession('sess-4');
+
+      expect(evicted).toContain('sess-1');
+      expect(manager.getSession('sess-1')).toBeUndefined();
+      expect(manager.getSession('sess-4')).toBeDefined();
+    });
+
+    test('getStats returns correct statistics', () => {
+      manager.getOrCreateSession('sess-1');
+      manager.getOrCreateSession('sess-2');
+      manager.getOrCreateSession('sess-1'); // access again
+
+      const stats = manager.getStats();
+      expect(stats.activeSessions).toBe(2);
+      expect(stats.maxSessions).toBe(3);
+      expect(stats.totalRequests).toBe(3); // 1 + 1 + 1 (re-access)
+    });
+
+    test('stop clears all sessions', () => {
+      manager.getOrCreateSession('sess-1');
+      manager.getOrCreateSession('sess-2');
+      manager.stop();
+      expect(manager.getAllSessions()).toHaveLength(0);
+    });
+  });
+
+  describe('aliases', () => {
+    test('createAlias and resolveAlias round-trip', () => {
+      manager.createAlias('old-id', 'new-id');
+      expect(manager.resolveAlias('old-id')).toBe('new-id');
+    });
+
+    test('resolveAlias returns undefined for unknown alias', () => {
+      expect(manager.resolveAlias('nonexistent')).toBeUndefined();
+    });
+
+    test('alias expires after TTL', async () => {
+      manager.createAlias('old-id', 'new-id', 50); // 50ms TTL
+      expect(manager.resolveAlias('old-id')).toBe('new-id');
+
+      await new Promise(resolve => setTimeout(resolve, 60));
+      expect(manager.resolveAlias('old-id')).toBeUndefined();
+    });
+
+    test('getAliasCount returns count of active aliases', () => {
+      manager.createAlias('old-1', 'new-1');
+      manager.createAlias('old-2', 'new-2');
+      expect(manager.getAliasCount()).toBe(2);
+    });
+
+    test('getAliasCount excludes expired aliases', async () => {
+      manager.createAlias('old-1', 'new-1', 50);
+      manager.createAlias('old-2', 'new-2', 5000);
+      expect(manager.getAliasCount()).toBe(2);
+
+      await new Promise(resolve => setTimeout(resolve, 60));
+      expect(manager.getAliasCount()).toBe(1);
+    });
+
+    test('stop clears aliases', () => {
+      manager.createAlias('old-1', 'new-1');
+      manager.stop();
+      expect(manager.resolveAlias('old-1')).toBeUndefined();
+      expect(manager.getAliasCount()).toBe(0);
+    });
+
+    test('overwriting an alias updates the target', () => {
+      manager.createAlias('old-id', 'new-1');
+      manager.createAlias('old-id', 'new-2');
+      expect(manager.resolveAlias('old-id')).toBe('new-2');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Clients/bridges that cache `Mcp-Session-Id` get permanently stuck with HTTP 400 when the server-side session expires or is evicted. The root cause is that the compat-initialize mechanism uses a minimal `NullResponse` shim that doesn't satisfy Hono's `getRequestListener()` inside the SDK's `StreamableHTTPServerTransport`, leaving the transport in an uninitialized state (`_initialized = false`). The SDK's `validateSession()` then returns 400 on every subsequent request.

### Changes

- **Fix compat-init**: Replace `NullResponse` shim with proper Node.js `IncomingMessage`/`ServerResponse` pair using `PassThrough` streams, so the SDK transport actually transitions to initialized state
- **Session aliases**: Add alias support to `SessionManager` — when a stale session is healed, the old ID maps to the new session for a 5-minute TTL, so subsequent requests with the cached ID resolve immediately without re-running compat init
- **Alias resolution**: Resolve aliases at the top of `handleMCPRequest()` and in `DELETE /mcp` before looking up transports
- **Canonical headers**: Always return `Mcp-Session-Id` header on all response paths so clients can converge on the fresh session ID
- **Structured errors**: Replace vague HTTP 400 with JSON-RPC error code `-32001` including `reason`, `recoverable`, and `retry` fields
- **Diagnostics**: Add `sessionHealth` (active sessions, total requests, active aliases, server uptime) to `system.info`
- **Tests**: `SessionManager` alias lifecycle tests + `MCPHttpServer` getter tests

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes on changed files
- [x] `npm test` — 147 tests pass (12 suites, including new session-manager tests)
- [ ] Manual: send request with bogus `Mcp-Session-Id`, confirm recovery with fresh session
- [ ] Manual: confirm new sessions still work normally
- [ ] Manual: confirm auth failures are not masked by session recovery