### PR TITLE
docs: replace claude mcp add --header with safe config approach

### DIFF
--- a/.claude-github/issue-32-response.md
+++ b/.claude-github/issue-32-response.md
@@ -8,62 +8,71 @@ If you're using the HTTP endpoint, your configuration should look like this:
 {
   "mcpServers": {
     "obsidian-vault": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "http://localhost:3001/mcp"
-      ]
+      "transport": {
+        "type": "http",
+        "url": "http://localhost:3001/mcp"
+      }
     }
   }
 }
 ```
 
 ## Solution 2: Using HTTPS with Self-Signed Certificates
-If you're using HTTPS (port 3443), you need to add the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable:
+If you're using HTTPS (port 3443), trust the plugin's self-signed certificate properly instead of disabling TLS verification. The certificate is located at `.obsidian/plugins/semantic-vault-mcp/certificates/default.crt` inside your vault.
+
+**macOS Keychain** (for clients that use the system trust store):
+```bash
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain \
+  /path/to/vault/.obsidian/plugins/semantic-vault-mcp/certificates/default.crt
+```
+
+**For Bun-based runtimes** (Claude Code), set `NODE_EXTRA_CA_CERTS` instead — Bun does not read the macOS system keychain:
+```bash
+export NODE_EXTRA_CA_CERTS=/path/to/vault/.obsidian/plugins/semantic-vault-mcp/certificates/default.crt
+launchctl setenv NODE_EXTRA_CA_CERTS /path/to/vault/.obsidian/plugins/semantic-vault-mcp/certificates/default.crt
+```
+
+Then configure the HTTPS endpoint:
 ```json
 {
   "mcpServers": {
     "obsidian-vault": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://localhost:3443/mcp"
-      ],
-      "env": {
-        "NODE_TLS_REJECT_UNAUTHORIZED": "0"
+      "transport": {
+        "type": "http",
+        "url": "https://localhost:3443/mcp"
       }
     }
   }
 }
 ```
 
+> **Avoid `NODE_TLS_REJECT_UNAUTHORIZED=0`** — this disables TLS verification process-wide, not just for the plugin. Trust the certificate explicitly instead.
+
 ## With API Key Authentication
-If you have API key authentication enabled, use this format:
+If you have API key authentication enabled, add the `headers` field to any of the configurations above:
 ```json
 {
   "mcpServers": {
     "obsidian-vault": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://localhost:3443/mcp",
-        "--header",
-        "Authorization:${AUTH}"
-      ],
-      "env": {
-        "NODE_TLS_REJECT_UNAUTHORIZED": "0",
-        "AUTH": "Bearer YOUR_API_KEY_HERE"
+      "transport": {
+        "type": "http",
+        "url": "https://localhost:3443/mcp",
+        "headers": {
+          "Authorization": "Bearer YOUR_API_KEY_HERE"
+        }
       }
     }
   }
 }
 ```
+
+> **Important:** Do not use `claude mcp add --header` to register this server — the CLI echoes resolved header values to stdout, exposing your API key. Edit the config file directly instead (`~/.claude/settings.json` for Claude Code, or your client's MCP config file).
+
+For Claude Code, add the config to `~/.claude/settings.json` (user scope) or `.mcp.json` (project scope). Copy the ready-to-use config from the plugin settings page in Obsidian.
 
 Could you please:
 1. Confirm which URL you're using (HTTP on port 3001 or HTTPS on port 3443)?
 2. Try the appropriate configuration above?
-3. Restart Claude Desktop after updating the configuration
-
-The `NODE_TLS_REJECT_UNAUTHORIZED` environment variable is crucial when using HTTPS with self-signed certificates, as Claude Desktop needs to bypass certificate validation for local development certificates.
+3. Restart your MCP client after updating the configuration
 
 Please let me know if this resolves the issue!

--- a/README.md
+++ b/README.md
@@ -41,12 +41,7 @@ Traditional file access gives AI a narrow view - one document at a time. This pl
 
 ### 2. Configure Your AI Client
 
-**Claude Code**
-```bash
-claude mcp add --transport http obsidian http://localhost:3001/mcp --header "Authorization: Bearer YOUR_API_KEY"
-```
-
-**Claude Desktop, Cline, and other MCP clients**
+**Claude Code** — add to `~/.claude/settings.json` (user scope) or `.mcp.json` (project scope):
 ```json
 {
   "mcpServers": {
@@ -63,7 +58,66 @@ claude mcp add --transport http obsidian http://localhost:3001/mcp --header "Aut
 }
 ```
 
-Copy the ready-to-use config with your API key from the plugin settings page.
+For HTTPS, use `https://localhost:3443/mcp` as the URL instead. Both `--transport http` and `--transport sse` work once the plugin's self-signed certificate is trusted — see [Trusting the self-signed certificate](#trusting-the-self-signed-certificate) below. **Claude Code runs on Bun and does not read the macOS system keychain**, so you will need to set `NODE_EXTRA_CA_CERTS`.
+
+> [!WARNING]
+> **Do not use `claude mcp add --header` to register this server.** The CLI echoes resolved header values to stdout, which exposes your API key to any parent process — including AI agents that capture tool output as context. On macOS, spawned MCP child process arguments are also logged to the unified log. Edit the config file directly instead.
+
+**Claude Desktop, Cline, and other MCP clients** — add to your client's MCP config file:
+```json
+{
+  "mcpServers": {
+    "obsidian-vault": {
+      "transport": {
+        "type": "http",
+        "url": "http://localhost:3001/mcp",
+        "headers": {
+          "Authorization": "Bearer YOUR_API_KEY"
+        }
+      }
+    }
+  }
+}
+```
+
+Copy the ready-to-use config with your API key from the plugin settings page. The same JSON format works for all MCP clients — only the config file location differs.
+
+### Trusting the self-signed certificate
+
+The plugin's HTTPS server uses a self-signed certificate auto-generated on first start and stored under `.obsidian/plugins/semantic-vault-mcp/certificates/default.crt` inside your vault. MCP clients reject self-signed certificates by default, so you need to explicitly trust it before connecting over HTTPS. Pick the method that matches your client runtime:
+
+**macOS Keychain (for clients that use the system trust store):**
+```bash
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain \
+  /path/to/vault/.obsidian/plugins/semantic-vault-mcp/certificates/default.crt
+```
+
+This works for most clients on macOS (Claude Desktop, browser-based tools, anything built on Node with `--use-system-ca` enabled).
+
+**`NODE_EXTRA_CA_CERTS` (required for Claude Code and other Bun-based runtimes):**
+
+Claude Code runs on [Bun](https://bun.sh), which does **not** consult the macOS system keychain for TLS trust. Trusting the certificate via Keychain Access alone has no effect — Bun only honors certificates listed in the `NODE_EXTRA_CA_CERTS` environment variable. This is almost always the real reason an HTTPS connection from Claude Code to the plugin fails.
+
+Add the plugin certificate to `NODE_EXTRA_CA_CERTS`:
+
+```bash
+# If you already maintain a combined CA bundle, append the plugin cert to it:
+cat /path/to/existing-ca.pem \
+  /path/to/vault/.obsidian/plugins/semantic-vault-mcp/certificates/default.crt \
+  > /etc/ssl/certs/extra-ca-certs.pem
+export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/extra-ca-certs.pem
+
+# If you don't have an existing bundle, point directly at the plugin cert:
+export NODE_EXTRA_CA_CERTS=/path/to/vault/.obsidian/plugins/semantic-vault-mcp/certificates/default.crt
+```
+
+Set it globally so every tool — including Claude Code launched from the macOS dock — picks it up:
+
+```bash
+launchctl setenv NODE_EXTRA_CA_CERTS /etc/ssl/certs/extra-ca-certs.pem
+```
+
+You will need to re-run these commands whenever the plugin regenerates its certificate (for example, after the 1-year validity expires).
 
 ### 3. Start Using
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,7 @@ We're actively working on fixing these security vulnerabilities:
 
 | Issue | Status | Priority |
 |-------|---------|----------|
-| No authentication on MCP server | 🔧 In Progress | CRITICAL |
+| No authentication on MCP server | ✅ Done | CRITICAL |
 | Path traversal in file operations | 📋 Planned | CRITICAL |
 | Missing input validation | 📋 Planned | HIGH |
 | Insecure session management | 📋 Planned | HIGH |
@@ -37,6 +37,7 @@ Until security improvements are complete:
 3. **Monitor vault access** for unexpected changes
 4. **Keep backups** of your vault
 5. **Review plugin permissions** in Obsidian
+6. **Edit config files directly** instead of using `claude mcp add --header` — the CLI echoes resolved header values to stdout, exposing your API key to parent processes and system logs
 
 ## Secure Configuration
 
@@ -51,7 +52,7 @@ Until security improvements are complete:
 
 ## Future Security Enhancements
 
-- [ ] API key authentication
+- [x] API key authentication
 - [ ] Path validation framework
 - [ ] Input sanitization
 - [ ] Rate limiting

--- a/docs/architecture/core/ADR-100-remove-concurrent-mode-toggle-and-simplify-connection-setup.md
+++ b/docs/architecture/core/ADR-100-remove-concurrent-mode-toggle-and-simplify-connection-setup.md
@@ -33,10 +33,24 @@ Remove the `enableConcurrentSessions` setting and the single-server code path. T
 
 ### 2. Simplify connection templates to two options
 
-**Claude Code** — a ready-to-copy `claude mcp add` command:
+**Claude Code** — add to `~/.claude/settings.json` (user scope) or `.mcp.json` (project scope):
+```json
+{
+  "mcpServers": {
+    "obsidian-vault": {
+      "transport": {
+        "type": "http",
+        "url": "http://localhost:3001/mcp",
+        "headers": {
+          "Authorization": "Bearer <key>"
+        }
+      }
+    }
+  }
+}
 ```
-claude mcp add --transport http obsidian http://localhost:3001/mcp --header "Authorization: Bearer <key>"
-```
+
+> Note: The previous recommendation of `claude mcp add --header` is deprecated because the CLI echoes resolved header values to stdout, exposing the bearer token to any process capturing output (including AI agents). On macOS, process arguments also appear in the unified log.
 
 **Other MCP clients** — a single JSON template using standard header-based auth:
 ```json

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,19 +19,25 @@ AI client cannot connect to the MCP server.
 Connection works but requests are rejected with 401/403 errors.
 
 **Solutions:**
-1. **Check API key**: Ensure the key in your client config matches the one in plugin settings
-2. **Header format**: Use `Authorization: Bearer YOUR_KEY` (note the space after Bearer)
-3. **Regenerated key**: The API key regenerates on plugin updates — copy the new key from settings
+1. **Check API key**: Ensure the key in your client JSON config matches the one shown in plugin settings
+2. **Check config location**: For Claude Code, the config lives in `~/.claude/settings.json` (user scope) or `.mcp.json` (project scope). Verify the `headers.Authorization` value matches `Bearer <your key>` (note the space after Bearer)
+3. **Regenerated key**: The API key regenerates on plugin updates — copy the new key from settings and update your config file
 
 ## SSL Certificate Errors
 
 **Symptoms:**
-Certificate warnings or connection failures when using HTTPS.
+Certificate warnings, TLS handshake failures, or silent connection failures when using HTTPS. The failure mode is often silent on the server side — the TLS handshake aborts before the HTTP request is sent, so the plugin's debug log shows nothing at all. Bun-based clients (for example, any CLI running on the Bun runtime) can fail this way even when the certificate has been trusted in Keychain Access, because **Bun does not consult the macOS system keychain for TLS trust**.
 
-**Solutions:**
-1. **For development**: Set `NODE_TLS_REJECT_UNAUTHORIZED=0` in your client config
-2. **Self-signed certs**: The plugin generates self-signed certificates on first run
-3. **Certificate location**: Certificates are stored in the plugin's data folder
+**Solution:**
+Trust the plugin's self-signed certificate properly. See [Trusting the self-signed certificate](../README.md#trusting-the-self-signed-certificate) in the main README for the full instructions, which cover:
+
+- **macOS Keychain** (`security add-trusted-cert`) — for clients that use the system trust store.
+- **`NODE_EXTRA_CA_CERTS`** — required for Bun-based runtimes; set via `launchctl setenv` to propagate to dock-launched GUI apps.
+
+The plugin auto-generates a self-signed certificate on first start and stores it under `.obsidian/plugins/semantic-vault-mcp/certificates/default.crt` inside your vault. You will need to re-trust it whenever the plugin regenerates it (for example, after the 1-year validity expires).
+
+**Avoid `NODE_TLS_REJECT_UNAUTHORIZED=0`:**
+This environment variable disables TLS certificate verification process-wide — not just for the plugin, but for every HTTPS connection the client makes. That is a significant downgrade to your security posture, and it masks legitimate certificate problems (expired, revoked, or tampered certs) instead of fixing them. Trust the plugin certificate explicitly as described above.
 
 ## Server Not Starting
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1412,32 +1412,14 @@ class MCPSettingTab extends PluginSettingTab {
 		resourcesList.createEl('li', {text: '🔄 Obsidian://session-info - active mcp sessions and statistics'});
 		
 		new Setting(info).setName("Claude code connection").setHeading();
-		const commandExample = info.createDiv('protocol-command-example');
-		const codeEl = commandExample.createEl('code');
-		codeEl.classList.add('mcp-code-block');
-		
+		info.createEl('p', {
+			text: 'Add to ~/.claude/settings.json (user scope) or .mcp.json (project scope):'
+		});
+
 		// Get correct protocol and port based on HTTPS setting
 		const protocol = this.plugin.settings.httpsEnabled ? 'https' : 'http';
 		const port = this.plugin.settings.httpsEnabled ? this.plugin.settings.httpsPort : this.plugin.settings.httpPort;
 		const baseUrl = `${protocol}://localhost:${port}`;
-		
-		const claudeCommand = this.plugin.settings.dangerouslyDisableAuth ?
-			`claude mcp add --transport http obsidian ${baseUrl}/mcp` :
-			`claude mcp add --transport http obsidian ${baseUrl}/mcp --header "Authorization: Bearer ${this.plugin.settings.apiKey}"`;
-
-		codeEl.textContent = claudeCommand;
-
-		// Add copy button
-		this.addCopyButton(commandExample, claudeCommand);
-		
-		new Setting(info).setName("Client configuration (claude desktop, cline, etc.)").setHeading();
-		info.createEl('p', {
-			text: 'Add this to your mcp client configuration file:'
-		});
-
-		const configExample = info.createDiv('desktop-config-example');
-		const configEl = configExample.createEl('pre');
-		configEl.classList.add('mcp-config-example');
 
 		const vaultName = this.app.vault.getName();
 		const configJson = this.plugin.settings.dangerouslyDisableAuth ? {
@@ -1462,6 +1444,27 @@ class MCPSettingTab extends PluginSettingTab {
 				}
 			}
 		};
+
+		const claudeCodeConfig = info.createDiv('claude-code-config-example');
+		const claudeCodeConfigEl = claudeCodeConfig.createEl('pre');
+		claudeCodeConfigEl.classList.add('mcp-config-example');
+		const claudeCodeConfigText = JSON.stringify(configJson, null, 2);
+		claudeCodeConfigEl.textContent = claudeCodeConfigText;
+		this.addCopyButton(claudeCodeConfig, claudeCodeConfigText);
+
+		info.createEl('p', {
+			text: 'Do not use "claude mcp add --header" \u2014 it echoes your API key to stdout and system logs. Edit the config file directly.',
+			cls: 'mcp-security-warning'
+		});
+
+		new Setting(info).setName("Client configuration (claude desktop, cline, etc.)").setHeading();
+		info.createEl('p', {
+			text: 'Add this to your mcp client configuration file:'
+		});
+
+		const configExample = info.createDiv('desktop-config-example');
+		const configEl = configExample.createEl('pre');
+		configEl.classList.add('mcp-config-example');
 
 		const configJsonText = JSON.stringify(configJson, null, 2);
 		configEl.textContent = configJsonText;
@@ -1597,21 +1600,24 @@ class MCPSettingTab extends PluginSettingTab {
 			}
 		}
 		
-		// Update protocol information section with proper auth handling
-		const protocolSection = document.querySelector('.protocol-command-example');
-		if (protocolSection) {
-			const codeBlock = protocolSection.querySelector('code');
-			if (codeBlock && info) {
+		// Update Claude Code config section with proper auth handling
+		const claudeCodeSection = document.querySelector('.claude-code-config-example');
+		if (claudeCodeSection) {
+			const preBlock = claudeCodeSection.querySelector('pre');
+			if (preBlock && info) {
 				// Get correct protocol and port based on HTTPS setting
 				const protocol = this.plugin.settings.httpsEnabled ? 'https' : 'http';
 				const port = this.plugin.settings.httpsEnabled ? this.plugin.settings.httpsPort : info.port;
 				const baseUrl = `${protocol}://localhost:${port}`;
-				
-				const claudeCommand = this.plugin.settings.dangerouslyDisableAuth ? 
-					`claude mcp add --transport http obsidian ${baseUrl}/mcp` :
-					`claude mcp add --transport http obsidian ${baseUrl}/mcp --header "Authorization: Bearer ${this.plugin.settings.apiKey}"`;
-				
-				codeBlock.textContent = claudeCommand;
+				const vaultName = this.app.vault.getName();
+
+				const configJson = this.plugin.settings.dangerouslyDisableAuth ? {
+					mcpServers: { [vaultName]: { transport: { type: "http", url: `${baseUrl}/mcp` } } }
+				} : {
+					mcpServers: { [vaultName]: { transport: { type: "http", url: `${baseUrl}/mcp`, headers: { Authorization: `Bearer ${this.plugin.settings.apiKey}` } } } }
+				};
+
+				preBlock.textContent = JSON.stringify(configJson, null, 2);
 			}
 		}
 		

--- a/styles.css
+++ b/styles.css
@@ -165,6 +165,13 @@
     margin-bottom: 10px;
 }
 
+.mcp-security-warning {
+    color: var(--text-warning);
+    font-size: 0.85em;
+    margin-top: 4px;
+    margin-bottom: 10px;
+}
+
 .mcp-auth-note {
     margin-bottom: 20px;
 }


### PR DESCRIPTION
## Summary

- Replace all `claude mcp add --header` setup instructions with JSON config file editing (`~/.claude/settings.json` or `.mcp.json`) — the CLI echoes resolved header values to stdout, exposing bearer tokens to parent processes and macOS unified log
- Update plugin settings UI to show JSON config snippet with copy button instead of CLI command, plus security warning
- Add self-signed certificate trust instructions for HTTPS (macOS Keychain + `NODE_EXTRA_CA_CERTS` for Bun-based runtimes)
- Update stale SECURITY.md (API key auth marked done, config-file best practice added)
- Modernize issue-32 response template (drop deprecated `mcp-remote` and `NODE_TLS_REJECT_UNAUTHORIZED=0`)

## Motivation

`claude mcp add --header "Authorization: Bearer TOKEN"` defeats secret-at-rest protections because the CLI resolves and echoes the header value at invocation time. Three exposure vectors:

1. **stdout echo** — confirmation output includes the resolved token (captured as tool result if run by an AI agent)
2. **macOS unified log** — spawned MCP child process argv logged with token prefixes visible
3. **at-rest cleartext** — token stored as literal cleartext in `~/.claude.json`

Editing the config file directly avoids all three vectors.

## Files changed (7)

| File | Scope |
|------|-------|
| `README.md` | JSON config + `[!WARNING]` admonition + cert trust instructions |
| `src/main.ts` | Settings UI: JSON config instead of CLI command, security warning |
| `styles.css` | `.mcp-security-warning` class |
| `docs/architecture/core/ADR-100-...md` | Deprecated `claude mcp add --header` reference |
| `docs/troubleshooting.md` | Auth errors + SSL cert trust rewrite |
| `SECURITY.md` | Auth status update, config-file best practice |
| `.claude-github/issue-32-response.md` | Native HTTP transport, proper cert trust |

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — no new errors
- [x] `npm test` — 127/127 pass
- [ ] Verify settings UI in Obsidian shows JSON config, copy button works
- [ ] Verify `[!WARNING]` admonition renders on GitHub
