### PR TITLE
fix(formatters): extract error text from content array in fetch_web response

### DIFF
--- a/src/formatters/system.ts
+++ b/src/formatters/system.ts
@@ -286,6 +286,13 @@ export interface WebFetchResponse {
 export function formatWebFetch(response: WebFetchResponse): string {
   const lines: string[] = [];
 
+  // Extract content string — handle MCP content array format [{type:'text', text:'...'}]
+  const content: string = typeof response.content === 'string'
+    ? response.content
+    : Array.isArray(response.content)
+      ? (response.content as Array<{type: string; text: string}>)[0]?.text ?? JSON.stringify(response.content)
+      : String(response.content);
+
   const title = response.title || 'Web Content';
   lines.push(header(1, `Fetched: ${title}`));
   lines.push('');
@@ -306,12 +313,12 @@ export function formatWebFetch(response: WebFetchResponse): string {
 
   // Truncate very long content
   const maxLength = 5000;
-  if (response.content.length > maxLength) {
-    lines.push(response.content.substring(0, maxLength));
+  if (content.length > maxLength) {
+    lines.push(content.substring(0, maxLength));
     lines.push('');
-    lines.push(`... (${response.content.length - maxLength} more characters)`);
+    lines.push(`... (${content.length - maxLength} more characters)`);
   } else {
-    lines.push(response.content);
+    lines.push(content);
   }
 
   lines.push(summaryFooter());


### PR DESCRIPTION
## Summary

- `fetch_web` returns errors as `{content: [{type:'text', text:'...'}], isError: true}` but `formatWebFetch` expected `content` to be a plain string
- When a content array hit a template literal it rendered as `[object Object]`
- Now extracts the `text` field from MCP content arrays before formatting

## Files changed

- `src/formatters/system.ts` — `formatWebFetch` handles both string and MCP content array formats

## Test plan

- [x] Trigger a `fetch_web` error (e.g. invalid URL) → error message renders as readable text, not `[object Object]`
- [x] Successful `fetch_web` response still formats correctly

### Test results (0.11.16-local.1)

Error case (invalid URL):
```json
{"content": [{"type": "text", "text": "Error fetching URL: Failed to fetch"}], "isError": true}
```

Success case (api.github.com/repos/aaronsb/obsidian-mcp-plugin): returned full JSON response as readable text content.