### PR TITLE
feat: return combined content inline when destination is omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Traditional file access gives AI a narrow view - one document at a time. This pl
 claude mcp add --transport http obsidian http://localhost:3001/mcp --header "Authorization: Bearer YOUR_API_KEY"
 ```
 
+For HTTPS, point Claude Code at `https://localhost:3443/mcp` instead. Both `--transport http` and `--transport sse` work once the plugin's self-signed certificate is trusted — see [Trusting the self-signed certificate](#trusting-the-self-signed-certificate) below. **Claude Code runs on Bun and does not read the macOS system keychain**, so you will need to set `NODE_EXTRA_CA_CERTS`.
+
 **Claude Desktop, Cline, and other MCP clients**
 ```json
 {
@@ -64,6 +66,43 @@ claude mcp add --transport http obsidian http://localhost:3001/mcp --header "Aut
 ```
 
 Copy the ready-to-use config with your API key from the plugin settings page.
+
+### Trusting the self-signed certificate
+
+The plugin's HTTPS server uses a self-signed certificate auto-generated on first start and stored under `.obsidian/plugins/semantic-vault-mcp/certificates/default.crt` inside your vault. MCP clients reject self-signed certificates by default, so you need to explicitly trust it before connecting over HTTPS. Pick the method that matches your client runtime:
+
+**macOS Keychain (for clients that use the system trust store):**
+```bash
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain \
+  /path/to/vault/.obsidian/plugins/semantic-vault-mcp/certificates/default.crt
+```
+
+This works for most clients on macOS (Claude Desktop, browser-based tools, anything built on Node with `--use-system-ca` enabled).
+
+**`NODE_EXTRA_CA_CERTS` (required for Claude Code and other Bun-based runtimes):**
+
+Claude Code runs on [Bun](https://bun.sh), which does **not** consult the macOS system keychain for TLS trust. Trusting the certificate via Keychain Access alone has no effect — Bun only honors certificates listed in the `NODE_EXTRA_CA_CERTS` environment variable. This is almost always the real reason an HTTPS connection from Claude Code to the plugin fails.
+
+Add the plugin certificate to `NODE_EXTRA_CA_CERTS`:
+
+```bash
+# If you already maintain a combined CA bundle, append the plugin cert to it:
+cat /path/to/existing-ca.pem \
+  /path/to/vault/.obsidian/plugins/semantic-vault-mcp/certificates/default.crt \
+  > /etc/ssl/certs/extra-ca-certs.pem
+export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/extra-ca-certs.pem
+
+# If you don't have an existing bundle, point directly at the plugin cert:
+export NODE_EXTRA_CA_CERTS=/path/to/vault/.obsidian/plugins/semantic-vault-mcp/certificates/default.crt
+```
+
+Set it globally so every tool — including Claude Code launched from the macOS dock — picks it up:
+
+```bash
+launchctl setenv NODE_EXTRA_CA_CERTS /etc/ssl/certs/extra-ca-certs.pem
+```
+
+You will need to re-run these commands whenever the plugin regenerates its certificate (for example, after the 1-year validity expires).
 
 ### 3. Start Using
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,12 +26,18 @@ Connection works but requests are rejected with 401/403 errors.
 ## SSL Certificate Errors
 
 **Symptoms:**
-Certificate warnings or connection failures when using HTTPS.
+Certificate warnings, TLS handshake failures, or silent connection failures when using HTTPS. The failure mode is often silent on the server side — the TLS handshake aborts before the HTTP request is sent, so the plugin's debug log shows nothing at all. Bun-based clients (for example, any CLI running on the Bun runtime) can fail this way even when the certificate has been trusted in Keychain Access, because **Bun does not consult the macOS system keychain for TLS trust**.
 
-**Solutions:**
-1. **For development**: Set `NODE_TLS_REJECT_UNAUTHORIZED=0` in your client config
-2. **Self-signed certs**: The plugin generates self-signed certificates on first run
-3. **Certificate location**: Certificates are stored in the plugin's data folder
+**Solution:**
+Trust the plugin's self-signed certificate properly. See [Trusting the self-signed certificate](../README.md#trusting-the-self-signed-certificate) in the main README for the full instructions, which cover:
+
+- **macOS Keychain** (`security add-trusted-cert`) — for clients that use the system trust store.
+- **`NODE_EXTRA_CA_CERTS`** — required for Bun-based runtimes; set via `launchctl setenv` to propagate to dock-launched GUI apps.
+
+The plugin auto-generates a self-signed certificate on first start and stores it under `.obsidian/plugins/semantic-vault-mcp/certificates/default.crt` inside your vault. You will need to re-trust it whenever the plugin regenerates it (for example, after the 1-year validity expires).
+
+**Avoid `NODE_TLS_REJECT_UNAUTHORIZED=0`:**
+This environment variable disables TLS certificate verification process-wide — not just for the plugin, but for every HTTPS connection the client makes. That is a significant downgrade to your security posture, and it masks legitimate certificate problems (expired, revoked, or tampered certs) instead of fixing them. Trust the plugin certificate explicitly as described above.
 
 ## Server Not Starting
 

--- a/src/formatters/vault.ts
+++ b/src/formatters/vault.ts
@@ -384,7 +384,9 @@ export function formatFileSplit(response: FileSplitResponse): string {
  */
 export interface FileCombineResponse {
   success: boolean;
-  destination: string;
+  destination?: string;
+  inline?: boolean;
+  content?: string;
   filesCombined: number;
   totalSize?: number;
   sourceFiles?: string[];
@@ -394,11 +396,27 @@ export function formatFileCombine(response: FileCombineResponse): string {
   const lines: string[] = [];
 
   const icon = response.success ? '✓' : '✗';
+
+  // Inline mode: return combined content directly
+  if (response.inline && response.content !== undefined) {
+    lines.push(header(1, `${icon} Combined ${response.filesCombined} files (inline)`));
+    lines.push('');
+    if (response.totalSize !== undefined) {
+      lines.push(property('Total size', formatFileSize(response.totalSize), 0));
+      lines.push('');
+    }
+    lines.push(response.content);
+    lines.push('');
+    lines.push(divider());
+    lines.push(summaryFooter());
+    return joinLines(lines);
+  }
+
   lines.push(header(1, `${icon} Combined: ${response.destination}`));
   lines.push('');
 
   if (response.success) {
-    lines.push(property('Destination', response.destination, 0));
+    lines.push(property('Destination', response.destination!, 0));
     lines.push(property('Files combined', response.filesCombined.toString(), 0));
     if (response.totalSize !== undefined) {
       lines.push(property('Total size', formatFileSize(response.totalSize), 0));

--- a/src/semantic/router.ts
+++ b/src/semantic/router.ts
@@ -628,8 +628,8 @@ export class SemanticRouter {
         const sortBy = paramStr(params, 'sortBy');
         const sortOrder = paramStr(params, 'sortOrder') ?? 'asc';
 
-        // Validate batch operation
-        const validationResult = this.validator.validate('batch.combine', { paths, path: destination });
+        // Validate batch operation (skip path validation when returning inline)
+        const validationResult = this.validator.validate('batch.combine', { paths, path: destination || '_inline_' });
         if (!validationResult.valid) {
           throw new ValidationException(
             validationResult.errors || [],
@@ -641,20 +641,18 @@ export class SemanticRouter {
           throw new Error('paths array is required for combine operation');
         }
 
-        if (!destination) {
-          throw new Error('destination is required for combine operation');
-        }
-        
-        // Check if destination exists
-        try {
-          const destFile = await this.api.getFile(destination);
-          if (destFile && !overwrite) {
-            throw new Error(`Destination already exists: ${destination}. Set overwrite=true to replace.`);
+        // When destination is provided, check if it already exists
+        if (destination) {
+          try {
+            const destFile = await this.api.getFile(destination);
+            if (destFile && !overwrite) {
+              throw new Error(`Destination already exists: ${destination}. Set overwrite=true to replace.`);
+            }
+          } catch {
+            // File doesn't exist, which is what we want
           }
-        } catch {
-          // File doesn't exist, which is what we want
         }
-        
+
         // Validate and get all source files
         const sourceFiles = [];
         for (const path of paths) {
@@ -667,12 +665,12 @@ export class SemanticRouter {
           }
           sourceFiles.push({ path, content: file.content });
         }
-        
+
         // Sort files if requested
         if (sortBy) {
           this.sortFiles(sourceFiles, sortBy, sortOrder);
         }
-        
+
         // Combine content
         const combinedContent = [];
         for (const file of sourceFiles) {
@@ -683,16 +681,37 @@ export class SemanticRouter {
           }
           combinedContent.push(file.content);
         }
-        
+
         const finalContent = combinedContent.join(separator);
-        
+
+        // If no destination, return content inline without writing to disk
+        if (!destination) {
+          return {
+            success: true,
+            inline: true,
+            content: finalContent,
+            filesCombined: paths.length,
+            totalSize: finalContent.length,
+            sourceFiles: paths,
+            workflow: {
+              message: `Combined ${paths.length} files inline (no file written)`,
+              suggested_next: [
+                {
+                  description: 'Save to a file',
+                  command: `vault(action='combine', paths=${JSON.stringify(paths)}, destination='combined.md')`
+                }
+              ]
+            }
+          };
+        }
+
         // Create or update destination file
         if (overwrite) {
           await this.api.updateFile(destination, finalContent);
         } else {
           await this.api.createFile(destination, finalContent);
         }
-        
+
         return {
           success: true,
           destination,

--- a/src/tools/semantic-tools.ts
+++ b/src/tools/semantic-tools.ts
@@ -140,8 +140,11 @@ const createSemanticTool = (operation: string, visibility?: ToolVisibility): Sem
     // Check for read-only mode before processing write operations
     const plugin = (api as unknown as { plugin?: PluginWithSettings }).plugin;
     if (plugin?.settings?.readOnlyMode && operation === 'vault') {
-      const writeOperations = ['create', 'update', 'delete', 'move', 'rename', 'copy', 'split', 'combine', 'concatenate'];
-      if (writeOperations.includes(args.action)) {
+      const writeOperations = ['create', 'update', 'delete', 'move', 'rename', 'copy', 'split', 'concatenate'];
+      // combine is only a write operation when destination is provided
+      const isWriteOp = writeOperations.includes(args.action) ||
+        (args.action === 'combine' && args.destination);
+      if (isWriteOp) {
         return {
           content: [{
             type: 'text' as const,
@@ -454,7 +457,7 @@ function getParametersForOperation(operation: string): Record<string, unknown> {
       },
       destination: {
         type: 'string',
-        description: 'Destination path for move/copy operations'
+        description: 'Destination path for move/copy/combine operations. For combine: omit to return content inline without writing a file'
       },
       newName: {
         type: 'string',


### PR DESCRIPTION
## Summary

- When `vault combine` is called without a `destination`, the combined content is now returned inline in the MCP response instead of requiring a file write
- This allows read-only consumers to use `combine` for multi-file retrieval without side effects
- `combine` without `destination` is permitted in read-only mode since no file is written

Also includes documentation for trusting the plugin's self-signed certificate in runtimes that don't read the macOS system keychain (e.g. Bun-based clients).

## Files changed

- `src/semantic/router.ts` — combine action returns inline content when destination is omitted
- `src/tools/semantic-tools.ts` — `combine` classified as write-op only when `destination` is provided
- `src/formatters/vault.ts` — `FileCombineResponse` supports optional destination and inline content
- `README.md` — self-signed certificate trust instructions
- `docs/troubleshooting.md` — expanded SSL troubleshooting guidance

## Test plan

- [x] `vault combine` with `destination` → writes file as before
- [x] `vault combine` without `destination` → returns combined content inline, no file created
- [x] `vault combine` without `destination` in read-only mode → succeeds (not blocked as write-op)
- [x] `vault combine` with `destination` in read-only mode → blocked as expected
- [x] Tool visibility tree (ADR-101) correctly lists `combine` action

### Test results (0.11.16-local.1)

**With destination (read-only off):** wrote `wiki/_test-combine-destination.md` (6.7 KB), file created on disk.

**Without destination (read-only off):** returned 7.4 KB inline, `"inline": true`, no file written.

**Without destination (read-only on):** succeeded — `"inline": true`, content returned, `"Combined 2 files inline (no file written)"`.

**With destination (read-only on):** blocked as expected:
```json
{"error": {"code": "READ_ONLY_MODE", "message": "Write operation 'combine' is blocked - read-only mode is enabled"}}
```

**Tool visibility tree:** `combine` appears in vault actions (13/13) in the ADR-101 tree-based settings UI, correctly auto-populated from `getActionsForOperation()`.