### PR TITLE
fix(session): retry compat-initialize on transient failure

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -20,6 +20,31 @@ import { SessionManager } from './utils/session-manager';
 import { MCPServerPool } from './utils/mcp-server-pool';
 import { CertificateManager, CertificateConfig } from './utils/certificate-manager';
 
+/** Maximum number of compat-initialize recovery attempts before returning error */
+export const MAX_RECOVERY_ATTEMPTS = 3;
+/** Base delay between recovery attempts in milliseconds (multiplied by attempt number) */
+export const RECOVERY_BACKOFF_MS = 500;
+
+/**
+ * Retry an async operation with linear backoff.
+ * Returns `{ result, attempts }` on success, or `null` if all attempts fail.
+ */
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  opts: { maxAttempts: number; backoffMs: number; shouldRetry: (result: T) => boolean }
+): Promise<{ result: T; attempts: number } | null> {
+  for (let attempt = 0; attempt < opts.maxAttempts; attempt++) {
+    if (attempt > 0) {
+      await new Promise(resolve => setTimeout(resolve, attempt * opts.backoffMs));
+    }
+    const result = await fn();
+    if (!opts.shouldRetry(result)) {
+      return { result, attempts: attempt + 1 };
+    }
+  }
+  return null;
+}
+
 /** Minimal plugin interface for MCPHttpServer.
  * Includes fields from SecurePluginRef and ObsidianAPIPluginRef so the same object
  * can be passed through the constructor chain. */
@@ -547,33 +572,44 @@ export class MCPHttpServer {
           }
         } as unknown as IncomingMessage;
         const versionsToTry = ['2025-06-18', '2024-11-05', '1.0'];
-        let initOk = false;
-        for (const ver of versionsToTry) {
-          try {
-            const initReq = {
-              jsonrpc: '2.0',
-              id: '__compat_init__',
-              method: 'initialize',
-              params: {
-                protocolVersion: ver,
-                capabilities: {},
-                clientInfo: { name: 'obsidian-mcp-compat', version: getVersion() }
+
+        // Worst case: MAX_RECOVERY_ATTEMPTS × versionsToTry.length init requests (~1500ms)
+        const retryResult = await retryWithBackoff(
+          async () => {
+            for (const ver of versionsToTry) {
+              try {
+                const initReq = {
+                  jsonrpc: '2.0',
+                  id: '__compat_init__',
+                  method: 'initialize',
+                  params: {
+                    protocolVersion: ver,
+                    capabilities: {},
+                    clientInfo: { name: 'obsidian-mcp-compat', version: getVersion() }
+                  }
+                } as unknown;
+                await transport.handleRequest(compatReq, createNullRes() as unknown as ServerResponse, initReq);
+                Debug.log(`Compat initialize succeeded with protocolVersion=${ver}`);
+                return { ok: true };
+              } catch (e) {
+                Debug.error(`Compat initialize attempt failed (protocolVersion=${ver}):`, e);
               }
-            } as unknown;
-            await transport.handleRequest(compatReq, createNullRes() as unknown as ServerResponse, initReq);
-            initOk = true;
-            Debug.log(`Compat initialize succeeded with protocolVersion=${ver}`);
-            break;
-          } catch (e) {
-            Debug.error(`Compat initialize attempt failed (protocolVersion=${ver}):`, e);
+            }
+            return { ok: false };
+          },
+          {
+            maxAttempts: MAX_RECOVERY_ATTEMPTS,
+            backoffMs: RECOVERY_BACKOFF_MS,
+            shouldRetry: (result) => !result.ok
           }
-        }
+        );
+
         // Fail-open: even if initialize failed, proceed with the original request
         // to avoid client retry loops. The transport/server may still reject it,
         // but this gives us a concrete server error to act on.
         requireInitializeNotice = false;
-        if (!initOk) {
-          Debug.log('Compat initialize failed; proceeding without explicit initialize (fail-open).');
+        if (!retryResult) {
+          Debug.log(`Compat initialize failed after ${MAX_RECOVERY_ATTEMPTS} attempts; proceeding without explicit initialize (fail-open).`);
         }
       }
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,4 +1,4 @@
-import { MCPHttpServer } from '../src/mcp-server';
+import { MCPHttpServer, MAX_RECOVERY_ATTEMPTS, RECOVERY_BACKOFF_MS, retryWithBackoff } from '../src/mcp-server';
 import { App } from 'obsidian';
 
 // Mock the fs module to prevent file system operations in tests
@@ -37,4 +37,60 @@ describe('MCPHttpServer', () => {
 
   // Note: Actual server start/stop tests would require more complex mocking
   // of Express and network interfaces. For now, we test the basic instantiation.
+
+  describe('retryWithBackoff', () => {
+    test('returns result on first attempt when fn succeeds immediately', async () => {
+      const fn = jest.fn().mockResolvedValue('ok');
+      const result = await retryWithBackoff(fn, {
+        maxAttempts: 3,
+        backoffMs: 10,
+        shouldRetry: (r) => r !== 'ok'
+      });
+      expect(result).toEqual({ result: 'ok', attempts: 1 });
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test('retries and succeeds on second attempt', async () => {
+      const fn = jest.fn()
+        .mockResolvedValueOnce('fail')
+        .mockResolvedValue('ok');
+      const result = await retryWithBackoff(fn, {
+        maxAttempts: 3,
+        backoffMs: 10,
+        shouldRetry: (r) => r !== 'ok'
+      });
+      expect(result).toEqual({ result: 'ok', attempts: 2 });
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    test('returns null after exhausting all attempts', async () => {
+      const fn = jest.fn().mockResolvedValue('fail');
+      const result = await retryWithBackoff(fn, {
+        maxAttempts: MAX_RECOVERY_ATTEMPTS,
+        backoffMs: 10,
+        shouldRetry: (r) => r === 'fail'
+      });
+      expect(result).toBeNull();
+      expect(fn).toHaveBeenCalledTimes(MAX_RECOVERY_ATTEMPTS);
+    });
+
+    test('applies linear backoff between attempts', async () => {
+      const timestamps: number[] = [];
+      const fn = jest.fn().mockImplementation(async () => {
+        timestamps.push(Date.now());
+        return timestamps.length < 3 ? 'fail' : 'ok';
+      });
+      await retryWithBackoff(fn, {
+        maxAttempts: 3,
+        backoffMs: RECOVERY_BACKOFF_MS,
+        shouldRetry: (r) => r !== 'ok'
+      });
+      // Second attempt should have ~500ms delay, third ~1000ms
+      const gap1 = timestamps[1] - timestamps[0];
+      const gap2 = timestamps[2] - timestamps[1];
+      expect(gap1).toBeGreaterThanOrEqual(400);  // 500ms with some tolerance
+      expect(gap2).toBeGreaterThanOrEqual(900);  // 1000ms with some tolerance
+      expect(gap2).toBeGreaterThan(gap1);         // linear increase
+    });
+  });
 });


### PR DESCRIPTION
## Summary

When a non-initialize request arrives without an active transport, the server attempts
a compat-initialize to transparently heal the session. Previously this was a single pass
through 3 protocol versions — if the server was transiently unavailable (plugin loading,
vault syncing), all 3 failed instantly and the request fell through to fail-open.

This adds a bounded retry cycle (3 attempts with linear backoff: 0ms, 500ms, 1000ms)
before falling through to fail-open. Clients that cache `Mcp-Session-Id` across server
restarts now survive brief transient failures without unnecessary fail-open fallbacks.

## Changes

- Extract generic `retryWithBackoff()` helper for testable retry/backoff logic
- Wrap compat-initialize protocol negotiation in retry loop (max 3 attempts)
- Linear backoff between attempts (500ms × attempt number)
- Existing fail-open fallback unchanged — fires only after all attempts exhausted
- Behavioural tests for retry logic (immediate success, retry-then-succeed, exhaustion, backoff timing)

## Test plan

- [x] `npm run build` — zero errors
- [x] `npm test` — 131 tests pass (127 baseline + 4 new)
- [ ] Manual: restart Obsidian plugin mid-session → next MCP call succeeds via retry
- [ ] Manual: stop plugin entirely → retry cycle fires 3 times then falls through to fail-open