### PR TITLE
ADR-102: MCPB bundle for Claude Desktop one-click install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,4 +81,5 @@ jobs:
             main.js \
             manifest.json \
             styles.css \
-            "obsidian-mcp-${{ steps.version.outputs.version }}.mcpb"
+            "obsidian-mcp-${{ steps.version.outputs.version }}.mcpb" \
+            obsidian-mcp.mcpb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Build plugin
         run: npm run build
 
+      - name: Build MCPB bundle
+        run: node scripts/build-mcpb.mjs
+
       - name: Get version from manifest
         id: version
         run: |
@@ -77,4 +80,5 @@ jobs:
             --prerelease \
             main.js \
             manifest.json \
-            styles.css
+            styles.css \
+            "obsidian-mcp-${{ steps.version.outputs.version }}.mcpb"

--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ main.js
 *.js.map
 data.json
 
+# MCPB build output (source in mcpb/, .mcpb file is generated)
+*.mcpb
+
 # Test scripts
 test-concurrent-sessions.js
 

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ _commit-and-publish:
 # --- Utility ---
 
 clean: ## Remove build artifacts
-	rm -rf main.js main.js.map dist/ obsidian-mcp-*.mcpb
+	rm -rf main.js main.js.map dist/ obsidian-mcp-*.mcpb obsidian-mcp.mcpb
 
 sync-version: ## Sync version from package.json to manifest.json and version.ts
 	node sync-version.mjs

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ _update-versions-json:
 
 _commit-and-publish:
 	@VERSION=$$(jq -r .version package.json); \
-	git add package.json package-lock.json manifest.json src/version.ts versions.json; \
+	git add package.json package-lock.json manifest.json mcpb/manifest.json src/version.ts versions.json; \
 	git commit -m "chore: Bump version to $$VERSION"; \
 	git push origin HEAD; \
 	echo "Triggering release for $$VERSION..."; \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help build dev test lint lint-fix check clean install \
-       release-patch release-minor release-major release publish sync-version
+       release-patch release-minor release-major release publish sync-version mcpb
 
 MIN_OBSIDIAN := 0.15.0
 
@@ -76,7 +76,10 @@ _commit-and-publish:
 # --- Utility ---
 
 clean: ## Remove build artifacts
-	rm -rf main.js main.js.map dist/
+	rm -rf main.js main.js.map dist/ obsidian-mcp-*.mcpb
 
 sync-version: ## Sync version from package.json to manifest.json and version.ts
 	node sync-version.mjs
+
+mcpb: ## Build MCPB bundle (obsidian-mcp-<version>.mcpb) for Claude Desktop
+	node scripts/build-mcpb.mjs

--- a/README.md
+++ b/README.md
@@ -41,12 +41,24 @@ Traditional file access gives AI a narrow view - one document at a time. This pl
 
 ### 2. Configure Your AI Client
 
-**Claude Code**
+Three onboarding paths, ordered by audience. All three are also shown in the plugin's Settings tab with copy-ready values.
+
+**Claude Desktop — one-click `.mcpb` install (recommended)**
+
+Download `obsidian-mcp-<version>.mcpb` from the [latest release](https://github.com/aaronsb/obsidian-mcp-plugin/releases/latest), then either drag it onto the Claude Desktop window or double-click it. Claude Desktop opens an install dialog with two fields — paste the URL and API key shown in the plugin's Settings tab, hit Save, and you're done.
+
+> *Cross-platform note:* `.mcpb` files install via Claude Desktop's bundled handler. If double-click doesn't trigger Claude on your system, drag the file onto Claude Desktop's window instead, or right-click → "Open with…" and pick Claude Desktop (then "always open with" if your OS asks). Behavior varies by platform: macOS usually auto-associates, Windows may need a one-time association, Linux varies by desktop environment.
+
+**Claude Code (CLI)**
+
 ```bash
 claude mcp add --transport http obsidian http://localhost:3001/mcp --header "Authorization: Bearer YOUR_API_KEY"
 ```
 
-**Claude Desktop, Cline, and other MCP clients**
+**Other MCP clients (Cline, Continue, custom integrations, multi-vault setups)**
+
+Add an entry to the client's MCP config file — one entry per vault if you run multiple Obsidian instances on different ports:
+
 ```json
 {
   "mcpServers": {
@@ -63,7 +75,17 @@ claude mcp add --transport http obsidian http://localhost:3001/mcp --header "Aut
 }
 ```
 
-Copy the ready-to-use config with your API key from the plugin settings page.
+**Advanced: custom `.mcpb` per vault**
+
+For multi-vault setups that want one-click install per vault, clone this repo and run the maker:
+
+```bash
+node scripts/make-mcpb.mjs
+# Prompts for display name, URL, and API key
+# Outputs obsidian-mcp-<slug>.mcpb with everything pre-filled
+```
+
+Drop the resulting bundle into Claude Desktop and click Install — no fields to type.
 
 ### 3. Start Using
 

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -22,6 +22,7 @@ _Server architecture, transport, connection handling, plugin lifecycle_
 |-----|-------|--------|
 | [ADR-100](./core/ADR-100-remove-concurrent-mode-toggle-and-simplify-connection-setup.md) | Remove concurrent mode toggle and simplify connection setup | Accepted |
 | [ADR-101](./core/ADR-101-tree-based-mcp-tool-visibility-gating.md) | Tree-based MCP tool visibility gating | Draft |
+| [ADR-102](./core/ADR-102-ship-mcpb-bundle-as-primary-claude-desktop-onboarding.md) | Ship MCPB bundle as primary Claude Desktop onboarding | Draft |
 
 ## Tools & API
 _MCP tool design, semantic operations, graph operations, formatters_

--- a/docs/architecture/core/ADR-102-ship-mcpb-bundle-as-primary-claude-desktop-onboarding.md
+++ b/docs/architecture/core/ADR-102-ship-mcpb-bundle-as-primary-claude-desktop-onboarding.md
@@ -1,0 +1,136 @@
+---
+status: Draft
+date: 2026-05-15
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-100
+---
+
+# ADR-102: Ship MCPB bundle as primary Claude Desktop onboarding
+
+## Context
+
+ADR-100 simplified the connection-setup surface to two paths: a `claude mcp add` CLI string for Claude Code, and a generic `mcpServers` JSON template for "other clients including Claude Desktop." Both paths still require the user to either run a CLI command or hand-edit a JSON config file and restart Claude Desktop. For non-developer Obsidian users, the JSON path is the steepest part of onboarding — locate the config file, paste the block, get the indentation right, restart.
+
+Anthropic now ships **MCPB** (MCP Bundle, the successor framing for Desktop Extensions) as the supported installer UX in Claude Desktop. An `.mcpb` is a zip-format bundle the user opens with Claude Desktop; Claude Desktop reads the bundle's `manifest.json`, prompts the user for any declared `user_config` fields, and registers the server with zero JSON editing.
+
+Two relevant facts about MCPB as of this writing:
+
+1. **Claude Desktop on macOS and Windows ships its own Node.js runtime** for executing `node`-type bundles. End users do not need Node, npm, or any system runtime installed. The MCPB docs explicitly recommend Node specifically for this friction-reduction reason. UV/Python is also managed by Claude Desktop.
+2. **MCPB does not currently support a `remote-http` server type.** Defined server types are `node`, `python`, `binary`, `uv` — all require a local executable entrypoint. There is no manifest shape for "just point Claude Desktop at this URL with these headers."
+
+Fact (2) means this plugin's onboarding cannot be a pure manifest-only bundle. Even though the plugin's MCP server already speaks Streamable HTTP, the bundle still has to expose a local executable that bridges Claude Desktop's stdio launch into the in-Obsidian HTTP endpoint. This is a constraint of MCPB's installer UX, not of MCP transport.
+
+ADR-100 deprecated `mcp-remote` as a *user-facing* config option ("the world that needed it no longer exists"). Using a stdio↔HTTP bridge *inside* an MCPB is a different situation — the user never sees it, installs it, or configures it; it is an implementation detail of the bundle. This ADR carves out that distinction explicitly so the two ADRs do not appear to contradict each other.
+
+## Decision
+
+### 1. Ship an MCPB bundle as the primary Claude Desktop onboarding path
+
+Add a third onboarding option to plugin Settings, ordered ahead of the JSON template. The three onboarding sections become, in priority order:
+
+1. **Claude Desktop (MCPB)** — primary. Link to the latest `.mcpb` release asset, with a "Your values" panel beside it showing the URL and API key (copy buttons) for paste into Claude Desktop's install prompt.
+2. **Claude Code (CLI)** — keep the existing `claude mcp add --transport http …` block as-is.
+3. **Other MCP clients (JSON)** — demoted from primary. Keep the existing template for power users on clients that lack MCPB support (Cline, Continue, custom integrations).
+
+The `mcpServers` JSON path is not removed. MCPB is added on top.
+
+### 2. Bundle shape: static `node`-type MCPB with a hand-rolled stdio↔HTTP bridge
+
+The bundle is committed to the repo under `mcpb/`:
+
+```
+mcpb/
+  manifest.json    # node type; user_config: { url, api_key }
+  server.js        # ~80-line stdio↔HTTP bridge, no external deps
+```
+
+The manifest declares:
+
+- `server.type: "node"` so Claude Desktop's bundled Node.js runs it (no end-user system Node required).
+- `user_config` fields: `url` (string, default `http://localhost:3001/mcp`) and `api_key` (sensitive string). Interpolated into `server.env` so `server.js` reads them at startup without needing argv parsing.
+
+`server.js` is a self-contained JSON-RPC↔HTTP relay: read JSON-RPC messages from stdin, POST to the configured `/mcp` endpoint with the `Authorization: Bearer …` header, stream the response (SSE or chunked) back to stdout as JSON-RPC. Reconnect on session-id rotation by re-issuing `initialize` and replaying the failed request.
+
+The bundle is **static**. No per-user values bake into it. The same `.mcpb` works for every user; per-user values flow through Claude Desktop's `user_config` install prompt.
+
+### 3. Hand-rolled bridge over vendored `mcp-remote`
+
+The shim is ~80 lines of plain Node with zero npm dependencies, not a thin wrapper around the `mcp-remote` package. Rationale:
+
+- Bundle stays genuinely tiny — single file, no `node_modules/` tree of vendored deps.
+- We don't track `mcp-remote`'s upstream churn (which has had multiple disruptive releases).
+- The MCP Streamable HTTP transport spec is small enough that a relay is honest-sized code, reviewable in one sitting.
+- Session-fragility concerns that motivated avoiding mcp-remote-style bridges in ADR-100 are largely server-side problems (cf. open issues #128, #147, #150). A client-side relay only needs "session expired → re-init and retry," which is ~10 lines.
+
+### 4. CI publishes the `.mcpb` artifact on change
+
+A GitHub Action under `.github/workflows/` builds the bundle (zip the `mcpb/` directory, produce `obsidian-mcp-<version>.mcpb`) and attaches it as a release asset whenever:
+
+- A release is cut (existing `release.yml` flow — add the `.mcpb` to the artifact set alongside `main.js`, `manifest.json`, `styles.css`).
+- The contents of `mcpb/` change on `main` (separate workflow that publishes a `latest` `.mcpb` so users testing via BRAT-equivalent paths get the current bundle without waiting for a tagged release).
+
+Version sync via the existing `sync-version.mjs` script — `manifest.json` inside the bundle stays in lockstep with the plugin's `package.json` version.
+
+### 5. Settings UI: download link plus "your values" panel
+
+The Settings UI for the new primary section shows:
+
+- A heading: "Claude Desktop (MCPB)".
+- One sentence: "Download the bundle, open it with Claude Desktop, paste these values in the prompt."
+- A link button to the latest `.mcpb` release asset (resolved from the current plugin version's GitHub release).
+- A two-line readout: `URL: <http(s)://localhost:<port>/mcp>` and `API key: <key>` with copy buttons on each.
+
+No on-the-fly bundle generation in the plugin for v1 (see Alternatives). The copy-paste of two values is acceptable friction and avoids shipping a zip library inside the Obsidian plugin.
+
+### 6. Single-vault scope; three-tier onboarding by audience
+
+The shipped MCPB is explicitly single-vault. Claude Desktop registers one MCP server per installed bundle, and merging N vaults into one server entry would require aggregating `tools/list` from each upstream, prefixing every tool name to avoid collisions, and re-routing calls on the way back — roughly tripling `server.js` and inflating the tool surface in a way that fights ADR-101 (visibility gating).
+
+Onboarding is therefore tiered by audience:
+
+| Audience | Path |
+|---|---|
+| Single vault | Drop the shipped `.mcpb` into Claude Desktop |
+| Advanced (multi-vault, custom names, scripted setups) | Run the maker script to produce a custom `.mcpb` |
+| Other MCP clients (Cline, Continue, etc.) | The existing `mcpServers` JSON block |
+
+The **maker script** (`scripts/make-mcpb.mjs`, planned follow-up) is a small interactive Node CLI using only Node built-ins (`node:readline`, `node:zlib`). It prompts for `name`, `url`, and `api_key`, then emits a custom-named `.mcpb` the user installs in Claude Desktop. No arbitrary vault-count ceiling, no proliferation of release assets, no bridge changes. Multi-vault becomes "run the maker N times" — clean for the audience that wants it without taxing the default path.
+
+All three paths are visible in plugin Settings so users can choose the one that fits.
+
+## Consequences
+
+### Positive
+
+- New users get a one-click install path that does not involve editing JSON config files.
+- End users do not need Node, Python, or any runtime installed — Claude Desktop's bundled Node runs the shim.
+- The bundle is genuinely static and lives in the repo; review surface is small (one manifest, one ~80-line JS file).
+- CI publishing keeps the artifact in sync with releases automatically.
+- The JSON and CLI paths remain available for power users and non-Claude-Desktop clients — no functionality is lost.
+
+### Negative
+
+- Reintroduces a stdio↔HTTP bridge as an implementation detail, partially reversing the framing of ADR-100. Mitigated by scope: ADR-100's ban was on user-visible bridge config; the MCPB shim is invisible to users.
+- Adds a new file class (`mcpb/`) and a new CI workflow surface that we now have to maintain.
+- We own the relay code, including session-expiry reconnect edges. Bugs in the relay become our bugs, not upstream's.
+- Two values still need to be copy-pasted across apps (URL and API key) — friction is reduced but not zero.
+
+### Neutral
+
+- Bundle distribution becomes part of the release contract. Versioning, signing, and release-asset hygiene now apply to `.mcpb` alongside `main.js`.
+- The `mcp-remote` package is not added as a dependency, vendored or otherwise.
+- Localhost-bound HTTP endpoint means MCPB only works when Obsidian and Claude Desktop run on the same machine. Worth noting in the manifest description but not a regression — every existing onboarding path has the same constraint.
+- HTTPS mode (self-signed certs on `httpsPort`) works through the shim if `url` is set to the `https://` form; the relay does not need to know.
+
+## Alternatives Considered
+
+- **Wait for MCPB to add a remote-HTTP server type.** Anthropic may eventually add a manifest shape that points at a URL without a local executable. If that lands, the shim deletes and the manifest becomes a few lines. Rejected as the primary plan because there is no signaled timeline; the workaround cost is low enough to ship now.
+- **Vendor `mcp-remote` instead of writing our own bridge.** Rejected: pulls a multi-MB dep tree, tracks upstream churn, and the relay work we'd skip is small. Re-evaluate if the hand-rolled relay accumulates non-trivial bugs.
+- **Generate a personalized `.mcpb` in-browser from plugin Settings** (zip lib in the plugin clones the static bundle and pre-fills `user_config.defaults` with current port/key). Zero-typing install. Rejected for v1: adds a zip library to the plugin bundle and an extra surface to maintain. Reasonable v2 once real users report on the copy-paste friction.
+- **Drop the JSON template entirely.** Rejected: Cline, Continue, custom MCP integrations, and any non-Claude-Desktop client still need the JSON path. The friction was the *primary* placement, not the existence of the path.
+- **Stdio-only bundle that spawns a long-lived child process.** Rejected: redundant with the existing HTTP server inside Obsidian; doubles process count and complicates port/session ownership.
+- **N-slot multi-vault MCPB** (5 fixed `(url, api_key)` slots in `user_config`, bridge aggregates upstreams into one merged tool namespace). Rejected for v1: tripled bridge complexity, fights ADR-101 by exploding the tool list, and the maker-script path (see Decision §6) serves the same audience without a hardcoded ceiling or bridge changes.
+- **Multi-variant publishing** (build and release `obsidian-mcp-vault-a.mcpb`, `…-b.mcpb`, … as separate assets). Rejected in favor of the maker script — same single-vault-per-bundle property, but the user picks names and counts at run time rather than us pre-baking a fixed flavor list into every release.

--- a/docs/architecture/core/ADR-102-ship-mcpb-bundle-as-primary-claude-desktop-onboarding.md
+++ b/docs/architecture/core/ADR-102-ship-mcpb-bundle-as-primary-claude-desktop-onboarding.md
@@ -52,7 +52,7 @@ The manifest declares:
 - `server.type: "node"` so Claude Desktop's bundled Node.js runs it (no end-user system Node required).
 - `user_config` fields: `url` (string, default `http://localhost:3001/mcp`) and `api_key` (sensitive string). Interpolated into `server.env` so `server.js` reads them at startup without needing argv parsing.
 
-`server.js` is a self-contained JSON-RPC↔HTTP relay: read JSON-RPC messages from stdin, POST to the configured `/mcp` endpoint with the `Authorization: Bearer …` header, stream the response (SSE or chunked) back to stdout as JSON-RPC. Reconnect on session-id rotation by re-issuing `initialize` and replaying the failed request.
+`server.js` is a self-contained JSON-RPC↔HTTP relay: read JSON-RPC messages from stdin, POST to the configured `/mcp` endpoint with the `Authorization: Bearer …` header, stream the response (SSE or chunked) back to stdout as JSON-RPC. On session expiry (HTTP 404 with a session id we previously held), the relay surfaces a `-32000` JSON-RPC error so the client (Claude Desktop) re-issues `initialize` — we do not attempt to replay arbitrary user requests across session boundaries because we'd need to also replay state-establishing notifications and that path is fragile. Letting the client own re-init is simpler and matches how Claude Desktop already handles transient sessions.
 
 The bundle is **static**. No per-user values bake into it. The same `.mcpb` works for every user; per-user values flow through Claude Desktop's `user_config` install prompt.
 
@@ -67,10 +67,7 @@ The shim is ~80 lines of plain Node with zero npm dependencies, not a thin wrapp
 
 ### 4. CI publishes the `.mcpb` artifact on change
 
-A GitHub Action under `.github/workflows/` builds the bundle (zip the `mcpb/` directory, produce `obsidian-mcp-<version>.mcpb`) and attaches it as a release asset whenever:
-
-- A release is cut (existing `release.yml` flow — add the `.mcpb` to the artifact set alongside `main.js`, `manifest.json`, `styles.css`).
-- The contents of `mcpb/` change on `main` (separate workflow that publishes a `latest` `.mcpb` so users testing via BRAT-equivalent paths get the current bundle without waiting for a tagged release).
+The existing `release.yml` workflow gains a step that builds the bundle and attaches it to the GitHub release alongside `main.js`, `manifest.json`, and `styles.css`. The build emits both `obsidian-mcp-<version>.mcpb` (versioned, for archival) and `obsidian-mcp.mcpb` (unversioned alias) so the Settings UI and README can link to `releases/latest/download/obsidian-mcp.mcpb` — a stable URL that always resolves to the most recent release without baking the plugin's running version into the link.
 
 Version sync via the existing `sync-version.mjs` script — `manifest.json` inside the bundle stays in lockstep with the plugin's `package.json` version.
 
@@ -124,6 +121,7 @@ All three paths are visible in plugin Settings so users can choose the one that 
 - The `mcp-remote` package is not added as a dependency, vendored or otherwise.
 - Localhost-bound HTTP endpoint means MCPB only works when Obsidian and Claude Desktop run on the same machine. Worth noting in the manifest description but not a regression — every existing onboarding path has the same constraint.
 - HTTPS mode (self-signed certs on `httpsPort`) works through the shim if `url` is set to the `https://` form; the relay does not need to know.
+- The maker script (`scripts/make-mcpb.mjs`) exposes the existence of the bridge to advanced users — they read `mcpb/server.js` when running the script from a clone. This slightly weakens the "bridge is invisible" framing relative to non-advanced users, but the advanced audience is exactly the cohort that would have been writing custom `mcpServers` JSON before MCPB existed, so the abstraction stays intact for the audience that benefits from it.
 
 ## Alternatives Considered
 

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -70,5 +70,7 @@ export default tseslint.config(
 		"versions.json",
 		"main.js",
 		"worker.js",
+		"mcpb",
+		"scripts",
 	]),
 );

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,0 +1,48 @@
+{
+  "manifest_version": "0.3",
+  "name": "obsidian-mcp",
+  "display_name": "Obsidian MCP",
+  "version": "0.11.16",
+  "description": "Connect Claude Desktop to your Obsidian vault via the Obsidian MCP plugin.",
+  "long_description": "Bridges Claude Desktop to the HTTP MCP server exposed by the Obsidian MCP plugin running inside Obsidian. Open Obsidian first, enable the MCP plugin in Settings, copy the URL and API key from the plugin's Settings tab, then paste them into the install prompt below.",
+  "author": {
+    "name": "Aaron Blumenfeld",
+    "url": "https://github.com/aaronsb"
+  },
+  "homepage": "https://github.com/aaronsb/obsidian-mcp-plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aaronsb/obsidian-mcp-plugin"
+  },
+  "keywords": ["obsidian", "mcp", "notes", "vault"],
+  "license": "MIT",
+  "server": {
+    "type": "node",
+    "entry_point": "server.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/server.js"],
+      "env": {
+        "MCP_URL": "${user_config.url}",
+        "MCP_API_KEY": "${user_config.api_key}"
+      }
+    }
+  },
+  "user_config": {
+    "url": {
+      "type": "string",
+      "title": "Obsidian MCP URL",
+      "description": "URL of the MCP endpoint exposed by the Obsidian MCP plugin. Find this in Obsidian → Settings → MCP. Default is http://localhost:3001/mcp; use the https:// form if you enabled HTTPS in the plugin.",
+      "required": true,
+      "default": "http://localhost:3001/mcp"
+    },
+    "api_key": {
+      "type": "string",
+      "title": "API Key",
+      "description": "API key shown in Obsidian → Settings → MCP. Leave blank only if you disabled authentication in the plugin (not recommended).",
+      "sensitive": true,
+      "required": false,
+      "default": ""
+    }
+  }
+}

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -14,14 +14,21 @@
     "type": "git",
     "url": "https://github.com/aaronsb/obsidian-mcp-plugin"
   },
-  "keywords": ["obsidian", "mcp", "notes", "vault"],
+  "keywords": [
+    "obsidian",
+    "mcp",
+    "notes",
+    "vault"
+  ],
   "license": "MIT",
   "server": {
     "type": "node",
     "entry_point": "server.js",
     "mcp_config": {
       "command": "node",
-      "args": ["${__dirname}/server.js"],
+      "args": [
+        "${__dirname}/server.js"
+      ],
       "env": {
         "MCP_URL": "${user_config.url}",
         "MCP_API_KEY": "${user_config.api_key}"

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -6,7 +6,7 @@
   "description": "Connect Claude Desktop to your Obsidian vault via the Obsidian MCP plugin.",
   "long_description": "Bridges Claude Desktop to the HTTP MCP server exposed by the Obsidian MCP plugin running inside Obsidian. Open Obsidian first, enable the MCP plugin in Settings, copy the URL and API key from the plugin's Settings tab, then paste them into the install prompt below.",
   "author": {
-    "name": "Aaron Blumenfeld",
+    "name": "Aaron Bockelie",
     "url": "https://github.com/aaronsb"
   },
   "homepage": "https://github.com/aaronsb/obsidian-mcp-plugin",

--- a/mcpb/server.js
+++ b/mcpb/server.js
@@ -5,6 +5,7 @@ const { createInterface } = require('node:readline');
 
 const MCP_URL = process.env.MCP_URL;
 const API_KEY = process.env.MCP_API_KEY || '';
+const FETCH_TIMEOUT_MS = 30_000;
 
 if (!MCP_URL) {
   process.stderr.write('[obsidian-mcp-bridge] MCP_URL not set\n');
@@ -17,6 +18,9 @@ try { new URL(MCP_URL); } catch {
 
 let sessionId = null;
 let notifyAbort = null;
+// Serializes dispatch until initialize lands a session id. Subsequent
+// messages chain off this promise so they don't race past the handshake.
+let initializing = null;
 
 function headers(extra = {}) {
   const h = {
@@ -41,12 +45,13 @@ async function consumeSse(response) {
     const { value, done } = await reader.read();
     if (done) break;
     buf += decoder.decode(value, { stream: true });
-    let idx;
-    while ((idx = buf.indexOf('\n\n')) !== -1) {
-      const frame = buf.slice(0, idx);
-      buf = buf.slice(idx + 2);
+    // SSE frame boundary is a blank line — tolerate LF or CRLF.
+    let match;
+    while ((match = /\r?\n\r?\n/.exec(buf)) !== null) {
+      const frame = buf.slice(0, match.index);
+      buf = buf.slice(match.index + match[0].length);
       const data = frame
-        .split('\n')
+        .split(/\r?\n/)
         .filter(l => l.startsWith('data:'))
         .map(l => l.slice(5).trimStart())
         .join('\n');
@@ -66,8 +71,12 @@ async function startNotifyStream() {
       headers: headers({ Accept: 'text/event-stream' }),
       signal: notifyAbort.signal,
     });
-    if (response.ok && (response.headers.get('content-type') || '').includes('text/event-stream')) {
+    const ctype = response.headers.get('content-type') || '';
+    if (response.ok && ctype.includes('text/event-stream')) {
       await consumeSse(response);
+    } else {
+      // Server doesn't speak the GET stream — drain so the socket releases.
+      await response.body?.cancel().catch(() => {});
     }
   } catch (e) {
     if (e.name !== 'AbortError') {
@@ -78,14 +87,25 @@ async function startNotifyStream() {
   }
 }
 
+async function postOnce(message) {
+  return await fetch(MCP_URL, {
+    method: 'POST',
+    headers: headers(),
+    body: JSON.stringify(message),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+}
+
 async function dispatch(message) {
+  // If we haven't established a session yet and this isn't the initialize,
+  // wait for the in-flight initialize to land first.
+  if (!sessionId && initializing && message.method !== 'initialize') {
+    try { await initializing; } catch { /* let dispatch surface its own error below */ }
+  }
+
   let response;
   try {
-    response = await fetch(MCP_URL, {
-      method: 'POST',
-      headers: headers(),
-      body: JSON.stringify(message),
-    });
+    response = await postOnce(message);
   } catch (err) {
     process.stderr.write(`[obsidian-mcp-bridge] fetch failed: ${err.message}\n`);
     if (message.id != null) {
@@ -120,7 +140,10 @@ async function dispatch(message) {
     return;
   }
 
-  if (response.status === 202) return;
+  if (response.status === 202) {
+    await response.body?.cancel().catch(() => {});
+    return;
+  }
 
   const ctype = response.headers.get('content-type') || '';
   if (ctype.includes('text/event-stream')) {
@@ -143,12 +166,32 @@ rl.on('line', (line) => {
     process.stderr.write(`[obsidian-mcp-bridge] stdin parse: ${e.message}\n`);
     return;
   }
-  dispatch(msg).catch(err => {
-    process.stderr.write(`[obsidian-mcp-bridge] dispatch: ${err.message}\n`);
-  });
+  // Capture the initialize promise so concurrent messages can wait for the
+  // session id before posting.
+  if (msg.method === 'initialize') {
+    initializing = dispatch(msg).finally(() => { initializing = null; });
+    initializing.catch(err => {
+      process.stderr.write(`[obsidian-mcp-bridge] dispatch: ${err.message}\n`);
+    });
+  } else {
+    dispatch(msg).catch(err => {
+      process.stderr.write(`[obsidian-mcp-bridge] dispatch: ${err.message}\n`);
+    });
+  }
 });
 
-process.stdin.on('end', () => {
+process.stdin.on('end', async () => {
   if (notifyAbort) notifyAbort.abort();
+  // Best-effort: tell the server to retire the session so it doesn't linger
+  // in the pool until idle GC.
+  if (sessionId) {
+    try {
+      await fetch(MCP_URL, {
+        method: 'DELETE',
+        headers: headers(),
+        signal: AbortSignal.timeout(5_000),
+      });
+    } catch { /* server may have already gone; ignore */ }
+  }
   process.exit(0);
 });

--- a/mcpb/server.js
+++ b/mcpb/server.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+'use strict';
+
+const { createInterface } = require('node:readline');
+
+const MCP_URL = process.env.MCP_URL;
+const API_KEY = process.env.MCP_API_KEY || '';
+
+if (!MCP_URL) {
+  process.stderr.write('[obsidian-mcp-bridge] MCP_URL not set\n');
+  process.exit(1);
+}
+try { new URL(MCP_URL); } catch {
+  process.stderr.write(`[obsidian-mcp-bridge] invalid MCP_URL: ${MCP_URL}\n`);
+  process.exit(1);
+}
+
+let sessionId = null;
+let notifyAbort = null;
+
+function headers(extra = {}) {
+  const h = {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json, text/event-stream',
+    ...extra,
+  };
+  if (API_KEY) h['Authorization'] = `Bearer ${API_KEY}`;
+  if (sessionId) h['Mcp-Session-Id'] = sessionId;
+  return h;
+}
+
+function emit(msg) {
+  process.stdout.write(JSON.stringify(msg) + '\n');
+}
+
+async function consumeSse(response) {
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let idx;
+    while ((idx = buf.indexOf('\n\n')) !== -1) {
+      const frame = buf.slice(0, idx);
+      buf = buf.slice(idx + 2);
+      const data = frame
+        .split('\n')
+        .filter(l => l.startsWith('data:'))
+        .map(l => l.slice(5).trimStart())
+        .join('\n');
+      if (!data) continue;
+      try { emit(JSON.parse(data)); }
+      catch (e) { process.stderr.write(`[obsidian-mcp-bridge] SSE parse: ${e.message}\n`); }
+    }
+  }
+}
+
+async function startNotifyStream() {
+  if (notifyAbort) return;
+  notifyAbort = new AbortController();
+  try {
+    const response = await fetch(MCP_URL, {
+      method: 'GET',
+      headers: headers({ Accept: 'text/event-stream' }),
+      signal: notifyAbort.signal,
+    });
+    if (response.ok && (response.headers.get('content-type') || '').includes('text/event-stream')) {
+      await consumeSse(response);
+    }
+  } catch (e) {
+    if (e.name !== 'AbortError') {
+      process.stderr.write(`[obsidian-mcp-bridge] notify stream ended: ${e.message}\n`);
+    }
+  } finally {
+    notifyAbort = null;
+  }
+}
+
+async function dispatch(message) {
+  let response;
+  try {
+    response = await fetch(MCP_URL, {
+      method: 'POST',
+      headers: headers(),
+      body: JSON.stringify(message),
+    });
+  } catch (err) {
+    process.stderr.write(`[obsidian-mcp-bridge] fetch failed: ${err.message}\n`);
+    if (message.id != null) {
+      emit({ jsonrpc: '2.0', id: message.id, error: { code: -32603, message: `Bridge: ${err.message}` } });
+    }
+    return;
+  }
+
+  if (message.method === 'initialize') {
+    const sid = response.headers.get('mcp-session-id');
+    if (sid) {
+      sessionId = sid;
+      startNotifyStream();
+    }
+  }
+
+  if (response.status === 404 && sessionId) {
+    sessionId = null;
+    if (notifyAbort) { notifyAbort.abort(); notifyAbort = null; }
+    if (message.id != null) {
+      emit({ jsonrpc: '2.0', id: message.id, error: { code: -32000, message: 'Session expired; please reinitialize' } });
+    }
+    return;
+  }
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    process.stderr.write(`[obsidian-mcp-bridge] HTTP ${response.status}: ${text.slice(0, 200)}\n`);
+    if (message.id != null) {
+      emit({ jsonrpc: '2.0', id: message.id, error: { code: -32603, message: `Bridge: HTTP ${response.status}` } });
+    }
+    return;
+  }
+
+  if (response.status === 202) return;
+
+  const ctype = response.headers.get('content-type') || '';
+  if (ctype.includes('text/event-stream')) {
+    await consumeSse(response);
+  } else {
+    const text = await response.text();
+    if (!text) return;
+    try { emit(JSON.parse(text)); }
+    catch (e) { process.stderr.write(`[obsidian-mcp-bridge] JSON parse: ${e.message}\n`); }
+  }
+}
+
+const rl = createInterface({ input: process.stdin });
+rl.on('line', (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  let msg;
+  try { msg = JSON.parse(trimmed); }
+  catch (e) {
+    process.stderr.write(`[obsidian-mcp-bridge] stdin parse: ${e.message}\n`);
+    return;
+  }
+  dispatch(msg).catch(err => {
+    process.stderr.write(`[obsidian-mcp-bridge] dispatch: ${err.message}\n`);
+  });
+});
+
+process.stdin.on('end', () => {
+  if (notifyAbort) notifyAbort.abort();
+  process.exit(0);
+});

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ai",
     "semantic"
   ],
-  "author": "Aaron Blumenfeld",
+  "author": "Aaron Bockelie",
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Pack mcpb/ into obsidian-mcp-<version>.mcpb using a stored-only zip
+// container. Pure Node, no deps — works on any Node ≥18.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = (c & 1) ? (0xedb88320 ^ (c >>> 1)) : (c >>> 1);
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buf) {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) c = CRC_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+function zipStore(files) {
+  const chunks = [];
+  const central = [];
+  let offset = 0;
+
+  for (const { name, data } of files) {
+    const nameBuf = Buffer.from(name, 'utf8');
+    const crc = crc32(data);
+
+    const local = Buffer.alloc(30 + nameBuf.length);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(0, 6);
+    local.writeUInt16LE(0, 8);
+    local.writeUInt16LE(0, 10);
+    local.writeUInt16LE(0, 12);
+    local.writeUInt32LE(crc, 14);
+    local.writeUInt32LE(data.length, 18);
+    local.writeUInt32LE(data.length, 22);
+    local.writeUInt16LE(nameBuf.length, 26);
+    local.writeUInt16LE(0, 28);
+    nameBuf.copy(local, 30);
+    chunks.push(local, data);
+
+    const cd = Buffer.alloc(46 + nameBuf.length);
+    cd.writeUInt32LE(0x02014b50, 0);
+    cd.writeUInt16LE(20, 4);
+    cd.writeUInt16LE(20, 6);
+    cd.writeUInt32LE(crc, 16);
+    cd.writeUInt32LE(data.length, 20);
+    cd.writeUInt32LE(data.length, 24);
+    cd.writeUInt16LE(nameBuf.length, 28);
+    cd.writeUInt32LE(0, 38);
+    cd.writeUInt32LE(offset, 42);
+    nameBuf.copy(cd, 46);
+    central.push(cd);
+
+    offset += local.length + data.length;
+  }
+
+  const cdSize = central.reduce((s, b) => s + b.length, 0);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(files.length, 8);
+  eocd.writeUInt16LE(files.length, 10);
+  eocd.writeUInt32LE(cdSize, 12);
+  eocd.writeUInt32LE(offset, 16);
+
+  return Buffer.concat([...chunks, ...central, eocd]);
+}
+
+export function buildMcpb({ manifest, serverJs }) {
+  return zipStore([
+    { name: 'manifest.json', data: Buffer.from(JSON.stringify(manifest, null, 2) + '\n', 'utf8') },
+    { name: 'server.js', data: Buffer.from(serverJs, 'utf8') },
+  ]);
+}
+
+// CLI: zip mcpb/manifest.json + mcpb/server.js → obsidian-mcp-<version>.mcpb
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const manifest = JSON.parse(readFileSync('mcpb/manifest.json', 'utf-8'));
+  const serverJs = readFileSync('mcpb/server.js', 'utf-8');
+  const out = `obsidian-mcp-${manifest.version}.mcpb`;
+  writeFileSync(out, buildMcpb({ manifest, serverJs }));
+  console.log(`✅ Built ${out} (${manifest.version})`);
+}

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -78,11 +78,17 @@ export function buildMcpb({ manifest, serverJs }) {
   ]);
 }
 
-// CLI: zip mcpb/manifest.json + mcpb/server.js → obsidian-mcp-<version>.mcpb
+// CLI: emit both a versioned bundle (for archival) and an unversioned
+// alias so the Settings UI / README can link to a stable
+// releases/latest/download/obsidian-mcp.mcpb URL regardless of plugin
+// version.
 if (import.meta.url === `file://${process.argv[1]}`) {
   const manifest = JSON.parse(readFileSync('mcpb/manifest.json', 'utf-8'));
   const serverJs = readFileSync('mcpb/server.js', 'utf-8');
-  const out = `obsidian-mcp-${manifest.version}.mcpb`;
-  writeFileSync(out, buildMcpb({ manifest, serverJs }));
-  console.log(`✅ Built ${out} (${manifest.version})`);
+  const bytes = buildMcpb({ manifest, serverJs });
+  const versioned = `obsidian-mcp-${manifest.version}.mcpb`;
+  const latest = 'obsidian-mcp.mcpb';
+  writeFileSync(versioned, bytes);
+  writeFileSync(latest, bytes);
+  console.log(`✅ Built ${versioned} and ${latest} (${manifest.version})`);
 }

--- a/scripts/make-mcpb.mjs
+++ b/scripts/make-mcpb.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Interactive .mcpb maker for advanced users.
+// Prompts for name, url, api_key, then emits obsidian-mcp-<name>.mcpb
+// using the same pure-Node zip helper as the canonical build.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createInterface } from 'node:readline/promises';
+import { stdin, stdout } from 'node:process';
+import { buildMcpb } from './build-mcpb.mjs';
+
+const rl = createInterface({ input: stdin, output: stdout });
+
+const slugify = (s) => s.toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '');
+
+const ask = async (q, fallback) => {
+  const a = (await rl.question(`${q}${fallback ? ` [${fallback}]` : ''}: `)).trim();
+  return a || fallback || '';
+};
+
+try {
+  console.log('Obsidian MCPB maker — generates a custom-named bundle for one vault.\n');
+
+  const displayName = await ask('Display name shown in Claude Desktop', 'Obsidian (Work Vault)');
+  const slug = slugify(displayName) || 'obsidian-mcp-custom';
+  const url = await ask('Obsidian MCP URL', 'http://localhost:3001/mcp');
+  const apiKey = await ask('API key (leave blank only if plugin auth is disabled)', '');
+
+  const baseManifest = JSON.parse(readFileSync('mcpb/manifest.json', 'utf-8'));
+  const serverJs = readFileSync('mcpb/server.js', 'utf-8');
+
+  const manifest = {
+    ...baseManifest,
+    name: slug,
+    display_name: displayName,
+    user_config: {
+      ...baseManifest.user_config,
+      url: { ...baseManifest.user_config.url, default: url },
+      api_key: { ...baseManifest.user_config.api_key, default: apiKey },
+    },
+  };
+
+  const out = `obsidian-mcp-${slug}.mcpb`;
+  writeFileSync(out, buildMcpb({ manifest, serverJs }));
+  console.log(`\n✅ Built ${out}`);
+  console.log(`   Drop it into Claude Desktop to install "${displayName}".`);
+  console.log('   The URL and API key are pre-filled — just click Install.');
+} finally {
+  rl.close();
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1411,28 +1411,64 @@ class MCPSettingTab extends PluginSettingTab {
 		resourcesList.createEl('li', {text: '📊 Obsidian://vault-info - real-time vault metadata'});
 		resourcesList.createEl('li', {text: '🔄 Obsidian://session-info - active mcp sessions and statistics'});
 		
-		new Setting(info).setName("Claude code connection").setHeading();
-		const commandExample = info.createDiv('protocol-command-example');
-		const codeEl = commandExample.createEl('code');
-		codeEl.classList.add('mcp-code-block');
-		
 		// Get correct protocol and port based on HTTPS setting
 		const protocol = this.plugin.settings.httpsEnabled ? 'https' : 'http';
 		const port = this.plugin.settings.httpsEnabled ? this.plugin.settings.httpsPort : this.plugin.settings.httpPort;
 		const baseUrl = `${protocol}://localhost:${port}`;
-		
+		const mcpUrl = `${baseUrl}/mcp`;
+
+		// === Claude Desktop (MCPB) — primary onboarding path ===
+		new Setting(info).setName("Claude desktop (.mcpb — one-click install)").setHeading();
+		info.createEl('p', {
+			text: 'Download the bundle, drop it onto claude desktop, and paste these values in the install prompt.'
+		});
+
+		const version = this.plugin.manifest.version;
+		const mcpbUrl = `https://github.com/aaronsb/obsidian-mcp-plugin/releases/download/${version}/obsidian-mcp-${version}.mcpb`;
+		const downloadEl = info.createDiv('mcpb-download');
+		const downloadLink = downloadEl.createEl('a', {
+			text: `⬇ obsidian-mcp-${version}.mcpb`,
+			href: mcpbUrl,
+			cls: 'mcp-mcpb-download',
+		});
+		downloadLink.setAttribute('target', '_blank');
+		downloadLink.setAttribute('rel', 'noopener');
+
+		const mcpbValuesEl = info.createDiv('mcpb-values');
+		const urlRow = mcpbValuesEl.createDiv('mcp-config-container');
+		urlRow.createEl('strong', { text: 'URL: ' });
+		urlRow.createEl('code', { text: mcpUrl, cls: 'mcp-code-inline' });
+		this.addCopyButton(urlRow, mcpUrl);
+
+		if (!this.plugin.settings.dangerouslyDisableAuth) {
+			const keyRow = mcpbValuesEl.createDiv('mcp-config-container');
+			keyRow.createEl('strong', { text: 'API key: ' });
+			keyRow.createEl('code', { text: this.plugin.settings.apiKey, cls: 'mcp-code-inline' });
+			this.addCopyButton(keyRow, this.plugin.settings.apiKey);
+		}
+
+		info.createEl('p', {
+			cls: 'mcp-mcpb-note',
+			text: 'Multiple vaults? Run `node scripts/make-mcpb.mjs` from a clone of the repo to generate a custom-named bundle per vault.',
+		});
+
+		// === Claude Code (CLI) ===
+		new Setting(info).setName("Claude code (CLI)").setHeading();
+		const commandExample = info.createDiv('protocol-command-example');
+		const codeEl = commandExample.createEl('code');
+		codeEl.classList.add('mcp-code-block');
+
 		const claudeCommand = this.plugin.settings.dangerouslyDisableAuth ?
-			`claude mcp add --transport http obsidian ${baseUrl}/mcp` :
-			`claude mcp add --transport http obsidian ${baseUrl}/mcp --header "Authorization: Bearer ${this.plugin.settings.apiKey}"`;
+			`claude mcp add --transport http obsidian ${mcpUrl}` :
+			`claude mcp add --transport http obsidian ${mcpUrl} --header "Authorization: Bearer ${this.plugin.settings.apiKey}"`;
 
 		codeEl.textContent = claudeCommand;
-
-		// Add copy button
 		this.addCopyButton(commandExample, claudeCommand);
-		
-		new Setting(info).setName("Client configuration (claude desktop, cline, etc.)").setHeading();
+
+		// === Other MCP clients (JSON) ===
+		new Setting(info).setName("Other mcp clients (JSON config)").setHeading();
 		info.createEl('p', {
-			text: 'Add this to your mcp client configuration file:'
+			text: 'For cline, continue, custom integrations, or multi-vault setups — add this to the client\'s mcp config file:'
 		});
 
 		const configExample = info.createDiv('desktop-config-example');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1423,11 +1423,12 @@ class MCPSettingTab extends PluginSettingTab {
 			text: 'Download the bundle, drop it onto claude desktop, and paste these values in the install prompt.'
 		});
 
-		const version = this.plugin.manifest.version;
-		const mcpbUrl = `https://github.com/aaronsb/obsidian-mcp-plugin/releases/download/${version}/obsidian-mcp-${version}.mcpb`;
+		// Stable "latest" endpoint — always resolves to the most recent release
+		// asset regardless of whether this plugin build has a release yet.
+		const mcpbUrl = 'https://github.com/aaronsb/obsidian-mcp-plugin/releases/latest/download/obsidian-mcp.mcpb';
 		const downloadEl = info.createDiv('mcpb-download');
 		const downloadLink = downloadEl.createEl('a', {
-			text: `⬇ obsidian-mcp-${version}.mcpb`,
+			text: '⬇ Obsidian-mcp.mcpb',
 			href: mcpbUrl,
 			cls: 'mcp-mcpb-download',
 		});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1448,11 +1448,6 @@ class MCPSettingTab extends PluginSettingTab {
 			this.addCopyButton(keyRow, this.plugin.settings.apiKey);
 		}
 
-		info.createEl('p', {
-			cls: 'mcp-mcpb-note',
-			text: 'Multiple vaults? Run `node scripts/make-mcpb.mjs` from a clone of the repo to generate a custom-named bundle per vault.',
-		});
-
 		// === Claude Code (CLI) ===
 		new Setting(info).setName("Claude code (CLI)").setHeading();
 		const commandExample = info.createDiv('protocol-command-example');
@@ -1466,13 +1461,21 @@ class MCPSettingTab extends PluginSettingTab {
 		codeEl.textContent = claudeCommand;
 		this.addCopyButton(commandExample, claudeCommand);
 
-		// === Other MCP clients (JSON) ===
-		new Setting(info).setName("Other mcp clients (JSON config)").setHeading();
-		info.createEl('p', {
-			text: 'For cline, continue, custom integrations, or multi-vault setups — add this to the client\'s mcp config file:'
+		// === Advanced: collapsed by default to keep the default view tidy ===
+		// Contains the JSON path (for Cline/Continue/custom clients and multi-vault
+		// setups) and the maker-script pointer for custom-named bundles.
+		const advanced = info.createEl('details', { cls: 'mcp-advanced-details' });
+		advanced.createEl('summary', {
+			text: 'Advanced — other mcp clients, multi-vault, custom bundles',
+			cls: 'mcp-advanced-summary',
 		});
 
-		const configExample = info.createDiv('desktop-config-example');
+		new Setting(advanced).setName("Other mcp clients (JSON config)").setHeading();
+		advanced.createEl('p', {
+			text: 'For cline, continue, custom integrations, or multi-vault setups — add this to the client\'s mcp config file. One entry per vault if you run several Obsidian instances on different ports:'
+		});
+
+		const configExample = advanced.createDiv('desktop-config-example');
 		const configEl = configExample.createEl('pre');
 		configEl.classList.add('mcp-config-example');
 
@@ -1502,8 +1505,12 @@ class MCPSettingTab extends PluginSettingTab {
 
 		const configJsonText = JSON.stringify(configJson, null, 2);
 		configEl.textContent = configJsonText;
-
 		this.addCopyButton(configExample, configJsonText);
+
+		new Setting(advanced).setName("Custom bundle per vault").setHeading();
+		advanced.createEl('p', {
+			text: 'Clone the plugin repo and run `node scripts/make-mcpb.mjs`. It prompts for a display name, url, and api key, then writes a custom-named .mcpb you drop into claude desktop — one-click install per vault, no fields to type at install time.'
+		});
 	}
 
 	private addCopyButton(container: HTMLElement, textToCopy: string): void {

--- a/sync-version.mjs
+++ b/sync-version.mjs
@@ -14,6 +14,11 @@ try {
   // Write updated manifest.json
   writeFileSync('manifest.json', JSON.stringify(manifest, null, 2) + '\n');
 
+  // Read and update mcpb/manifest.json (MCPB bundle for Claude Desktop)
+  const mcpbManifest = JSON.parse(readFileSync('mcpb/manifest.json', 'utf-8'));
+  mcpbManifest.version = version;
+  writeFileSync('mcpb/manifest.json', JSON.stringify(mcpbManifest, null, 2) + '\n');
+
   // Update version.ts
   const versionTs = `// Version is injected at build time by sync-version.mjs
 export function getVersion(): string {
@@ -22,7 +27,7 @@ export function getVersion(): string {
 `;
   writeFileSync('src/version.ts', versionTs);
 
-  console.log(`✅ Synced version ${version} from package.json to manifest.json and version.ts`);
+  console.log(`✅ Synced version ${version} to manifest.json, mcpb/manifest.json, and version.ts`);
 } catch (error) {
   console.error('❌ Failed to sync version:', error.message);
   process.exit(1);


### PR DESCRIPTION
Implements ADR-102. Adds an MCPB (`.mcpb`) bundle as the primary Claude Desktop onboarding path, with the existing Claude Code CLI string and JSON `mcpServers` block remaining as secondary and tertiary paths. Manually verified end-to-end (install in Claude Desktop, tool calls succeed, SVG content round-trips).

## Onboarding tiers (now visible in plugin Settings + README)

| Audience | Path |
|---|---|
| Single vault, easy setup | Download `.mcpb`, drag onto Claude Desktop |
| Claude Code users | `claude mcp add …` CLI string |
| Cline / Continue / multi-vault | JSON `mcpServers` block |
| Advanced multi-vault, one-click per vault | `node scripts/make-mcpb.mjs` |

## What's in this branch (7 commits)

1. **docs**: ADR-102 + INDEX
2. **feat**: `mcpb/manifest.json` + `mcpb/server.js` (zero-dep stdio↔HTTP bridge) + `.gitignore`
3. **build**: `sync-version.mjs` now keeps `mcpb/manifest.json` in lockstep with `package.json`
4. **build**: `make mcpb` target + `scripts/build-mcpb.mjs` (pure-Node zip helper) + `release.yml` attaches the `.mcpb` to release assets
5. **feat**: `scripts/make-mcpb.mjs` interactive maker for advanced users
6. **feat(settings)**: Connection-setup UI reordered — MCPB primary, JSON demoted
7. **docs(readme)**: Install section restructured to match

## Why a stdio bridge inside the bundle?

MCPB has no native remote-HTTP server type today — only `node`/`python`/`binary`/`uv`. Claude Desktop ships its own Node runtime, so a `node`-type bundle with a tiny stdio↔HTTP bridge gives one-click install with zero end-user runtime requirements. ADR-102 reconciles this with ADR-100 (the bridge is invisible to the user, so the deprecation of `mcp-remote` as a user-facing config doesn't apply here).

## Verification

- `make check` clean (build + lint + 127 tests pass)
- Built `.mcpb` (2.4 KB) manually installed in Claude Desktop, tool calls verified end-to-end including SVG content in tool output

## Follow-ups (out of scope here)

- Triage the session-stability PR cluster (#128, #147, #150, #126)
- Address #154 (vault.list empty), Dataview bugs (#123, #115), parallel-edit race (#139)