### PR TITLE
fix(vault): Recurse listFiles into subfolders (#154)

### DIFF
--- a/src/utils/obsidian-api.ts
+++ b/src/utils/obsidian-api.ts
@@ -228,7 +228,19 @@ export class ObsidianAPI {
       if (!folder || !(folder instanceof TFolder)) {
         throw new Error(`Directory not found: ${directory}`);
       }
-      files = folder.children;
+      // Walk the folder tree to collect every descendant. Matches the
+      // recursive semantics of vault.getAllLoadedFiles() for the root
+      // case, so a caller doesn't see an empty list when a folder only
+      // contains subfolders.
+      files = [];
+      const stack: TAbstractFile[] = [...folder.children];
+      while (stack.length > 0) {
+        const f = stack.pop()!;
+        files.push(f);
+        if (f instanceof TFolder) {
+          stack.push(...f.children);
+        }
+      }
     } else {
       files = vault.getAllLoadedFiles();
     }

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -7,6 +7,11 @@ export abstract class TAbstractFile {
 
 export class TFile extends TAbstractFile {
   extension!: string;
+  stat: { mtime: number; ctime: number; size: number } = { mtime: 0, ctime: 0, size: 0 };
+}
+
+export class TFolder extends TAbstractFile {
+  children: TAbstractFile[] = [];
 }
 
 export class App {

--- a/tests/list-files-recursive.test.ts
+++ b/tests/list-files-recursive.test.ts
@@ -1,0 +1,92 @@
+import { App, TFile, TFolder } from 'obsidian';
+import { ObsidianAPI } from '../src/utils/obsidian-api';
+
+// Regression coverage for issue #154 — vault.list(directory) returned an
+// empty array for folders whose direct children were all subfolders.
+// listFiles should recurse into descendant folders, matching the
+// behavior of the root case (which uses vault.getAllLoadedFiles()).
+
+function makeFile(path: string): TFile {
+  const f = new TFile();
+  f.path = path;
+  f.name = path.split('/').pop()!;
+  f.extension = 'md';
+  return f;
+}
+
+function makeFolder(path: string, children: TFile[] | TFolder[] = []): TFolder {
+  const folder = new TFolder();
+  folder.path = path;
+  folder.name = path.split('/').pop() || path;
+  folder.children = children;
+  return folder;
+}
+
+describe('ObsidianAPI.listFiles — folder-of-folders (#154)', () => {
+  let api: ObsidianAPI;
+  let mockApp: App;
+  let allFiles: (TFile | TFolder)[];
+  let lookup: Map<string, TFile | TFolder>;
+
+  beforeEach(() => {
+    // Vault layout:
+    //   technical/
+    //     ai_research/
+    //       paper.md
+    //     experiments/
+    //       trial.md
+    //       (no notes at technical/ level)
+    const paper = makeFile('technical/ai_research/paper.md');
+    const trial = makeFile('technical/experiments/trial.md');
+    const aiResearch = makeFolder('technical/ai_research', [paper]);
+    const experiments = makeFolder('technical/experiments', [trial]);
+    const technical = makeFolder('technical', [aiResearch, experiments]);
+
+    allFiles = [technical, aiResearch, experiments, paper, trial];
+    lookup = new Map(allFiles.map(f => [f.path, f]));
+
+    mockApp = new App();
+    mockApp.vault.getAbstractFileByPath = (path: string) => lookup.get(path) ?? null;
+    mockApp.vault.getAllLoadedFiles = () => allFiles;
+    mockApp.vault.adapter = { basePath: '/mock' } as any;
+
+    api = new ObsidianAPI(mockApp);
+  });
+
+  it('returns all descendant files when a folder contains only subfolders', async () => {
+    const files = await api.listFiles('technical');
+    expect(files).toEqual([
+      'technical/ai_research/paper.md',
+      'technical/experiments/trial.md',
+    ]);
+  });
+
+  it('still recurses through nested subfolders', async () => {
+    const deep = makeFile('technical/ai_research/sub/deep.md');
+    const sub = makeFolder('technical/ai_research/sub', [deep]);
+    const aiResearch = lookup.get('technical/ai_research') as TFolder;
+    aiResearch.children = [...aiResearch.children, sub];
+    allFiles.push(sub, deep);
+    lookup.set(sub.path, sub);
+    lookup.set(deep.path, deep);
+
+    const files = await api.listFiles('technical');
+    expect(files).toContain('technical/ai_research/sub/deep.md');
+  });
+
+  it('throws when the directory does not exist', () => {
+    // Note: listFiles throws synchronously despite the Promise return type.
+    // Preserving that behavior so existing callers' try/catch around the call
+    // site keeps working unchanged.
+    expect(() => api.listFiles('does-not-exist')).toThrow(/Directory not found/);
+  });
+
+  it('still returns the full vault when called without a directory', async () => {
+    const files = await api.listFiles();
+    // getAllLoadedFiles returns folders too — listFiles must filter to files.
+    expect(files).toEqual([
+      'technical/ai_research/paper.md',
+      'technical/experiments/trial.md',
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #154.

## Bug

\`vault.list(directory)\` returned an empty array whenever the target folder's direct children were all subfolders. The non-paginated code path used \`folder.children\` (level-only) and then filtered to \`TFile\` — every descendant got dropped. Meanwhile the root case (\`vault.list()\` with no directory) used \`vault.getAllLoadedFiles()\` which is recursive, so root and directory listings silently diverged.

Live-reproduced in the running plugin before the fix: \`vault.list('technical')\` on a folder of folders returned \`Found 0 items\` even though every subfolder contained notes.

## Fix

\`listFiles\` now walks the folder tree when a directory is provided, matching the root case's recursive semantics. Caller contract is unchanged — still returns full vault-rooted paths to \`.md\` files — but the empty-list cliff for folder-of-folders inputs is gone.

The synchronous throw on missing-directory is preserved; callers at \`router.ts:538\` and \`:1030\` use it as a "does this exist as a directory" probe.

## Tests

New \`tests/list-files-recursive.test.ts\` with regression coverage:
- Folder of subfolders → returns all descendant files
- Arbitrary nesting depth recurses correctly
- Missing directory still throws synchronously
- Root call still returns the full vault

Test fixture \`tests/__mocks__/obsidian.ts\` gained a \`TFolder\` class and a \`stat\` field on \`TFile\` to support the test harness.

\`make check\` clean (build + lint + 131 tests, including 4 new).