### PR TITLE
fix(router): Numeric pagination params silently dropped (parseInt(paramStr) → paramNum)

### DIFF
--- a/src/semantic/router.ts
+++ b/src/semantic/router.ts
@@ -171,8 +171,11 @@ export class SemanticRouter {
         // recursive=false there; listFilesPaginated routes through
         // the same path regardless.
         if (params.page || params.pageSize) {
-          const page = parseInt(paramStr(params, 'page') ?? '1') || 1;
-          const pageSize = parseInt(paramStr(params, 'pageSize') ?? '20') || 20;
+          // MCP clients send these as JSON numbers; paramStr returns undefined
+          // for non-strings, so parseInt(paramStr(...) ?? '1') silently
+          // collapsed to defaults and made pagination a no-op.
+          const page = paramNum(params, 'page') ?? 1;
+          const pageSize = paramNum(params, 'pageSize') ?? 20;
           const recursive = directory !== undefined;
           return await this.api.listFilesPaginated(directory, page, pageSize, recursive);
         }
@@ -283,8 +286,9 @@ export class SemanticRouter {
 
         // Use advanced search with ranking and snippets
         try {
-          const page = parseInt(paramStr(params, 'page') ?? '1') || 1;
-          const pageSize = parseInt(paramStr(params, 'pageSize') ?? '10') || 10;
+          // MCP clients send these as JSON numbers — use paramNum, not paramStr.
+          const page = paramNum(params, 'page') ?? 1;
+          const pageSize = paramNum(params, 'pageSize') ?? 10;
           // Use searchStrategy for search, fall back to strategy for backward compatibility
           const strategy = (paramStr(params, 'searchStrategy') || paramStr(params, 'strategy') || 'combined') as 'filename' | 'content' | 'combined';
           const includeContent = params.includeContent !== false; // Default to true
@@ -303,7 +307,7 @@ export class SemanticRouter {
             searchOptions.includeSnippets = Boolean(params.includeSnippets);
           }
           if (params.snippetLength !== undefined) {
-            searchOptions.snippetLength = parseInt(paramStr(params, 'snippetLength') ?? '0');
+            searchOptions.snippetLength = paramNum(params, 'snippetLength') ?? 0;
           }
 
           const searchResults = await this.api.searchPaginated(


### PR DESCRIPTION
Caught while live-verifying #158 in 0.11.19.

## Bug

Pagination was silently a no-op for the MCP-facing surface. \`vault.list(directory='technical', page=2, pageSize=50)\` returned **page 1 of 4 with 20 per page** — the user's values were discarded before the call reached \`listFilesPaginated\`.

## Root cause

MCP clients send numeric arguments (\`page\`, \`pageSize\`, \`snippetLength\`) as JSON numbers. The router's helper \`paramStr\` returns \`undefined\` for non-string values (see \`router.ts:38\`), so:

\`\`\`ts
const page = parseInt(paramStr(params, 'page') ?? '1') || 1;
// number 2 → paramStr → undefined → '1' → parseInt → 1 → || 1 → 1
\`\`\`

…always collapsed to the default. Pre-existing bug; #158 just made it visible by adding "Use page=N" hints in the formatted output that didn't actually work.

## Fix

Use the already-defined sibling helper \`paramNum\` (router.ts:44) — three call sites:

| Line | Path |
|---|---|
| 174-175 | \`vault.list\` pagination (the immediate verifier) |
| 286-287 | \`vault.search\` pagination |
| 306 | \`vault.search\` \`snippetLength\` |

## Verification

- \`make check\` clean — build + lint + 134 tests
- After publish, live test will be \`vault.list('technical', page=2, pageSize=50)\` → should return items 51-77 sorted by full path