### PR TITLE
feat(scorecard): pull Obsidian portal scorecard as free post-release signal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,6 +389,46 @@ Obsidian's checks *before* running `make promote`. Treat it as a
 validation/dry-run tool: end-user installs and updates still come from the
 matching stable release tag's assets, not from a scanned branch.
 
+### Reading the scorecard as free signal — `make scorecard`
+
+The public plugin page (`community.obsidian.md/plugins/semantic-vault-mcp`)
+renders an automated **Health** grade and **Review** scan — deterministic
+static analysis, not an LLM. It is free signal we can pull without logging in:
+
+```
+make scorecard          # prose + freshness delta, for reading
+node scripts/scorecard.mjs --json   # one JSON line, for diffing across releases
+```
+
+Key facts about this tool:
+
+- **Freshness is not guaranteed.** A *fresh* scan is only triggered from the
+  authenticated developer portal. The public page reflects the last release
+  Obsidian scanned, so the script reports a `freshness` delta (portal version
+  vs `manifest.json`). `STALE` means a logged-in re-scan is still needed.
+- **Drift guard.** The findings come from Obsidian's Next.js RSC payload, so
+  the parser is coupled to their internal serialization. If the page
+  structure changes, the script exits **non-zero with a `SCRAPER DRIFT`
+  banner** — that means review `scripts/scorecard.mjs`, *not* that the
+  scorecard is clean. The scorecard body itself never gates anything.
+
+### Known accepted scorecard cautions
+
+Not every "Caution" is a defect — some are deliberate trade-offs. Do not
+"fix" these by reverting the decision behind them:
+
+- **"The release contains additional files: …`.mcpb`…"** — expected and
+  accepted. Per **ADR-102**, releases intentionally ship the `.mcpb`
+  bundles so `releases/latest/download/obsidian-mcp.mcpb` (the plugin
+  Settings download) resolves. Clearing this caution would mean breaking
+  ADR-102; it stays.
+- **"… scan not available" disclosures** — neutral. These mean Obsidian's
+  malware/dependency/obfuscation scanners did not run, not that the plugin
+  failed them. Nothing for us to do.
+
+Genuinely actionable findings get GitHub issues (e.g. #163, #164); the
+scorecard CI-gate idea is tracked in #165.
+
 ## Important Notes
 
 - **Critical Path**: The ObsidianAPI abstraction layer is the cornerstone of this architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,6 +389,17 @@ Obsidian's checks *before* running `make promote`. Treat it as a
 validation/dry-run tool: end-user installs and updates still come from the
 matching stable release tag's assets, not from a scanned branch.
 
+### Where the listing text comes from
+
+- **Short description** — repo-driven. Single source of truth is
+  `package.json`; `sync-version.mjs` propagates it to `manifest.json`; use
+  `make set-description DESC='...'` (never hand-edit the JSON). The portal's
+  one-liner refreshes on the next scan after release.
+- **Long "About"** — *not* in the repo. Obsidian seeded this portal-side
+  during the community.obsidian.md migration; it is decoupled from
+  `package.json`/`manifest.json` and only editable in the authenticated
+  developer portal. Repo edits will **not** change it — update it there.
+
 ### Reading the scorecard as free signal — `make scorecard`
 
 The public plugin page (`community.obsidian.md/plugins/semantic-vault-mcp`)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help build dev test lint lint-fix check clean install \
-       release-patch release-minor release-major release publish promote sync-version mcpb
+       release-patch release-minor release-major release publish promote sync-version mcpb scorecard
 
 MIN_OBSIDIAN := 0.15.0
 
@@ -89,3 +89,6 @@ sync-version: ## Sync version from package.json to manifest.json and version.ts
 
 mcpb: ## Build MCPB bundle (obsidian-mcp-<version>.mcpb) for Claude Desktop
 	node scripts/build-mcpb.mjs
+
+scorecard: ## Pull the Obsidian community portal scorecard + freshness delta (free post-release signal)
+	@node scripts/scorecard.mjs

--- a/scripts/scorecard.mjs
+++ b/scripts/scorecard.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+// Fetch the Obsidian community portal scorecard for this plugin and surface it
+// as diffable prose plus a freshness delta against local repo state.
+//
+// Why: the portal page is public and server-rendered, so the automated
+// Health/Review scan is free signal we can pull without logging in. But a
+// *fresh* scan is only triggered from the (authenticated) developer portal —
+// so the public scorecard reflects whatever release Obsidian last scanned,
+// not necessarily our HEAD. This script makes that staleness explicit by
+// diffing the portal's reported version/updated against the local repo.
+//
+// Usage: node scripts/scorecard.mjs            (prose, for reading/evaluation)
+//        node scripts/scorecard.mjs --json     (single JSON line, for diffing)
+//
+// Exit code is always 0 — this is an advisory signal, not a gate.
+
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+const SLUG = 'semantic-vault-mcp';
+const URL = `https://community.obsidian.md/plugins/${SLUG}`;
+
+// The portal is a Next.js App Router page. The scorecard *summary*
+// (Health/Review/version) is rendered into the DOM, but the detailed
+// findings live only in the RSC flight payload inside <script>
+// self.__next_f.push(...) </script> as escaped JSON. So we decode the
+// whole document — DOM text AND unescaped script payload — into one
+// searchable blob. This coupling to their internal serialization is
+// exactly why the drift guard below exists.
+function htmlToText(html) {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/\\u003c/gi, '<')
+    .replace(/\\u003e/gi, '>')
+    .replace(/\\u0026/gi, '&')
+    .replace(/\\n/g, '\n')
+    .replace(/\\"/g, '"')
+    .replace(/\\\//g, '/')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&#x27;|&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\s*\n\s*/g, '\n')
+    .trim();
+}
+
+function pick(re, text, group = 1) {
+  const m = text.match(re);
+  return m ? m[group].trim() : null;
+}
+
+function repoState() {
+  const manifest = JSON.parse(readFileSync('manifest.json', 'utf8'));
+  const git = (cmd) => {
+    try {
+      return execSync(cmd, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+    } catch {
+      return null;
+    }
+  };
+  return {
+    manifestVersion: manifest.version,
+    latestTag: git('git describe --tags --abbrev=0'),
+    headSha: git('git rev-parse --short HEAD'),
+    headDate: git('git log -1 --format=%cI'),
+  };
+}
+
+async function main() {
+  const asJson = process.argv.includes('--json');
+
+  let html;
+  try {
+    const res = await fetch(URL, { headers: { 'User-Agent': 'obsidian-mcp-scorecard/1' } });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    html = await res.text();
+  } catch (e) {
+    console.error(`scorecard: could not fetch ${URL} — ${e.message}`);
+    process.exit(0);
+  }
+
+  const text = htmlToText(html);
+
+  const portal = {
+    health: pick(/Health\s+(Excellent|Good|Fair|Poor|Caution)/i, text),
+    review: pick(/Review\s+(Excellent|Good|Caution|Warning|Critical)/i, text),
+    issuesFound: pick(/(\d+)\s+issues? found by automated scans/i, text),
+    currentVersion: pick(/Current version\s+([0-9][^\s]*)/i, text),
+    lastUpdated: pick(/Last updated\s+([^\n]+?)(?:\s+Created)/i, text),
+    created: pick(/Created\s+([^\n]+?)(?:\s+Updates|\s+Downloads)/i, text),
+  };
+
+  // Findings come through as discrete JSON string literals in the decoded
+  // payload, not contiguous prose, so isolate candidate sentences and keep
+  // the ones carrying a known finding signature. The signature set — not a
+  // DOM path — is the contract; if Obsidian rewords these, the drift guard
+  // fires rather than silently dropping findings.
+  const SIGNATURE =
+    /(scan not available\.|verification not available\.|\)\s*calls|artifact attestation|certificate verification|additional files|are supported\.|issues? found by automated)/i;
+  const candidates = [
+    ...new Set(
+      (text.match(/[^\n"]{12,260}/g) || [])
+        .map((s) => s.trim())
+        .filter((s) => SIGNATURE.test(s)),
+    ),
+  ];
+  // Drop fragments that are a substring of a longer kept finding — the
+  // payload carries both whole sentences and partial JSX children.
+  const findings = candidates
+    .filter((s) => !candidates.some((o) => o !== s && o.includes(s)))
+    .slice(0, 20);
+
+  // Scraper drift guard. This parser depends on the portal's current DOM
+  // wording/structure. When Obsidian reworks the page, anchors silently
+  // vanish and every field returns null — which would look like a clean
+  // scorecard. Treat missing critical anchors as a hard failure that tells
+  // the operator to review THIS script, not as a passing scan.
+  const critical = {
+    health: portal.health,
+    review: portal.review,
+    'issues count': portal.issuesFound,
+    'portal version': portal.currentVersion,
+  };
+  const missing = Object.entries(critical)
+    .filter(([, v]) => v == null)
+    .map(([k]) => k);
+  // A non-clean Review with zero extracted findings also means the findings
+  // selectors drifted, even if the headline anchors still parse.
+  const findingsDrift =
+    portal.review &&
+    /caution|warning|critical/i.test(portal.review) &&
+    findings.length === 0;
+  const drift = missing.length > 0 || findingsDrift;
+
+  const repo = repoState();
+
+  // Freshness: is the public scorecard even reviewing our current version?
+  let freshness = 'unknown';
+  if (portal.currentVersion && repo.manifestVersion) {
+    if (portal.currentVersion === repo.manifestVersion) {
+      freshness = 'current — portal scanned the version in manifest.json';
+    } else {
+      freshness = `STALE — portal scanned ${portal.currentVersion}, manifest is ${repo.manifestVersion} (a logged-in re-scan on the dev portal is needed to refresh)`;
+    }
+  }
+
+  if (asJson) {
+    console.log(
+      JSON.stringify({
+        portal,
+        findings,
+        repo,
+        freshness,
+        integrity: drift ? 'DRIFT' : 'ok',
+        missingAnchors: missing,
+        findingsDrift,
+        fetchedAt: new Date().toISOString(),
+      }),
+    );
+    process.exit(drift ? 2 : 0);
+  }
+
+  if (drift) {
+    const bang = '!'.repeat(64);
+    console.error(bang);
+    console.error('SCRAPER DRIFT — the Obsidian portal page no longer parses');
+    console.error('as expected. Do NOT trust the scorecard below; it may be');
+    console.error('silently empty. scripts/scorecard.mjs needs review.');
+    if (missing.length) console.error(`  missing anchors : ${missing.join(', ')}`);
+    if (findingsDrift) console.error('  findings selectors matched nothing despite a non-clean Review');
+    console.error(`  page          : ${URL}`);
+    console.error(bang);
+  }
+
+  const line = '─'.repeat(64);
+  console.log(line);
+  console.log(`Obsidian scorecard — ${SLUG}`);
+  console.log(URL);
+  console.log(line);
+  console.log(`Health          : ${portal.health ?? '?'}`);
+  console.log(`Review          : ${portal.review ?? '?'}  (${portal.issuesFound ?? '?'} issues)`);
+  console.log(`Portal version  : ${portal.currentVersion ?? '?'}`);
+  console.log(`Portal updated  : ${portal.lastUpdated ?? '?'}`);
+  console.log(`Portal created  : ${portal.created ?? '?'}`);
+  console.log(line);
+  console.log(`Repo manifest   : ${repo.manifestVersion}`);
+  console.log(`Repo latest tag : ${repo.latestTag ?? '?'}`);
+  console.log(`Repo HEAD       : ${repo.headSha ?? '?'} (${repo.headDate ?? '?'})`);
+  console.log(line);
+  console.log(`Freshness       : ${freshness}`);
+  console.log(line);
+  console.log('Findings (prose — read, do not gate on):');
+  for (const f of findings) console.log(`  • ${f}`);
+  console.log(line);
+
+  // Non-zero only on scraper drift — the scorecard content itself is
+  // advisory and never gates, but a broken parser must be loud.
+  process.exit(drift ? 2 : 0);
+}
+
+main();


### PR DESCRIPTION
## What

Adds `scripts/scorecard.mjs` + `make scorecard` — pulls the Obsidian community portal's automated Health/Review scan as free post-release signal, no browser or login needed.

Came out of diagnosing the "No release matches" portal error: the page is server-rendered (summary in DOM, detailed findings in the Next.js RSC `__next_f` payload), so it's scrapable.

## Features

- **Freshness delta** — portal "Current version" vs `manifest.json`. A fresh scan only triggers from the authenticated dev portal, so the public page can lag; `STALE` flags when a logged-in re-scan is still needed.
- **Scraper drift guard** — parser is coupled to Obsidian's internal serialization by necessity. Missing critical anchors, or zero findings on a non-clean Review, exits **non-zero** with a `SCRAPER DRIFT` banner. The parser rots loudly, never silently. The scorecard body itself never gates anything (advisory only).
- `--json` mode for diffing findings across releases.

## Docs

CLAUDE.md gains: `make scorecard` usage, the freshness caveat, the drift-guard contract, and a **"known accepted cautions"** list — the `.mcpb` "additional files" caution is ADR-102 by design (clearing it would break the Settings download), and "scan not available" disclosures are neutral.

## Findings triaged into issues

Live scorecard for 0.11.21 (Review: Caution, 4 issues):

| Finding | Disposition |
|---|---|
| `rejectUnauthorized: false` SSL flag | #163 — verify inert (only inbound, no `requestCert`), remove default |
| 2 assets missing artifact attestation | #164 — add `attest-build-provenance` to release.yml |
| Extra `.mcpb` files unsupported | Accepted (ADR-102) — documented, not a defect |
| "scan not available" ×5 | Neutral disclosures — not actionable |
| Post-promote scorecard regression gate | #165 |

Pre-push gates: build ✅ lint ✅ (0 errors) test ✅