### PR TITLE
fix: clear actionable Obsidian scorecard cautions (#163, #164)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ env:
 
 permissions:
   contents: write
+  id-token: write      # required for build-provenance attestation (#164)
+  attestations: write  # required for build-provenance attestation (#164)
 
 jobs:
   build:
@@ -57,6 +59,15 @@ jobs:
           else
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Attest build provenance
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            main.js
+            obsidian-mcp-${{ steps.version.outputs.version }}.mcpb
+            obsidian-mcp.mcpb
 
       - name: Create Release
         if: steps.check_tag.outputs.exists == 'false'

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,7 +59,8 @@ const DEFAULT_SETTINGS: MCPPluginSettings = {
 		enabled: false,
 		selfSigned: true,
 		autoGenerate: true,
-		rejectUnauthorized: false,
+		// rejectUnauthorized omitted on purpose: inert for our inbound HTTPS
+		// server (no requestCert); cert-manager defaults it to true. See #163.
 		minTLSVersion: 'TLSv1.2'
 	},
 	debugLogging: false,

--- a/tests/security/tls-cert-verification.test.ts
+++ b/tests/security/tls-cert-verification.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Regression guard for #163.
+ *
+ * Obsidian's community scorecard pattern-matches the literal
+ * `rejectUnauthorized: false` and flags it as a Risk ("Plugin disables SSL
+ * certificate verification"). In our code that option is inert — it is only
+ * passed to the inbound HTTPS server, which never sets `requestCert`, so Node
+ * ignores it. The fix (#163) was to stop emitting the flagged literal and let
+ * certificate-manager default the effective value to `true` via `!== false`.
+ *
+ * These tests fail if the literal is reintroduced or if the secure default
+ * flips, so the finding cannot silently come back.
+ */
+describe('TLS certificate verification (#163)', () => {
+  const read = (rel: string) => readFileSync(join(__dirname, '..', '..', rel), 'utf8');
+
+  it('does not emit the scanner-flagged `rejectUnauthorized: false` literal', () => {
+    const flagged = /rejectUnauthorized\s*:\s*false/;
+    expect(read('src/main.ts')).not.toMatch(flagged);
+    expect(read('src/utils/certificate-manager.ts')).not.toMatch(flagged);
+  });
+
+  it('keeps certificate-manager defaulting verification ON when unset', () => {
+    // The effective option is computed as `config.rejectUnauthorized !== false`.
+    // Guard the contract: absent/true => verification on; only an explicit
+    // false disables it (and nothing in our defaults sets that).
+    const effective = (v: boolean | undefined) => v !== false;
+    expect(effective(undefined)).toBe(true);
+    expect(effective(true)).toBe(true);
+    expect(effective(false)).toBe(false);
+
+    // The expression must still be present in certificate-manager — if it is
+    // refactored away, this guard is no longer meaningful and must be revised.
+    expect(read('src/utils/certificate-manager.ts')).toMatch(
+      /rejectUnauthorized\s*:\s*config\.rejectUnauthorized\s*!==\s*false/,
+    );
+  });
+});


### PR DESCRIPTION
Implements the two genuinely clearable scorecard cautions so we can run the prerelease → BRAT → promote → re-scan loop and observe whether the remaining (accepted) `.mcpb` item alone still holds Review at "Caution".

## #163 — `rejectUnauthorized: false` (Risk → cleared)

Verified inert: the literal only lived in `DEFAULT_SETTINGS.certificateConfig`, consumed solely at `certificate-manager.ts:301` and passed to the **inbound** `https.createServer`, which never sets `requestCert` — Node ignores `rejectUnauthorized` there. `certificate-manager` already defaults the effective value to `true` via `!== false`, so removing the default line is **behavior-preserving** and deletes the exact token the scanner flags.

Guard: `tests/security/tls-cert-verification.test.ts` fails if the literal returns or the secure default flips.

## #164 — missing artifact attestation (Other → cleared)

Adds `actions/attest-build-provenance@v2` (gated identically to Create Release) + `id-token`/`attestations: write` permissions, attesting `main.js` and both `.mcpb` bundles. No change to what ships.

## Not addressed (by design)

- **`.mcpb` "additional files"** — investigated: no Obsidian allowlist/ignore mechanism exists; it's lowest-severity "Other", informational, non-blocking; clearing it would mean reverting ADR-102. Accepted & documented in CLAUDE.md (PR #166). This PR is the experiment to see if Review still flags "Caution" on this alone post-fix.
- **"scan not available" disclosures** — neutral, not in our control.

## Verification loop (post-merge, user-driven)

1. Merge → `make release-patch` (prerelease)
2. You point BRAT at the prerelease in Obsidian, confirm no functional regression
3. `make promote` → you re-trigger the scan on the dev portal (account action)
4. `make scorecard` confirms #163/#164 cleared and reveals whether `.mcpb` alone keeps "Caution"

Gates: build ✅ lint ✅ test ✅ (139/139)