### PR TITLE
chore(meta): make pattern for plugin description + reality-based copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help build dev test lint lint-fix check clean install \
-       release-patch release-minor release-major release publish promote sync-version mcpb
+       release-patch release-minor release-major release publish promote sync-version mcpb set-description
 
 MIN_OBSIDIAN := 0.15.0
 
@@ -84,8 +84,12 @@ _commit-and-publish:
 clean: ## Remove build artifacts
 	rm -rf main.js main.js.map dist/ obsidian-mcp-*.mcpb obsidian-mcp.mcpb
 
-sync-version: ## Sync version from package.json to manifest.json and version.ts
+sync-version: ## Sync version + description from package.json to manifest.json, mcpb, version.ts
 	node sync-version.mjs
 
 mcpb: ## Build MCPB bundle (obsidian-mcp-<version>.mcpb) for Claude Desktop
 	node scripts/build-mcpb.mjs
+
+set-description: ## Set plugin description (SoT: package.json) + sync. Usage: make set-description DESC='...'
+	@node scripts/set-description.mjs "$(DESC)"
+	@node sync-version.mjs

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "semantic-vault-mcp",
   "name": "Semantic Notes Vault MCP",
   "minAppVersion": "1.6.6",
-  "description": "Semantic MCP server providing AI tools with direct vault access via HTTP transport.",
+  "description": "Give Claude Desktop and other AI assistants semantic access to your notes through a built-in Model Context Protocol (MCP) server.",
   "author": "Aaron Bockelie",
   "authorUrl": "https://github.com/aaronsb",
   "fundingUrl": "https://github.com/sponsors/aaronsb",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian-mcp-plugin",
   "version": "0.11.21",
-  "description": "Semantic MCP server providing AI tools with direct vault access via HTTP transport.",
+  "description": "Give Claude Desktop and other AI assistants semantic access to your notes through a built-in Model Context Protocol (MCP) server.",
   "main": "main.js",
   "scripts": {
     "dev": "node esbuild.config.mjs",

--- a/scripts/set-description.mjs
+++ b/scripts/set-description.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// Set the plugin description in package.json (the single source of truth).
+// Run via `make set-description DESC='...'`, which then runs sync-version.mjs
+// to propagate it into manifest.json. Avoids hand-editing either JSON file.
+
+import { readFileSync, writeFileSync } from 'fs';
+
+const desc = process.argv[2];
+
+if (!desc || !desc.trim()) {
+  console.error("❌ No description given. Usage: make set-description DESC='Your text.'");
+  process.exit(1);
+}
+
+// Obsidian's plugin guidelines cap the catalog description at 250 chars.
+if (desc.length > 250) {
+  console.error(`❌ Description is ${desc.length} chars; Obsidian's limit is 250.`);
+  process.exit(1);
+}
+
+try {
+  const pkg = JSON.parse(readFileSync('package.json', 'utf-8'));
+  if (pkg.description === desc) {
+    console.log('ℹ️  Description unchanged.');
+    process.exit(0);
+  }
+  pkg.description = desc;
+  writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+  console.log(`✅ package.json description set (${desc.length} chars). Run sync-version to propagate.`);
+} catch (error) {
+  console.error('❌ Failed to set description:', error.message);
+  process.exit(1);
+}

--- a/sync-version.mjs
+++ b/sync-version.mjs
@@ -7,9 +7,15 @@ try {
   const packageJson = JSON.parse(readFileSync('package.json', 'utf-8'));
   const version = packageJson.version;
 
+  // package.json is the single source of truth for both version and the
+  // plugin description. mcpb/manifest.json keeps its own Claude-Desktop
+  // specific description and is intentionally not synced here.
+  const description = packageJson.description;
+
   // Read and update manifest.json
   const manifest = JSON.parse(readFileSync('manifest.json', 'utf-8'));
   manifest.version = version;
+  manifest.description = description;
 
   // Write updated manifest.json
   writeFileSync('manifest.json', JSON.stringify(manifest, null, 2) + '\n');
@@ -27,7 +33,7 @@ export function getVersion(): string {
 `;
   writeFileSync('src/version.ts', versionTs);
 
-  console.log(`✅ Synced version ${version} to manifest.json, mcpb/manifest.json, and version.ts`);
+  console.log(`✅ Synced version ${version} + description to manifest.json (version also: mcpb/manifest.json, version.ts)`);
 } catch (error) {
   console.error('❌ Failed to sync version:', error.message);
   process.exit(1);


### PR DESCRIPTION
## Why
Two asks: (1) the short/long descriptions were word-salad and didn't reflect reality (it ships a one-click `.mcpb` for Claude Desktop; "MCP" is a good search keyword but needs spelling out); (2) stop hand-editing `package.json`/`manifest.json` — use the `make` pattern.

## Changes
- **`package.json` = single source of truth** for the description (as it already is for version). `sync-version.mjs` now propagates `description` → `manifest.json`. `mcpb/manifest.json` keeps its own Claude-Desktop-specific description and is deliberately **not** synced.
- **`make set-description DESC='...'`** (+ `scripts/set-description.mjs`) — no hand-editing; enforces Obsidian's 250-char limit.
- **New short description** (chosen from options): _"Give Claude Desktop and other AI assistants semantic access to your notes through a built-in Model Context Protocol (MCP) server."_ (129 chars)

## Out of scope (handled by you)
The portal **long "About"** is a dev-portal field you edit while logged in (not in the repo). Proposed copy to paste there:

> An MCP (Model Context Protocol) server that runs inside your vault, exposing your notes to AI assistants that speak MCP — Claude Desktop, Claude Code, Continue, Cline, and more. A one-click `.mcpb` bundle wires up Claude Desktop in seconds. Under the hood AI gets semantic search, link/graph traversal, and read-write access, so it can explore concepts and synthesize across notes instead of reading one file at a time.

## Propagation
The portal short line updates when the next release is scanned — same prerelease→promote→re-scan loop as #167. Gates: build ✅ lint ✅ test ✅ (139).