### PR TITLE
fix(release): align MIN_OBSIDIAN with manifest minAppVersion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help build dev test lint lint-fix check clean install \
        release-patch release-minor release-major release publish promote sync-version mcpb scorecard set-description
 
-MIN_OBSIDIAN := 0.15.0
+MIN_OBSIDIAN := 1.6.6
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \


### PR DESCRIPTION
## Defect

`_update-versions-json` (run by every `make release-*`) injects `MIN_OBSIDIAN` into `versions.json`. It was stale at **0.15.0** while `manifest.json` minAppVersion is **1.6.6** (raised for 0.11.21, where `versions.json` was hand-corrected but the Makefile was not).

Without this, the next `make release-patch` (0.11.22) would write `"0.11.22": "0.15.0"` into `versions.json` — inconsistent with the shipped manifest, and a likely compatibility-reporting discrepancy on Obsidian's side.

## Fix

One line: `MIN_OBSIDIAN := 1.6.6`. Now the automation produces a consistent `versions.json` entry without manual patching.

## Follow-up (not in this PR)

`minAppVersion` now lives in two places (`manifest.json` hand-set, `Makefile` for versions.json). Worth coupling to one source later — noting, not scoping here.

Found while prepping the post-merge prerelease for the scorecard-fix verification loop. Blocks that prerelease.