### PR TITLE
fix(ci): attest all installable assets (styles.css/manifest.json), not just main.js

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,14 @@ jobs:
         if: steps.check_tag.outputs.exists == 'false'
         uses: actions/attest-build-provenance@v2
         with:
+          # Attest every asset Obsidian installs (main.js, manifest.json,
+          # styles.css) plus the .mcpb bundles. The portal flags any
+          # installable asset lacking attestation — #164 originally missed
+          # styles.css/manifest.json.
           subject-path: |
             main.js
+            manifest.json
+            styles.css
             obsidian-mcp-${{ steps.version.outputs.version }}.mcpb
             obsidian-mcp.mcpb
 


### PR DESCRIPTION
## Gap

Confirmed by the dev-portal review of `70884bb` (0.11.22):

- ✅ Pass: "main.js release asset has a verified GitHub artifact attestation" — #164 works
- ⚠️ Recommendation: "styles.css release asset does not have a GitHub artifact attestation"

#164's `subject-path` covered `main.js` + the `.mcpb` bundles but not `styles.css`/`manifest.json`. Obsidian flags **any** installable asset without attestation.

## Fix

Add `manifest.json` and `styles.css` to the attestation `subject-path`. Now every asset Obsidian installs carries verifiable provenance.

## Context

The `70884bb` review proved the experiment: the `rejectUnauthorized` **Error** (sole driver of the 0.11.21 Fail) is gone (#163), main.js attestation verified by Obsidian (#164). Only non-failing Recommendations + the by-design prerelease Error remained. This closes the last actionable Recommendation; the `.mcpb` additional-files Recommendation stays by ADR-102 (confirmed non-failing).

Gates: build ✅ lint ✅ test ✅