### PR TITLE
chore: low-risk Obsidian review fixes (builtin-modules, README title)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Obsidian MCP Plugin
+# Semantic Notes Vault MCP
 
 ![GitHub stars](https://img.shields.io/github/stars/aaronsb/obsidian-mcp-plugin?style=social)
 ![GitHub forks](https://img.shields.io/github/forks/aaronsb/obsidian-mcp-plugin?style=social)

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import process from "process";
-import builtins from "builtin-modules";
+import { builtinModules } from "node:module";
 
 const banner =
 `/*
@@ -32,7 +32,7 @@ const context = await esbuild.context({
 		'@lezer/common',
 		'@lezer/highlight',
 		'@lezer/lr',
-		...builtins],
+		...builtinModules],
 	format: 'cjs',
 	target: 'es2018',
 	logLevel: "info",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "@types/minimatch": "^5.1.2",
         "@types/node": "^25.3.0",
         "@typescript-eslint/utils": "^8.56.0",
-        "builtin-modules": "^5.0.0",
         "esbuild": "^0.27.3",
         "eslint": "^9.39.2",
         "eslint-plugin-obsidianmd": "^0.3.0",
@@ -3453,19 +3452,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/builtin-modules": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.0.0.tgz",
-      "integrity": "sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@types/minimatch": "^5.1.2",
     "@types/node": "^25.3.0",
     "@typescript-eslint/utils": "^8.56.0",
-    "builtin-modules": "^5.0.0",
     "esbuild": "^0.27.3",
     "eslint": "^9.39.2",
     "eslint-plugin-obsidianmd": "^0.3.0",


### PR DESCRIPTION
Two **safe, mechanical** fixes from the 0.11.23 source-code review (all Warnings, non-gating):

## #5 — `builtin-modules` → `node:module`
Review: _"builtin-modules should be replaced with an alternative package"_ (`package.json:36`). Only used in `esbuild.config.mjs` to externalize Node builtins. `node:module`'s `builtinModules` is the native equivalent (Node 6.x+). Behavior-equivalent; devDependency removed, clean lockfile diff (only `builtin-modules` dropped). Build verified — bundle still externalizes builtins.

## #9 — README title ↔ manifest name
Review: _"README title ('Obsidian MCP Plugin') does not match the plugin name in manifest.json ('Semantic Notes Vault MCP')"_. Title aligned.

## Deliberately NOT in this PR

- **#7 CSS `!important`** — *not* mechanical. The `.mcp-api-key-input` rules force text-selectability over Obsidian's base input styles; deleting `!important` risks making the API-key field unselectable. Obsidian's guidance is *increase specificity*, which needs visual verification. Separate careful PR.
- **#8 README placeholder** — no standard placeholder tokens (`[description]`, `TODO`, template comments) exist in the README. Only candidate is `(coming soon)` on the community-install line. Not blind-editing on a guess — needs the portal's specific flag.

Gates: build ✅ lint ✅ test ✅ (139). No behavior change.