### PR TITLE
fix(css): remove !important via selector specificity

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -122,8 +122,11 @@
 }
 
 /* Utility Classes */
+/* Element-qualified so it outspecifies framework-set display (e.g. Obsidian's
+   button display) without !important; plain .mcp-hidden covers containers. */
+button.mcp-hidden,
 .mcp-hidden {
-    display: none !important;
+    display: none;
 }
 
 /* Config Path Info */
@@ -137,12 +140,14 @@
 }
 
 /* API Key Input */
-.mcp-api-key-input {
-    user-select: text !important;
-    -webkit-user-select: text !important;
-    -moz-user-select: text !important;
-    -ms-user-select: text !important;
-    cursor: text !important;
+/* input-qualified selector outspecifies container-level user-select:none
+   without !important, keeping the API key selectable/copyable. */
+input.mcp-api-key-input {
+    user-select: text;
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    cursor: text;
 }
 
 /* Make disabled input more readable */


### PR DESCRIPTION
Clears the CSS-lint Warning from the Obsidian review (non-gating). All 6 `!important` declarations removed by **increasing specificity** (Obsidian's recommended approach), not blind deletion.

| Rule | Before | After | Why it still wins |
|---|---|---|---|
| hide utility | `.mcp-hidden { display:none !important }` | `button.mcp-hidden, .mcp-hidden { display:none }` | `button.mcp-hidden` (0,1,1) out-specifies framework button `display` |
| API key input | `.mcp-api-key-input { user-select/cursor … !important }` | `input.mcp-api-key-input { … }` | `input.`-qualified (0,1,1) out-specifies container `user-select:none` |

Behavior-preserving **by design**, but CSS specificity vs. Obsidian's live styles can't be fully verified headless. **Two visual checks needed before merge** (Obsidian is open):
1. Settings → API key field: text still **selectable/copyable** (triple-click selects, Ctrl+C works)
2. Buttons that hide on disabled state + collapsed sections still **actually hide** (e.g. disable a server, its action buttons vanish)

Gates: build ✅ lint ✅ test ✅ (139).