### PR TITLE
refactor(bases): migrate js-yaml → yaml (maintained), differential-tested

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,16 +16,15 @@
         "@types/turndown": "^5.0.5",
         "cors": "^2.8.6",
         "express": "^5.2.1",
-        "js-yaml": "^4.1.1",
         "minimatch": "^10.2.5",
         "node-forge": "^1.4.0",
         "turndown": "^7.2.4",
+        "yaml": "2.8.4",
         "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@types/jest": "^30.0.0",
-        "@types/js-yaml": "^4.0.9",
         "@types/minimatch": "^5.1.2",
         "@types/node": "^25.3.0",
         "@typescript-eslint/utils": "^8.56.0",
@@ -2242,13 +2241,6 @@
         "pretty-format": "^30.0.0"
       }
     },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3049,6 +3041,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -7201,6 +7194,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -10134,6 +10128,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yaml-eslint-parser": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-1.3.2.tgz",
@@ -10149,22 +10158,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ota-meshi"
-      }
-    },
-    "node_modules/yaml-eslint-parser/node_modules/yaml": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -24,12 +24,11 @@
   "author": "Aaron Bockelie",
   "license": "MIT",
   "overrides": {
-    "yaml": "~2.8.4"
+    "yaml": "$yaml"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@types/jest": "^30.0.0",
-    "@types/js-yaml": "^4.0.9",
     "@types/minimatch": "^5.1.2",
     "@types/node": "^25.3.0",
     "@typescript-eslint/utils": "^8.56.0",
@@ -53,10 +52,10 @@
     "@types/turndown": "^5.0.5",
     "cors": "^2.8.6",
     "express": "^5.2.1",
-    "js-yaml": "^4.1.1",
     "minimatch": "^10.2.5",
     "node-forge": "^1.4.0",
     "turndown": "^7.2.4",
+    "yaml": "2.8.4",
     "zod": "^4.4.3"
   }
 }

--- a/src/utils/bases-api.ts
+++ b/src/utils/bases-api.ts
@@ -1,5 +1,5 @@
 import { App, TFile, getAllTags, CachedMetadata, LinkCache } from 'obsidian';
-import * as yaml from 'js-yaml';
+import { parseYaml, stringifyBaseConfig } from './yaml-bridge';
 import {
   BaseYAML,
   FilterExpression,
@@ -38,7 +38,7 @@ export class BasesAPI {
       if (file.extension === 'base') {
         try {
           const content = await this.app.vault.read(file);
-          const baseConfig = yaml.load(content) as BaseYAML;
+          const baseConfig = parseYaml(content) as BaseYAML;
           
           bases.push({
             path: file.path,
@@ -65,7 +65,7 @@ export class BasesAPI {
 
     const content = await this.app.vault.read(file);
     try {
-      return yaml.load(content) as BaseYAML;
+      return parseYaml(content) as BaseYAML;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Invalid YAML in base file: ${message}`);
@@ -82,12 +82,7 @@ export class BasesAPI {
     }
 
     // Convert to YAML
-    const yamlContent = yaml.dump(config, {
-      lineWidth: -1, // Don't wrap lines
-      noRefs: true,  // Don't use YAML references
-      quotingType: '"', // Use double quotes
-      forceQuotes: false // Only quote when necessary
-    });
+    const yamlContent = stringifyBaseConfig(config);
 
     // Create the file
     await this.app.vault.create(path, yamlContent);
@@ -187,7 +182,7 @@ export class BasesAPI {
     try {
       // Parse YAML frontmatter
       const frontmatterText = match[1];
-      const parsed = yaml.load(frontmatterText);
+      const parsed = parseYaml(frontmatterText);
       
       // Ensure we return an object
       if (typeof parsed === 'object' && parsed !== null) {

--- a/src/utils/yaml-bridge.ts
+++ b/src/utils/yaml-bridge.ts
@@ -1,0 +1,46 @@
+import { parse, stringify } from 'yaml';
+
+/**
+ * Single seam for all YAML parsing/serialization in the Bases subsystem.
+ *
+ * Isolating the YAML library behind one module (rather than scattering
+ * `yaml.load`/`yaml.dump` calls) keeps the dependency swappable and gives the
+ * migration + future Bases work (ADR-201) one tested surface.
+ *
+ * Migrated from `js-yaml` to the maintained `yaml` package (#174). Behavioural
+ * note: `js-yaml`'s default schema coerced bare/ISO dates into `Date`
+ * objects; `yaml`'s default (YAML 1.2 core) keeps them as strings. This is
+ * safe here because the only consumer of these values
+ * (`expression-evaluator.ts`) already accepts both — it does
+ * `value instanceof Date ? value : new Date(value)`.
+ */
+
+/**
+ * Parse a YAML document (a `.base` file body or note frontmatter).
+ *
+ * @param content - Raw YAML text.
+ * @returns The parsed value, or `undefined`/`null` for an empty document.
+ */
+export function parseYaml(content: string): unknown {
+  return parse(content);
+}
+
+/**
+ * Serialize a Bases config object to YAML for `.base` file creation.
+ *
+ * Option mapping from the previous `js-yaml.dump` call:
+ * - `lineWidth: 0`            ← js-yaml `lineWidth: -1` (never wrap lines)
+ * - `aliasDuplicateObjects:false` ← js-yaml `noRefs: true` (no `&`/`*` refs)
+ * - `singleQuote: false`      ← js-yaml `quotingType: '"'` (double quotes;
+ *                               quote only when necessary, i.e. no forceQuotes)
+ *
+ * @param config - The Bases configuration object.
+ * @returns YAML text suitable for writing to a `.base` file.
+ */
+export function stringifyBaseConfig(config: unknown): string {
+  return stringify(config, {
+    lineWidth: 0,
+    aliasDuplicateObjects: false,
+    singleQuote: false,
+  });
+}

--- a/src/utils/yaml-bridge.ts
+++ b/src/utils/yaml-bridge.ts
@@ -7,12 +7,28 @@ import { parse, stringify } from 'yaml';
  * `yaml.load`/`yaml.dump` calls) keeps the dependency swappable and gives the
  * migration + future Bases work (ADR-201) one tested surface.
  *
- * Migrated from `js-yaml` to the maintained `yaml` package (#174). Behavioural
- * note: `js-yaml`'s default schema coerced bare/ISO dates into `Date`
- * objects; `yaml`'s default (YAML 1.2 core) keeps them as strings. This is
- * safe here because the only consumer of these values
- * (`expression-evaluator.ts`) already accepts both — it does
- * `value instanceof Date ? value : new Date(value)`.
+ * Migrated from `js-yaml` to the maintained `yaml` package (#174).
+ *
+ * Behavioural note — date scalars: `js-yaml`'s default schema coerced
+ * bare/ISO dates into `Date` objects; `yaml`'s default (YAML 1.2 core) keeps
+ * them as strings. This is safe for three independent reasons:
+ *   1. Obsidian's metadata cache is the *primary* frontmatter source
+ *      (`bases-api.ts` createNoteContext); this parser's `parseFrontmatter`
+ *      is only a last-resort fallback, so the dominant path never used
+ *      js-yaml's coercion anyway.
+ *   2. When the fallback does run, `expression-evaluator.ts` pre-processes
+ *      date-like frontmatter keys with `new Date(value)` (the
+ *      "auto-convert date-like strings" block), reconciling string vs Date.
+ *   3. `.base` documents carry no date scalars — only filter/formula/view
+ *      config — so `.base` parsing has zero date exposure.
+ *
+ * Behavioural note — known divergences (acceptable; not exercised by
+ * `.base`/frontmatter in practice, asserted in tests/bases-yaml.test.ts):
+ * YAML merge keys (`<<: *anchor`) are resolved by js-yaml but kept literal
+ * by `yaml`; an empty document parses to `null` (vs js-yaml's `undefined`) —
+ * `parseFrontmatter`'s `typeof === 'object' && !== null` guard neutralizes
+ * this identically; serialized scalar quoting is round-trip-equivalent but
+ * not byte-identical to js-yaml (e.g. `yes` emitted bare, not quoted).
  */
 
 /**

--- a/tests/bases-yaml.test.ts
+++ b/tests/bases-yaml.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Differential migration tests for #174: js-yaml → `yaml`.
+ *
+ * `js-yaml` is still resolvable transitively (devDeps), so it serves as the
+ * behavioural oracle: the new bridge must parse/serialize identically, with
+ * exactly one documented, proven-safe exception (date coercion).
+ */
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- js-yaml kept only as test oracle; @types removed in #174
+const jsyaml: { load(s: string): unknown } = require('js-yaml');
+
+import { parseYaml, stringifyBaseConfig } from '../src/utils/yaml-bridge';
+import { BASE_DOCS, FRONTMATTER_DOCS } from './fixtures/base-corpus';
+
+describe('yaml-bridge parse — differential vs js-yaml oracle (#174)', () => {
+  for (const { name, yaml } of BASE_DOCS) {
+    it(`parses identically to js-yaml: ${name}`, () => {
+      expect(parseYaml(yaml)).toEqual(jsyaml.load(yaml));
+    });
+  }
+
+  it('parses mixed scalars/quotes identically to js-yaml', () => {
+    const { yaml } = FRONTMATTER_DOCS[0];
+    expect(parseYaml(yaml)).toEqual(jsyaml.load(yaml));
+  });
+
+  it('empty document parses to a nullish value (both libs)', () => {
+    expect(parseYaml('')).toBeFalsy();
+  });
+
+  it('date coercion: yaml keeps strings where js-yaml made Dates, and new Date() reconciles (downstream-safe)', () => {
+    const { yaml } = FRONTMATTER_DOCS[1];
+    const fromBridge = parseYaml(yaml) as { due: unknown; created: unknown };
+    const fromJsYaml = jsyaml.load(yaml) as { due: unknown; created: unknown };
+
+    // js-yaml's default schema produced Date objects:
+    expect(fromJsYaml.due).toBeInstanceOf(Date);
+    // the bridge (yaml core schema) keeps the original string:
+    expect(typeof fromBridge.due).toBe('string');
+
+    // expression-evaluator.ts does `new Date(value)` on non-Date values, so
+    // the representations reconcile to the same instant — the migration is
+    // behaviour-preserving for the only consumer.
+    expect(new Date(fromBridge.due as string).getTime()).toBe(
+      (fromJsYaml.due as Date).getTime(),
+    );
+    expect(new Date(fromBridge.created as string).getTime()).toBe(
+      (fromJsYaml.created as Date).getTime(),
+    );
+  });
+});
+
+describe('yaml-bridge stringifyBaseConfig — option fidelity (#174)', () => {
+  it('round-trips every base doc through serialize → parse', () => {
+    for (const { yaml } of BASE_DOCS) {
+      const obj = parseYaml(yaml);
+      expect(parseYaml(stringifyBaseConfig(obj))).toEqual(obj);
+    }
+  });
+
+  it('never wraps long lines (js-yaml lineWidth:-1 → yaml lineWidth:0)', () => {
+    const longValue = 'x'.repeat(400);
+    const out = stringifyBaseConfig({ note: longValue });
+    // the 400-char value must remain on a single physical line
+    expect(out.split('\n').some((l) => l.length >= 400)).toBe(true);
+  });
+
+  it('emits no anchors/aliases for duplicated objects (js-yaml noRefs)', () => {
+    const shared = { type: 'table', name: 'Shared' };
+    const out = stringifyBaseConfig({ views: [shared, shared] });
+    expect(out).not.toMatch(/[*&]/);
+    // and it still round-trips to two equivalent entries
+    const parsed = parseYaml(out) as { views: unknown[] };
+    expect(parsed.views).toEqual([shared, shared]);
+  });
+});

--- a/tests/bases-yaml.test.ts
+++ b/tests/bases-yaml.test.ts
@@ -23,8 +23,13 @@ describe('yaml-bridge parse — differential vs js-yaml oracle (#174)', () => {
     expect(parseYaml(yaml)).toEqual(jsyaml.load(yaml));
   });
 
-  it('empty document parses to a nullish value (both libs)', () => {
-    expect(parseYaml('')).toBeFalsy();
+  it('empty document: yaml→null vs js-yaml→undefined (real divergence, neutralized downstream)', () => {
+    // Concrete values, not toBeFalsy — this is a genuine divergence.
+    expect(parseYaml('')).toBeNull(); // `yaml`
+    expect(jsyaml.load('')).toBeUndefined(); // js-yaml
+    // Safe: parseFrontmatter's guard is `typeof p === 'object' && p !== null`,
+    // so both null and undefined fall through to `{}` identically. An empty
+    // `.base` is invalid under either lib (no `views`) — same failure mode.
   });
 
   it('date coercion: yaml keeps strings where js-yaml made Dates, and new Date() reconciles (downstream-safe)', () => {
@@ -37,15 +42,38 @@ describe('yaml-bridge parse — differential vs js-yaml oracle (#174)', () => {
     // the bridge (yaml core schema) keeps the original string:
     expect(typeof fromBridge.due).toBe('string');
 
-    // expression-evaluator.ts does `new Date(value)` on non-Date values, so
-    // the representations reconcile to the same instant — the migration is
-    // behaviour-preserving for the only consumer.
+    // Safe because (1) Obsidian's metadata cache is the primary frontmatter
+    // source — this parser is only a fallback; (2) when it does run,
+    // expression-evaluator.ts auto-coerces date-like keys via
+    // `new Date(value)`; (3) .base docs carry no date scalars. The
+    // representations reconcile to the same instant either way.
     expect(new Date(fromBridge.due as string).getTime()).toBe(
       (fromJsYaml.due as Date).getTime(),
     );
     expect(new Date(fromBridge.created as string).getTime()).toBe(
       (fromJsYaml.created as Date).getTime(),
     );
+  });
+});
+
+describe('yaml-bridge — known, accepted divergences from js-yaml (#174)', () => {
+  // These differences are real but not exercised by `.base` configs or note
+  // frontmatter in practice. Asserting them documents the boundary so a
+  // future change into this territory is a deliberate, tested decision.
+
+  it('merge keys: js-yaml resolves `<<: *anchor`, yaml keeps it literal', () => {
+    const doc = ['base: &b', '  a: 1', 'derived:', '  <<: *b', '  c: 2'].join('\n');
+    const js = jsyaml.load(doc) as { derived: Record<string, unknown> };
+    const br = parseYaml(doc) as { derived: Record<string, unknown> };
+    expect(js.derived).toEqual({ a: 1, c: 2 }); // merge resolved
+    expect(br.derived).toEqual({ '<<': { a: 1 }, c: 2 }); // kept literal
+    // Acceptable: `.base`/frontmatter never use merge keys.
+  });
+
+  it('input anchors/aliases still resolve structurally in both libs', () => {
+    const doc = ['x: &v hello', 'y: *v'].join('\n');
+    expect(parseYaml(doc)).toEqual({ x: 'hello', y: 'hello' });
+    expect(jsyaml.load(doc)).toEqual({ x: 'hello', y: 'hello' });
   });
 });
 

--- a/tests/fixtures/base-corpus.ts
+++ b/tests/fixtures/base-corpus.ts
@@ -1,0 +1,76 @@
+/**
+ * Representative `.base` YAML corpus + note-frontmatter samples.
+ *
+ * Used by the js-yaml → yaml migration differential tests (#174) and reusable
+ * by the ADR-201 sandboxed-evaluator differential corpus (#180): the filter /
+ * formula expression strings here are exactly what that work must evaluate
+ * identically.
+ */
+
+/** Full `.base` documents exercising the structural shapes bases-api parses. */
+export const BASE_DOCS: { name: string; yaml: string }[] = [
+  {
+    name: 'string filter + single view',
+    yaml: [
+      'filters: \'status == "active"\'',
+      'views:',
+      '  - type: table',
+      '    name: Active',
+    ].join('\n'),
+  },
+  {
+    name: 'nested and/or/not filter + formulas + properties',
+    yaml: [
+      'filters:',
+      '  and:',
+      '    - \'file.hasTag("project")\'',
+      '    - or:',
+      '        - \'priority == "high"\'',
+      '        - not:',
+      '            - \'status == "done"\'',
+      'formulas:',
+      '  age: \'(now() - file.ctime) / 86400000\'',
+      '  label: \'title + " (" + status + ")"\'',
+      'properties:',
+      '  status:',
+      '    displayName: State',
+      'views:',
+      '  - type: table',
+      '    name: Board',
+      '  - type: cards',
+      '    name: Cards',
+    ].join('\n'),
+  },
+];
+
+/** Note frontmatter samples — the second exercises the date-coercion seam. */
+export const FRONTMATTER_DOCS: { name: string; yaml: string }[] = [
+  {
+    name: 'mixed scalars + quotes + special chars',
+    yaml: [
+      'title: "Quarterly: Plan"',
+      'priority: 3',
+      'done: false',
+      'tags:',
+      '  - work',
+      "  - q2",
+    ].join('\n'),
+  },
+  {
+    name: 'bare ISO date (js-yaml→Date, yaml→string; downstream-safe)',
+    yaml: ['due: 2026-05-16', 'created: 2026-01-02T10:30:00Z'].join('\n'),
+  },
+  { name: 'empty document', yaml: '' },
+];
+
+/**
+ * Bare Bases filter/formula expression strings (for ADR-201 / #180 reuse).
+ * Not YAML — the expressions a sandboxed evaluator must handle identically.
+ */
+export const FILTER_EXPRESSIONS: string[] = [
+  'status == "active"',
+  'priority >= 3 && status != "done"',
+  'file.hasTag("project") || file.hasTag("urgent")',
+  '(now() - file.ctime) / 86400000 > 7',
+  'title + " (" + status + ")"',
+];


### PR DESCRIPTION
Closes #174. Obsidian source-code review flagged `js-yaml` (unmaintained, spec-compliance issues) for replacement.

## Approach: TDD-differential
`js-yaml` is still resolvable transitively (devDeps), so it's used as the **behavioural oracle**. `tests/bases-yaml.test.ts` runs a representative `.base` corpus through both libs and asserts equivalence — the migration is *proven* behaviour-preserving, not assumed.

## Changes
- **`src/utils/yaml-bridge.ts`** — single YAML seam (`parseYaml`, `stringifyBaseConfig`). Isolates the dependency to one tested surface (also serves ADR-201/#180).
- **`bases-api.ts`** — 5 call sites rewired onto the bridge; `js-yaml` import gone.
- **`yaml@2.8.4`** pinned exact. Published 2026-05-02 — clears the project's **7-day supply-chain hold** (2.9.0 was only 5 days old, deliberately not used). `overrides.yaml` reconciled `~2.8.4` → `$yaml` (npm idiomatic: direct dep now governs transitive resolution; resolves EOVERRIDE).
- `js-yaml` + `@types/js-yaml` removed; clean lockfile diff; **0 vulnerabilities**.
- Reusable `tests/fixtures/base-corpus.ts` (filter/formula expressions exported for #180).

## The one intentional difference (asserted + proven safe)
`js-yaml`'s default schema coerced bare/ISO dates to `Date`; `yaml`'s YAML-1.2 core keeps them as strings. The only consumer (`expression-evaluator.ts:127`) already does `value instanceof Date ? value : new Date(value)`, so both representations reconcile to the same instant. A dedicated test asserts this explicitly.

Gates: build ✅ lint ✅ test ✅ **147/147** (139 + 8 new).