### PR TITLE
fix(ui): stop orphaning status-bar elements on async startup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -248,32 +248,38 @@ export default class ObsidianMCPPlugin extends Plugin {
 	private statusBarItem?: HTMLElement;
 
 	updateStatusBar(): void {
-		if (this.statusBarItem) {
-			this.statusBarItem.remove();
+		// Create the status bar element exactly once and mutate it thereafter.
+		// Previously this remove()'d + addStatusBarItem()'d on every call;
+		// updateStatusBar() fires several times during async startup, so
+		// concurrent calls could each add an element while only the last was
+		// tracked in this.statusBarItem — orphaning a transient "Mcp: error"
+		// element that survived until the next Obsidian reload (#178).
+		if (!this.statusBarItem) {
+			this.statusBarItem = this.addStatusBarItem();
 		}
-		
+		const item = this.statusBarItem;
+
+		item.removeClass('mcp-statusbar-disabled', 'mcp-statusbar-running', 'mcp-statusbar-error', 'mcp-hidden');
+
 		if (!this.settings.showConnectionStatus) {
+			item.setText('');
+			item.addClass('mcp-hidden');
 			return;
 		}
 
-		this.statusBarItem = this.addStatusBarItem();
-
-		// Remove any existing status classes
-		this.statusBarItem.removeClass('mcp-statusbar-disabled', 'mcp-statusbar-running', 'mcp-statusbar-error');
-
 		if (!this.settings.httpEnabled && !this.settings.httpsEnabled) {
-			this.statusBarItem.setText('Mcp: disabled');
-			this.statusBarItem.addClass('mcp-statusbar-disabled');
+			item.setText('Mcp: disabled');
+			item.addClass('mcp-statusbar-disabled');
 		} else if (this.mcpServer?.isServerRunning()) {
 			const vaultName = this.app.vault.getName();
 			const protocols: string[] = [];
 			if (this.settings.httpEnabled) protocols.push(`HTTP:${this.settings.httpPort}`);
 			if (this.settings.httpsEnabled) protocols.push(`HTTPS:${this.settings.httpsPort}`);
-			this.statusBarItem.setText(`MCP: ${vaultName} (${protocols.join(', ')})`);
-			this.statusBarItem.addClass('mcp-statusbar-running');
+			item.setText(`MCP: ${vaultName} (${protocols.join(', ')})`);
+			item.addClass('mcp-statusbar-running');
 		} else {
-			this.statusBarItem.setText('Mcp: error');
-			this.statusBarItem.addClass('mcp-statusbar-error');
+			item.setText('Mcp: error');
+			item.addClass('mcp-statusbar-error');
 		}
 	}
 


### PR DESCRIPTION
Closes #178.

## Bug
The status bar showed **both** `Mcp: error` and `MCP: <vault> (HTTP:3001)` simultaneously; an Obsidian reload cleared it. Confirmed reproduction + reload-clears behavior with the user.

## Root cause
`updateStatusBar()` did `remove()` + `addStatusBarItem()` **every call**, tracking only the latest in `this.statusBarItem`. It fires several times during async startup (port-conflict handling, server-start callbacks, settings changes). Concurrent calls each `addStatusBarItem()`; the earlier transient `Mcp: error` element (server not yet bound) gets orphaned — untracked, never removed, surviving until plugin unload (reload).

## Fix
Create the element **once**, mutate it thereafter (`setText` + class swap). `showConnectionStatus=false` hides the single element via the existing `mcp-hidden` utility rather than removing/recreating DOM. Duplicate/orphaned indicators are now structurally impossible regardless of call ordering or async races. Not a server bug — the server was always healthy (verified via live smoke tests).

Gates: build ✅ lint ✅ test ✅ (139). Diff is 20 lines in one method.