### PR TITLE
test(bases): differential corpus + new Function baseline (ADR-201, PR 1/2)

### DIFF
--- a/tests/bases-expression-evaluator.test.ts
+++ b/tests/bases-expression-evaluator.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Characterization corpus for the ADR-201 sandboxed-evaluator work (#180).
+ *
+ * PR1 (this file): lock the *current* `new Function` evaluator's behaviour
+ * over the differential corpus, and prove the live RCE the ADR exists to
+ * close — `constructor.constructor` reaches the `Function` constructor through
+ * the `with` scope chain, so a synced/shared `.base` runs arbitrary JS today.
+ *
+ * PR2 swaps in the vetted no-eval library: the EVAL_CASES block must keep
+ * passing unchanged (proving behavioural parity), and the SECURITY block here
+ * gets *inverted* — every escape must then throw or return the evaluator's
+ * safe `false`, never a computed value.
+ */
+
+import { App } from 'obsidian';
+import { ExpressionEvaluator } from '../src/utils/expression-evaluator';
+import {
+  EVAL_CASES,
+  SECURITY_EXPRESSIONS,
+  makeNoteContext,
+} from './fixtures/base-corpus';
+
+const evaluator = new ExpressionEvaluator(new App());
+
+describe('ExpressionEvaluator — behavioural baseline (current new Function, ADR-201/#180)', () => {
+  for (const { expr, expected } of EVAL_CASES) {
+    it(`evaluates: ${expr}`, () => {
+      expect(evaluator.evaluate(expr, makeNoteContext())).toEqual(expected);
+    });
+  }
+});
+
+describe('ExpressionEvaluator — live RCE the new Function path exposes (ADR-201 motivation)', () => {
+  // These assertions are intentionally the *vulnerability*: a computed return
+  // value proves arbitrary JS executed. PR2 inverts each to expect a thrown
+  // error or the evaluator's safe `false` — never the number below.
+  const proofs: { expr: string; reachedValue: number }[] = [
+    { expr: 'constructor.constructor("return 1 + 1")()', reachedValue: 2 },
+    { expr: '({}).constructor.constructor("return 42")()', reachedValue: 42 },
+    { expr: '(1).constructor.constructor("return 99")()', reachedValue: 99 },
+  ];
+
+  for (const { expr, reachedValue } of proofs) {
+    it(`TODAY executes arbitrary code via: ${expr}`, () => {
+      expect(evaluator.evaluate(expr, makeNoteContext())).toBe(reachedValue);
+    });
+  }
+
+  it('every SECURITY_EXPRESSIONS entry is a defined escape vector to invert in PR2', () => {
+    // No behavioural assertion here (some escapes return huge globals); this
+    // pins the set's existence so PR2 has an explicit inversion checklist.
+    expect(SECURITY_EXPRESSIONS.length).toBeGreaterThanOrEqual(10);
+    expect(SECURITY_EXPRESSIONS).toContain('globalThis');
+    expect(SECURITY_EXPRESSIONS).toContain(
+      'constructor.constructor("return 1 + 1")()',
+    );
+  });
+});

--- a/tests/fixtures/base-corpus.ts
+++ b/tests/fixtures/base-corpus.ts
@@ -64,13 +64,167 @@ export const FRONTMATTER_DOCS: { name: string; yaml: string }[] = [
 ];
 
 /**
- * Bare Bases filter/formula expression strings (for ADR-201 / #180 reuse).
- * Not YAML — the expressions a sandboxed evaluator must handle identically.
+ * Differential corpus for the ADR-201 sandboxed evaluator (#180).
+ *
+ * Each case is a Bases filter/formula expression plus its expected value under
+ * the *canonical* note context below. The current `new Function` evaluator is
+ * the behavioural oracle: PR1 locks these expectations against it; PR2 asserts
+ * the replacement library produces identical results before the swap lands.
+ *
+ * Time-dependent primitives (`now()`, `today()`) appear only inside relations
+ * that are stable for all wall-clock times (e.g. a past date `<` today), so
+ * expectations never rot.
  */
-export const FILTER_EXPRESSIONS: string[] = [
-  'status == "active"',
-  'priority >= 3 && status != "done"',
-  'file.hasTag("project") || file.hasTag("urgent")',
-  '(now() - file.ctime) / 86400000 > 7',
-  'title + " (" + status + ")"',
+
+import type { NoteContext } from '../../src/types/bases-yaml';
+
+/** Fixed file timestamps so duration math is deterministic. */
+const CTIME = Date.UTC(2026, 0, 1); // 2026-01-01T00:00:00Z
+const MTIME = Date.UTC(2026, 4, 1); // 2026-05-01T00:00:00Z — exactly 120 days after CTIME
+
+/**
+ * The single canonical context every EVAL_CASE is evaluated against. Built
+ * fresh per call so a test mutating it cannot leak into others. Shape matches
+ * what `ExpressionEvaluator.createEvalContext` reads — `file`/`cache` are
+ * structural stand-ins (cast), not real Obsidian instances.
+ */
+export function makeNoteContext(): NoteContext {
+  return {
+    file: {
+      basename: 'Quarterly Plan',
+      path: 'Projects/Quarterly Plan.md',
+      parent: { path: 'Projects' },
+      extension: 'md',
+      stat: { size: 1024, ctime: CTIME, mtime: MTIME },
+    },
+    cache: {
+      tags: [{ tag: 'project' }, { tag: 'q2' }],
+      links: [{ link: 'Roadmap' }, { link: 'Budget' }],
+    },
+    frontmatter: {
+      title: 'Quarterly Plan',
+      status: 'active',
+      priority: 3,
+      done: false,
+      owner: 'alice',
+      due: '2026-12-31', // date-coerced by createEvalContext (key === 'due')
+      created: '2026-01-02', // date-coerced (key === 'created')
+      tags: ['project', 'q2'],
+    },
+    formulas: { score: 42 },
+  } as unknown as NoteContext;
+}
+
+/** An expression and its expected value under {@link makeNoteContext}. */
+export interface EvalCase {
+  expr: string;
+  expected: unknown;
+}
+
+/**
+ * ~50 cases spanning every operator class and every function/property the
+ * evaluator exposes (date/now/today/number/string/iff/choice/min/max/abs/
+ * round/list, file.hasTag/inFolder/hasLink/hasProperty, file.* props,
+ * note./formula./bare-name resolution, ternary, string concat).
+ */
+export const EVAL_CASES: EvalCase[] = [
+  // Bare-name (frontmatter via `with`) + comparisons
+  { expr: 'status == "active"', expected: true },
+  { expr: 'priority >= 3 && status != "done"', expected: true },
+  { expr: 'priority < 3', expected: false },
+  { expr: 'done', expected: false },
+  { expr: '!done', expected: true },
+  { expr: 'done == false', expected: true },
+  { expr: 'owner == "alice" || owner == "bob"', expected: true },
+  { expr: 'status', expected: 'active' },
+
+  // Arithmetic
+  { expr: 'priority + 1', expected: 4 },
+  { expr: 'priority * 2 - 1', expected: 5 },
+  { expr: 'priority / 2', expected: 1.5 },
+  { expr: 'priority % 2', expected: 1 },
+
+  // Ternary + string concat
+  { expr: '(priority > 2) ? "hi" : "lo"', expected: 'hi' },
+  { expr: 'title + " (" + status + ")"', expected: 'Quarterly Plan (active)' },
+  { expr: '"a" + "b" + "c"', expected: 'abc' },
+
+  // note. / formula. resolution
+  { expr: 'note.status == "active"', expected: true },
+  { expr: 'note.priority + note.priority', expected: 6 },
+  { expr: 'formula.score > 40', expected: true },
+  { expr: 'formula.score', expected: 42 },
+
+  // file.* properties
+  { expr: 'file.name', expected: 'Quarterly Plan' },
+  { expr: 'file.path', expected: 'Projects/Quarterly Plan.md' },
+  { expr: 'file.folder', expected: 'Projects' },
+  { expr: 'file.ext == "md"', expected: true },
+  { expr: 'file.size >= 1024', expected: true },
+  { expr: 'file.ctime < file.mtime', expected: true },
+  { expr: '(file.mtime - file.ctime) / 86400000', expected: 120 },
+  { expr: 'file.tags', expected: ['#project', '#q2'] },
+  { expr: 'file.links', expected: ['Roadmap', 'Budget'] },
+
+  // file.* methods
+  { expr: 'file.hasTag("project")', expected: true },
+  { expr: 'file.hasTag("missing")', expected: false },
+  { expr: 'file.hasTag("#q2")', expected: true },
+  { expr: 'file.hasTag("a", "project")', expected: true },
+  { expr: 'file.inFolder("Projects")', expected: true },
+  { expr: 'file.inFolder("Other")', expected: false },
+  { expr: 'file.hasLink("Roadmap")', expected: true },
+  { expr: 'file.hasLink("[[Budget]]")', expected: true },
+  { expr: 'file.hasLink("Nope")', expected: false },
+  { expr: 'file.hasProperty("status")', expected: true },
+  { expr: 'file.hasProperty("nonexistent")', expected: false },
+
+  // Global functions
+  { expr: 'min(3, 1, 2)', expected: 1 },
+  { expr: 'max(priority, 10)', expected: 10 },
+  { expr: 'abs(0 - 5)', expected: 5 },
+  { expr: 'abs(-5)', expected: 5 },
+  { expr: 'round(3.14159, 2)', expected: 3.14 },
+  { expr: 'round(2.5)', expected: 3 },
+  { expr: 'number("42") + 8', expected: 50 },
+  { expr: 'string(priority)', expected: '3' },
+  { expr: 'iff(priority > 2, "big", "small")', expected: 'big' },
+  { expr: 'choice(done, "yes", "no")', expected: 'no' },
+  { expr: 'list("x")', expected: ['x'] },
+  { expr: 'list(file.tags)', expected: ['#project', '#q2'] },
+
+  // Date functions — relations stable for all wall-clock times
+  { expr: 'date("2020-01-01") < today()', expected: true },
+  { expr: 'today() <= now()', expected: true },
+  { expr: 'date("2026-12-31") > date("2026-01-01")', expected: true },
+  { expr: 'note.due > date("2026-06-01")', expected: true },
+  { expr: 'note.created < note.due', expected: true },
+];
+
+/**
+ * Bare expression strings (back-compat narrative export; superset lives in
+ * {@link EVAL_CASES}).
+ */
+export const FILTER_EXPRESSIONS: string[] = EVAL_CASES.map((c) => c.expr);
+
+/**
+ * Sandbox-escape attempts. The current `new Function` + `with` evaluator
+ * EXECUTES these (PR1 proves the live RCE: `constructor.constructor` reaches
+ * the `Function` constructor through the `with` scope chain). PR2's replacement
+ * MUST refuse every one — throw, or return the evaluator's safe `false` — and
+ * never reach a callable `Function`/global. This set is the concrete
+ * "no globals reach" assertion, not a doc claim.
+ */
+export const SECURITY_EXPRESSIONS: string[] = [
+  'constructor.constructor("return 1 + 1")()',
+  'constructor.constructor("return 7")()',
+  '({}).constructor.constructor("return 42")()',
+  '(1).constructor.constructor("return 99")()',
+  '"".constructor.constructor("return 5")()',
+  '[].constructor.constructor("return 8")()',
+  'file.constructor.constructor("return 3")()',
+  'globalThis',
+  'this',
+  'note.__proto__',
+  'note.constructor',
 ];


### PR DESCRIPTION
## PR 1 of 2 — ADR-201 / #180

Per **ADR-201** and the advisor-confirmed sequence: land the differential
regression net **first**, independent of library choice, against the
*current* `new Function` evaluator as the behavioural oracle. The library
swap is PR 2.

### What this adds

- **`tests/fixtures/base-corpus.ts`** — `EVAL_CASES` (~57 expr/expected
  pairs) covering every operator class and every function/property the
  evaluator exposes (date/now/today/number/string/iff/choice/min/max/abs/
  round/list, file.hasTag/inFolder/hasLink/hasProperty, file.* props,
  note./formula./bare-name resolution, ternary, string concat).
  `makeNoteContext()` is the single canonical fixed context (built fresh
  per call). `SECURITY_EXPRESSIONS` is the sandbox-escape set.
- **`tests/bases-expression-evaluator.test.ts`** — locks current behaviour
  over the corpus, and **proves the live RCE ADR-201 exists to close**:
  `constructor.constructor("return …")()` reaches the `Function`
  constructor through the `with` scope chain and returns 2/42/99 *today*,
  so a synced/shared `.base` runs arbitrary JS in the Electron renderer.

### Why corpus-first

Picking the library first then writing the corpus invites rationalizing
the choice. The corpus is library-independent and is itself a positive
consequence the ADR lists (Bases gains a regression net it lacks). PR 2
introduces the vetted no-eval library; `EVAL_CASES` must keep passing
unchanged (parity), and the SECURITY block gets **inverted** — every
escape must then throw or return the evaluator's safe `false`.

### Determinism

Time-dependent primitives (`now()`, `today()`) appear only inside
relations stable for all wall-clock times (past date `<` today), so
expectations never rot.

### Checks

- 209/209 tests pass (`bases-yaml.test.ts` still green — fixture
  restructure is non-breaking)
- `npm run build` + `npm run lint` clean (0 errors)

Refs #180 · ADR-201
