### PR TITLE
feat(bases): sandboxed expression evaluator — replace new Function (ADR-201, PR 2/2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,12 +471,28 @@ by reverting the decision behind them; they were analysed and accepted:
 - **"… scan not available" disclosures** — neutral. Obsidian's
   malware/dependency/obfuscation scanners did not run; not a failure.
 
-**Dynamic code execution** (`new Function` in the Bases evaluator) is a real
-architectural decision, not an accepted finding — tracked for an ADR in #175.
+**Dynamic code execution** — the Bases-evaluator `new Function` (the
+exploitable vector: arbitrary JS from a synced/shared `.base`) is **removed**
+per **ADR-201**, implemented in #180 (PR #185 corpus/baseline, PR #186
+expression-eval swap). The evaluator now parses with `expression-eval` (jsep
+grammar, no globals) plus a tested `constructor`/`__proto__`/`prototype`/
+`this` denylist; a differential corpus proves behavioural parity.
+
+Caveat for future scans: `grep "new Function" main.js` is **not** zero by
+design. The residual occurrences are transitive-dependency codegen — ajv
+@6.14.0 schema-validator compilation + a library deprecation shim — a
+different, library-internal class **not reachable from vault content**. They
+were already in 0.11.25's bundle, the release that passed full review with
+only the fs Warning, so they were non-gating then. The "Dynamic Code
+Execution" Recommendation was attributed to the Bases path specifically;
+this clears that path. Whether a heuristic re-scan re-flags the ajv-class
+residual is unknown until the next scan (scorecard blind — #183); if it
+does, it is the *transitive* class above, not the closed Bases vector.
 
 Actionable findings became issues/PRs: #163/#164/#170 (SSL + attestation,
-shipped), #171/#173 (build-dep + CSS, shipped), #174 (js-yaml), #175 (eval
-ADR), #176 (this doc). Scorecard CI-gate idea: #165.
+shipped), #171/#173 (build-dep + CSS, shipped), #174 (js-yaml, shipped),
+#180 (sandboxed Bases evaluator, PR #185/#186), #176 (this doc). Scorecard
+CI-gate idea: #165.
 
 ## Important Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/turndown": "^5.0.5",
         "cors": "^2.8.6",
         "express": "^5.2.1",
+        "expression-eval": "5.0.1",
         "minimatch": "^10.2.5",
         "node-forge": "^1.4.0",
         "turndown": "^7.2.4",
@@ -5225,6 +5226,16 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/expression-eval": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/expression-eval/-/expression-eval-5.0.1.tgz",
+      "integrity": "sha512-7SL4miKp19lI834/F6y156xlNg+i9Q41tteuGNCq9C06S78f1bm3BXuvf0+QpQxv369Pv/P2R7Hb17hzxLpbDA==",
+      "deprecated": "The expression-eval npm package is no longer maintained. The package was originally published as part of a now-completed personal project, and I do not have incentives to continue maintenance.",
+      "license": "MIT",
+      "dependencies": {
+        "jsep": "^0.3.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7201,6 +7212,15 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsep": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-0.3.5.tgz",
+      "integrity": "sha512-AoRLBDc6JNnKjNcmonituEABS5bcfqDhQAWWXNTFrqu6nVXBpBAGfcoTGZMFlIrh9FjmE1CQyX9CTNwZrXMMDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/jsesc": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/turndown": "^5.0.5",
     "cors": "^2.8.6",
     "express": "^5.2.1",
+    "expression-eval": "5.0.1",
     "minimatch": "^10.2.5",
     "node-forge": "^1.4.0",
     "turndown": "^7.2.4",

--- a/src/utils/expression-evaluator.ts
+++ b/src/utils/expression-evaluator.ts
@@ -1,7 +1,65 @@
 import { App, getAllTags, LinkCache } from 'obsidian';
+import { parse, eval as evaluateAst } from 'expression-eval';
 import { NoteContext } from '../types/bases-yaml';
 import { Debug } from './debug';
 import { BasesReference } from './bases-reference';
+
+/**
+ * Member names that bridge from a plain value to the `Function` constructor
+ * (`x.constructor.constructor("…")()`) or the prototype chain. expression-eval
+ * 5.x already blocks `constructor`/`__proto__` internally; this denylist is
+ * defense-in-depth that (a) also covers `prototype`, (b) covers the computed
+ * form `x["constructor"]`, and (c) does not silently weaken if the pinned
+ * library's internal list changes. ADR-201's "explicit, tested no-globals
+ * safety property" lives here, not in a transitive dependency.
+ */
+const FORBIDDEN_MEMBERS = new Set(['constructor', '__proto__', 'prototype']);
+
+/** Minimal structural view of the jsep AST nodes we need to walk. */
+interface AstNode {
+  type: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Reject any member access whose property resolves to a forbidden name,
+ * whether written as `a.constructor` (Identifier) or `a["constructor"]`
+ * (computed Literal). Throws so the caller's existing catch returns the
+ * evaluator's safe `false` — a blocked `.base` expression fails closed,
+ * exactly as a malformed one already does.
+ */
+function assertNoForbiddenAccess(node: unknown): void {
+  if (!node || typeof node !== 'object') return;
+  const n = node as AstNode;
+
+  // `this` resolves to the whole evaluation context object — no legitimate
+  // use in a `.base` filter/formula, and a needless reflection surface. Reject.
+  if (n.type === 'ThisExpression') {
+    throw new Error('`this` is not allowed in Bases expressions');
+  }
+
+  if (n.type === 'MemberExpression') {
+    const property = n.property as AstNode | undefined;
+    const computed = n.computed === true;
+    const name =
+      !computed && property?.type === 'Identifier'
+        ? (property.name as string)
+        : computed && property?.type === 'Literal'
+          ? String(property.value)
+          : undefined;
+    if (name !== undefined && FORBIDDEN_MEMBERS.has(name)) {
+      throw new Error(`Access to member "${name}" is not allowed`);
+    }
+  }
+
+  for (const value of Object.values(n)) {
+    if (Array.isArray(value)) {
+      value.forEach(assertNoForbiddenAccess);
+    } else if (value && typeof value === 'object') {
+      assertNoForbiddenAccess(value);
+    }
+  }
+}
 
 /**
  * Evaluates Bases filter and formula expressions
@@ -37,16 +95,13 @@ export class ExpressionEvaluator {
         }
       }
       
-      // Parse and evaluate the expression
-      // Use 'with' statement to avoid reserved word conflicts
-      // Note: 'with' is discouraged but safe in our controlled context
-      // eslint-disable-next-line @typescript-eslint/no-implied-eval -- Intentional for Bases filter/formula evaluation
-      const func = new Function('context', `
-        with (context) {
-          return ${expression};
-        }
-      `) as (ctx: Record<string, unknown>) => unknown;
-      const result: unknown = func(evalContext);
+      // Parse with expression-eval (jsep grammar — no `eval`/`Function`/`new`
+      // and no global scope), reject prototype-chain escapes, then evaluate
+      // against the curated context. `.base` files are synced/shareable, so
+      // this must not execute arbitrary JS (ADR-201).
+      const ast = parse(expression);
+      assertNoForbiddenAccess(ast);
+      const result: unknown = evaluateAst(ast, evalContext);
       
       if (Debug.isDebugMode()) {
         Debug.log(`Expression result: ${String(result)}`);

--- a/tests/bases-expression-evaluator.test.ts
+++ b/tests/bases-expression-evaluator.test.ts
@@ -1,15 +1,14 @@
 /**
- * Characterization corpus for the ADR-201 sandboxed-evaluator work (#180).
+ * Differential corpus for the ADR-201 sandboxed evaluator (#180).
  *
- * PR1 (this file): lock the *current* `new Function` evaluator's behaviour
- * over the differential corpus, and prove the live RCE the ADR exists to
- * close — `constructor.constructor` reaches the `Function` constructor through
- * the `with` scope chain, so a synced/shared `.base` runs arbitrary JS today.
+ * EVAL_CASES is the behavioural-parity contract: these expectations were
+ * locked in PR1 against the old `new Function` path and must keep passing
+ * unchanged now that expression-eval backs the evaluator — that equivalence
+ * IS the migration's safety proof.
  *
- * PR2 swaps in the vetted no-eval library: the EVAL_CASES block must keep
- * passing unchanged (proving behavioural parity), and the SECURITY block here
- * gets *inverted* — every escape must then throw or return the evaluator's
- * safe `false`, never a computed value.
+ * The SECURITY block is the inverted half: the sandbox-escape expressions
+ * that executed arbitrary JS under `new Function` must now all fail closed —
+ * never a function, never the real global, never a computed value.
  */
 
 import { App } from 'obsidian';
@@ -30,29 +29,33 @@ describe('ExpressionEvaluator — behavioural baseline (current new Function, AD
   }
 });
 
-describe('ExpressionEvaluator — live RCE the new Function path exposes (ADR-201 motivation)', () => {
-  // These assertions are intentionally the *vulnerability*: a computed return
-  // value proves arbitrary JS executed. PR2 inverts each to expect a thrown
-  // error or the evaluator's safe `false` — never the number below.
-  const proofs: { expr: string; reachedValue: number }[] = [
-    { expr: 'constructor.constructor("return 1 + 1")()', reachedValue: 2 },
-    { expr: '({}).constructor.constructor("return 42")()', reachedValue: 42 },
-    { expr: '(1).constructor.constructor("return 99")()', reachedValue: 99 },
+describe('ExpressionEvaluator — sandbox escapes fail closed (ADR-201)', () => {
+  // The exact expressions that returned 2/42/99 under `new Function` must now
+  // yield the evaluator's safe `false` (denylist throws → existing catch).
+  const formerlyExecuting = [
+    'constructor.constructor("return 1 + 1")()',
+    '({}).constructor.constructor("return 42")()',
+    '(1).constructor.constructor("return 99")()',
   ];
 
-  for (const { expr, reachedValue } of proofs) {
-    it(`TODAY executes arbitrary code via: ${expr}`, () => {
-      expect(evaluator.evaluate(expr, makeNoteContext())).toBe(reachedValue);
+  for (const expr of formerlyExecuting) {
+    it(`no longer executes: ${expr}`, () => {
+      expect(evaluator.evaluate(expr, makeNoteContext())).toBe(false);
     });
   }
 
-  it('every SECURITY_EXPRESSIONS entry is a defined escape vector to invert in PR2', () => {
-    // No behavioural assertion here (some escapes return huge globals); this
-    // pins the set's existence so PR2 has an explicit inversion checklist.
-    expect(SECURITY_EXPRESSIONS.length).toBeGreaterThanOrEqual(10);
-    expect(SECURITY_EXPRESSIONS).toContain('globalThis');
-    expect(SECURITY_EXPRESSIONS).toContain(
-      'constructor.constructor("return 1 + 1")()',
-    );
+  it('no SECURITY_EXPRESSIONS entry reaches a function, the real global, or a value', () => {
+    for (const expr of SECURITY_EXPRESSIONS) {
+      const result = evaluator.evaluate(expr, makeNoteContext());
+      // The security property: never a callable, never the real globalThis,
+      // and never a "successful" computed value — only the safe failure
+      // sentinels (false from the catch, or an unresolved-identifier undefined
+      // that carries no global reach).
+      expect(typeof result).not.toBe('function');
+      expect(result).not.toBe(globalThis);
+      expect(result === false || result === undefined || result === null).toBe(
+        true,
+      );
+    }
   });
 });

--- a/tests/fixtures/base-corpus.ts
+++ b/tests/fixtures/base-corpus.ts
@@ -227,4 +227,10 @@ export const SECURITY_EXPRESSIONS: string[] = [
   'this',
   'note.__proto__',
   'note.constructor',
+  // Runtime-computed member name: our static pre-walk sees a BinaryExpression
+  // property (not Identifier/Literal) and does NOT catch this — it must fail
+  // closed via expression-eval's own access guard. Pins that the two layers
+  // compose, so the "defense-in-depth" claim is test-grounded, not asserted.
+  'note[("cons" + "tructor")]',
+  'file[("__pro" + "to__")]',
 ];


### PR DESCRIPTION
## PR 2 of 2 — ADR-201 / #180  (depends on #185, merged)

Closes the arbitrary-code-execution vector ADR-201 exists to remove: a
synced/shared `.base` file could run arbitrary JS in Obsidian's Electron
renderer via `new Function` + `with(context)`.

### Change

- **Removed** `new Function('context', 'with(context){return ${expr}}')`
  and its `no-implied-eval` eslint-disable from `expression-evaluator.ts`.
- **Adopted `expression-eval@5.0.1`** (pinned exact). jsep grammar — no
  `eval`/`Function`/`new`, no global scope, member denylist built in.
  jsep `0.3.5` is its audited transitive parser. Both releases are years
  old (7-day supply-chain hold satisfied); `npm audit` 0 vulnerabilities.
- **Defense-in-depth pre-walk** (`assertNoForbiddenAccess`): rejects
  `constructor` / `__proto__` / `prototype` in *both* `a.constructor` and
  computed-Literal `a["constructor"]` forms, plus `ThisExpression`. It does
  **not** catch runtime-computed names (`a[("cons"+"tructor")]`) — those
  fail closed via expression-eval's own access guard; the two layers
  composing is **pinned by a SECURITY test**, not asserted in prose.
- `createEvalContext` and every helper are **untouched** — that is what
  preserves behavioural parity. Call sites unchanged; `evaluate()`
  signature identical.

### Why expression-eval (evidence, not preference)

| candidate | grammar parity | security |
|---|---|---|
| `expr-eval` 2.0.2 | ❌ string concat → `null`; `&&`/`||` don't parse; numeric booleans | ✅ own grammar, no Function reach |
| **`expression-eval` 5.0.1** | ✅ exact JS semantics (concat, `&&`, `!`, ternary, `%`, method-call-on-member) | ✅ built-in `constructor`/`__proto__` denylist + our pre-walk |

`expr-eval` would have forced users to rewrite existing `.base` files.
`expression-eval` matches JS exactly, so the differential corpus passes
unchanged.

### Proof — differential corpus (from #185)

- **57 `EVAL_CASES` still green** → `expression-eval` == old `new Function`
  for every realistic Bases construct.
- The escapes that returned `2`/`42`/`99` under `new Function` now **fail
  closed** (`false`); the whole `SECURITY_EXPRESSIONS` set (incl.
  runtime-computed member names) never reaches a function, the real
  `globalThis`, or a value.

### Scanner finding — scoped claim, with the honest caveat

This **closes the Bases code path** the Obsidian "Dynamic Code Execution"
Recommendation was attributed to. It does **not** make
`grep "new Function" main.js` zero — by design:

- `main.js` is a bundle; it still contains **3 transitive-dependency**
  `new Function` (ajv@6.14.0 schema-validator codegen + a library
  deprecation shim). expression-eval/jsep dist contain **zero**; this
  PR's only `package.json` change is `+expression-eval`.
- Those instances were in **0.11.25's** bundle too — the release that
  passed full review with only the accepted fs Warning — so that class is
  pre-existing, library-internal (not reachable from vault content), and
  was non-gating then.
- Whether a heuristic re-scan re-flags the ajv-class residual is unknown
  until the next scan (scorecard scraper blind — #183). If it does, that is
  the *transitive* class, **not** the closed Bases vector. Documented in
  `CLAUDE.md` "Known accepted review findings".

### Compatibility

No behavioural change for legitimate `.base` filters/formulas (corpus
proves it). Breaking **only by design**: the RCE vectors, `this`, and
prototype-chain member access are now refused. Release-note line:
*"Bases filter/formula expressions are now evaluated by a sandboxed parser;
arbitrary JavaScript, `this`, and prototype access are no longer executed."*

### Checks

- 209/209 tests · `npm run build` + `npm run lint` clean (0 errors) ·
  `npm audit` 0 vulnerabilities

Refs #180 · ADR-201
