### PR TITLE
security(docs): safe MCP config approach (reimplements #143)

### DIFF
--- a/.claude-github/issue-32-response.md
+++ b/.claude-github/issue-32-response.md
@@ -1,69 +1,78 @@
-Thank you for reporting this issue! Based on the logs, I can see the server is connecting successfully but the tools aren't appearing in Claude Desktop.
+Thank you for reporting this issue! Based on the logs, the server is connecting but the tools aren't appearing in your client.
 
-This appears to be related to SSL certificate validation when using HTTPS with the plugin. The solution depends on whether you're using HTTP or HTTPS:
+This is almost always MCP transport configuration or SSL certificate trust. Modern MCP clients speak HTTP transport natively — you no longer need the `mcp-remote` bridge.
 
-## Solution 1: Using HTTP (Recommended for troubleshooting)
-If you're using the HTTP endpoint, your configuration should look like this:
+## Solution 1: Using HTTP (recommended for troubleshooting)
+
 ```json
 {
   "mcpServers": {
     "obsidian-vault": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "http://localhost:3001/mcp"
-      ]
-    }
-  }
-}
-```
-
-## Solution 2: Using HTTPS with Self-Signed Certificates
-If you're using HTTPS (port 3443), you need to add the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable:
-```json
-{
-  "mcpServers": {
-    "obsidian-vault": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://localhost:3443/mcp"
-      ],
-      "env": {
-        "NODE_TLS_REJECT_UNAUTHORIZED": "0"
+      "transport": {
+        "type": "http",
+        "url": "http://localhost:3001/mcp"
       }
     }
   }
 }
 ```
 
-## With API Key Authentication
-If you have API key authentication enabled, use this format:
+## Solution 2: Using HTTPS with the self-signed certificate
+
+If you're using HTTPS (port 3443), **trust the plugin's self-signed certificate** rather than disabling TLS verification. The cert is at `.obsidian/plugins/semantic-vault-mcp/certificates/default.crt` inside your vault.
+
+**macOS Keychain** (clients that use the system trust store):
+```bash
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain \
+  /path/to/vault/.obsidian/plugins/semantic-vault-mcp/certificates/default.crt
+```
+
+**Bun-based runtimes (Claude Code)** — Bun does not read the macOS keychain, so set `NODE_EXTRA_CA_CERTS` instead:
+```bash
+export NODE_EXTRA_CA_CERTS=/path/to/vault/.obsidian/plugins/semantic-vault-mcp/certificates/default.crt
+launchctl setenv NODE_EXTRA_CA_CERTS /path/to/vault/.obsidian/plugins/semantic-vault-mcp/certificates/default.crt
+```
+
+Then point the config at the HTTPS endpoint:
 ```json
 {
   "mcpServers": {
     "obsidian-vault": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://localhost:3443/mcp",
-        "--header",
-        "Authorization:${AUTH}"
-      ],
-      "env": {
-        "NODE_TLS_REJECT_UNAUTHORIZED": "0",
-        "AUTH": "Bearer YOUR_API_KEY_HERE"
+      "transport": {
+        "type": "http",
+        "url": "https://localhost:3443/mcp"
       }
     }
   }
 }
 ```
+
+> **Avoid `NODE_TLS_REJECT_UNAUTHORIZED=0`** — it disables TLS verification process-wide, not just for the plugin. Trust the certificate explicitly instead.
+
+## With API key authentication
+
+Add a `headers` field to any of the configs above:
+```json
+{
+  "mcpServers": {
+    "obsidian-vault": {
+      "transport": {
+        "type": "http",
+        "url": "https://localhost:3443/mcp",
+        "headers": {
+          "Authorization": "Bearer YOUR_API_KEY_HERE"
+        }
+      }
+    }
+  }
+}
+```
+
+> **Important:** do not register this server with `claude mcp add --header` — the CLI echoes the resolved header to stdout and (on macOS) the unified log, exposing your API key. Edit the config file directly: `~/.claude/settings.json` (user scope) or `.mcp.json` (project scope) for Claude Code, or your client's MCP config file. The plugin's Settings tab has a ready-to-paste snippet.
 
 Could you please:
-1. Confirm which URL you're using (HTTP on port 3001 or HTTPS on port 3443)?
+1. Confirm which URL you're using (HTTP on 3001 or HTTPS on 3443)?
 2. Try the appropriate configuration above?
-3. Restart Claude Desktop after updating the configuration
-
-The `NODE_TLS_REJECT_UNAUTHORIZED` environment variable is crucial when using HTTPS with self-signed certificates, as Claude Desktop needs to bypass certificate validation for local development certificates.
+3. Restart your MCP client after updating the configuration?
 
 Please let me know if this resolves the issue!

--- a/README.md
+++ b/README.md
@@ -51,11 +51,28 @@ Download `obsidian-mcp-<version>.mcpb` from the [latest release](https://github.
 
 > *Cross-platform note:* `.mcpb` files install via Claude Desktop's bundled handler. If double-click doesn't trigger Claude on your system, drag the file onto Claude Desktop's window instead, or right-click → "Open with…" and pick Claude Desktop (then "always open with" if your OS asks). Behavior varies by platform: macOS usually auto-associates, Windows may need a one-time association, Linux varies by desktop environment.
 
-**Claude Code (CLI)**
+**Claude Code** — add to `~/.claude/settings.json` (user scope) or `.mcp.json` (project scope):
 
-```bash
-claude mcp add --transport http obsidian http://localhost:3001/mcp --header "Authorization: Bearer YOUR_API_KEY"
+```json
+{
+  "mcpServers": {
+    "obsidian-vault": {
+      "transport": {
+        "type": "http",
+        "url": "http://localhost:3001/mcp",
+        "headers": {
+          "Authorization": "Bearer YOUR_API_KEY"
+        }
+      }
+    }
+  }
+}
 ```
+
+For HTTPS, use `https://localhost:3443/mcp` instead — see [Trusting the self-signed certificate](#trusting-the-self-signed-certificate) below. **Claude Code runs on Bun, which does not read the macOS system keychain**, so you will need to set `NODE_EXTRA_CA_CERTS`.
+
+> [!WARNING]
+> **Do not use `claude mcp add --header` to register this server.** The CLI resolves and echoes the header value to stdout, exposing your API key to any parent process — including AI agents that capture tool output as context. On macOS the spawned MCP child process arguments are also written to the unified log. Edit the config file directly instead; copy the ready-made snippet from the plugin's Settings tab.
 
 **Other MCP clients (Cline, Continue, custom integrations, multi-vault setups)**
 
@@ -88,6 +105,33 @@ node scripts/make-mcpb.mjs
 ```
 
 Drop the resulting bundle into Claude Desktop and click Install — no fields to type.
+
+### Trusting the self-signed certificate
+
+The plugin's HTTPS server uses a self-signed certificate auto-generated on first start and stored under `.obsidian/plugins/semantic-vault-mcp/certificates/default.crt` inside your vault. MCP clients reject self-signed certificates by default, so you need to explicitly trust it before connecting over HTTPS. Pick the method that matches your client runtime.
+
+**macOS Keychain** (for clients that use the system trust store — Claude Desktop, browser-based tools, Node with `--use-system-ca`):
+
+```bash
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain \
+  /path/to/vault/.obsidian/plugins/semantic-vault-mcp/certificates/default.crt
+```
+
+**`NODE_EXTRA_CA_CERTS`** (required for Claude Code and other Bun-based runtimes):
+
+Bun does **not** consult the macOS system keychain for TLS trust, so trusting the certificate via Keychain Access alone has no effect — this is almost always the real reason an HTTPS connection from Claude Code fails. Bun only honors certificates listed in `NODE_EXTRA_CA_CERTS`:
+
+```bash
+# Point directly at the plugin cert, or append it to an existing CA bundle:
+export NODE_EXTRA_CA_CERTS=/path/to/vault/.obsidian/plugins/semantic-vault-mcp/certificates/default.crt
+
+# Propagate to GUI apps launched from the macOS dock (including Claude Code):
+launchctl setenv NODE_EXTRA_CA_CERTS /path/to/vault/.obsidian/plugins/semantic-vault-mcp/certificates/default.crt
+```
+
+Re-run these whenever the plugin regenerates its certificate (e.g. after the 1-year validity expires).
+
+> **Avoid `NODE_TLS_REJECT_UNAUTHORIZED=0`.** It disables TLS verification process-wide — for *every* HTTPS connection the client makes, not just this plugin — and masks legitimate certificate problems (expired, revoked, tampered). Trust the certificate explicitly instead.
 
 ### 3. Start Using
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,7 @@ We're actively working on fixing these security vulnerabilities:
 
 | Issue | Status | Priority |
 |-------|---------|----------|
-| No authentication on MCP server | 🔧 In Progress | CRITICAL |
+| No authentication on MCP server | ✅ Done | CRITICAL |
 | Path traversal in file operations | 📋 Planned | CRITICAL |
 | Missing input validation | 📋 Planned | HIGH |
 | Insecure session management | 📋 Planned | HIGH |
@@ -37,6 +37,7 @@ Until security improvements are complete:
 3. **Monitor vault access** for unexpected changes
 4. **Keep backups** of your vault
 5. **Review plugin permissions** in Obsidian
+6. **Edit MCP config files directly** instead of using `claude mcp add --header` — the CLI echoes resolved header values to stdout, exposing your API key to parent processes and (on macOS) the unified log
 
 ## Secure Configuration
 
@@ -51,7 +52,7 @@ Until security improvements are complete:
 
 ## Future Security Enhancements
 
-- [ ] API key authentication
+- [x] API key authentication
 - [ ] Path validation framework
 - [ ] Input sanitization
 - [ ] Rate limiting

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,19 +19,25 @@ AI client cannot connect to the MCP server.
 Connection works but requests are rejected with 401/403 errors.
 
 **Solutions:**
-1. **Check API key**: Ensure the key in your client config matches the one in plugin settings
-2. **Header format**: Use `Authorization: Bearer YOUR_KEY` (note the space after Bearer)
-3. **Regenerated key**: The API key regenerates on plugin updates — copy the new key from settings
+1. **Check API key**: Ensure the key in your client config matches the one shown in plugin settings
+2. **Check config location**: For Claude Code, the config lives in `~/.claude/settings.json` (user scope) or `.mcp.json` (project scope). Verify the `headers.Authorization` value is `Bearer <your key>` (note the space after Bearer)
+3. **Regenerated key**: The API key regenerates on plugin updates — copy the new key from settings and update your config file
+4. **Don't use `claude mcp add --header`**: it echoes the resolved token to stdout and (on macOS) the unified log. Edit the config file directly instead
 
 ## SSL Certificate Errors
 
 **Symptoms:**
-Certificate warnings or connection failures when using HTTPS.
+Certificate warnings, TLS handshake failures, or silent connection failures when using HTTPS. The failure is often silent server-side — the handshake aborts before the HTTP request is sent, so the plugin's debug log shows nothing. Bun-based clients can fail this way even after trusting the cert in Keychain Access, because **Bun does not consult the macOS system keychain for TLS trust**.
 
-**Solutions:**
-1. **For development**: Set `NODE_TLS_REJECT_UNAUTHORIZED=0` in your client config
-2. **Self-signed certs**: The plugin generates self-signed certificates on first run
-3. **Certificate location**: Certificates are stored in the plugin's data folder
+**Solution:**
+Trust the plugin's self-signed certificate properly. See [Trusting the self-signed certificate](../README.md#trusting-the-self-signed-certificate) in the README for the full instructions, covering:
+
+- **macOS Keychain** (`security add-trusted-cert`) — for clients that use the system trust store.
+- **`NODE_EXTRA_CA_CERTS`** — required for Bun-based runtimes; set via `launchctl setenv` so dock-launched GUI apps inherit it.
+
+The cert is auto-generated on first start under `.obsidian/plugins/semantic-vault-mcp/certificates/default.crt` inside your vault; re-trust it whenever the plugin regenerates it.
+
+**Avoid `NODE_TLS_REJECT_UNAUTHORIZED=0`:** it disables TLS verification process-wide — not just for the plugin — and masks legitimate certificate problems (expired, revoked, tampered) instead of fixing them.
 
 ## Server Not Starting
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1461,18 +1461,10 @@ class MCPSettingTab extends PluginSettingTab {
 			this.addCopyButton(keyRow, this.plugin.settings.apiKey);
 		}
 
-		// === Claude Code (CLI) ===
-		new Setting(info).setName("Claude code (CLI)").setHeading();
+		// === Claude Code ===
+		new Setting(info).setName("Claude code").setHeading();
 		const commandExample = info.createDiv('protocol-command-example');
-		const codeEl = commandExample.createEl('code');
-		codeEl.classList.add('mcp-code-block');
-
-		const claudeCommand = this.plugin.settings.dangerouslyDisableAuth ?
-			`claude mcp add --transport http obsidian ${mcpUrl}` :
-			`claude mcp add --transport http obsidian ${mcpUrl} --header "Authorization: Bearer ${this.plugin.settings.apiKey}"`;
-
-		codeEl.textContent = claudeCommand;
-		this.addCopyButton(commandExample, claudeCommand);
+		this.renderClaudeCodeConnection(commandExample, baseUrl);
 
 		// === Advanced: collapsed by default to keep the default view tidy ===
 		// Contains the JSON path (for Cline/Continue/custom clients and multi-vault
@@ -1523,6 +1515,65 @@ class MCPSettingTab extends PluginSettingTab {
 		new Setting(advanced).setName("Custom bundle per vault").setHeading();
 		advanced.createEl('p', {
 			text: 'Clone the plugin repo and run `node scripts/make-mcpb.mjs`. It prompts for a display name, url, and api key, then writes a custom-named .mcpb you drop into claude desktop — one-click install per vault, no fields to type at install time.'
+		});
+	}
+
+	/**
+	 * Render the Claude Code connection block.
+	 *
+	 * When auth is enabled we deliberately do NOT show `claude mcp add --header`:
+	 * that CLI resolves and echoes the header value to stdout (captured by any
+	 * parent process, including AI agents), and on macOS the spawned MCP child
+	 * process argv is written to the unified log — both leak the bearer token.
+	 * Editing the config file directly avoids every one of those vectors, so the
+	 * authenticated path shows a ready-to-paste JSON snippet plus a warning
+	 * instead. The no-auth path carries no secret, so the plain CLI command is
+	 * safe and kept for convenience.
+	 *
+	 * Single source of truth for both the initial render and the live-refresh
+	 * handler, so the two cannot drift apart.
+	 */
+	private renderClaudeCodeConnection(container: HTMLElement, baseUrl: string): void {
+		container.empty();
+
+		if (this.plugin.settings.dangerouslyDisableAuth) {
+			const codeEl = container.createEl('code');
+			codeEl.classList.add('mcp-code-block');
+			const cmd = `claude mcp add --transport http obsidian ${baseUrl}/mcp`;
+			codeEl.textContent = cmd;
+			this.addCopyButton(container, cmd);
+			return;
+		}
+
+		container.createEl('p', {
+			text: 'Add to ~/.claude/settings.json (user scope) or .mcp.json (project scope):',
+		});
+
+		const vaultName = this.app.vault.getName();
+		const configJson = {
+			mcpServers: {
+				[vaultName]: {
+					transport: {
+						type: 'http',
+						url: `${baseUrl}/mcp`,
+						headers: {
+							Authorization: `Bearer ${this.plugin.settings.apiKey}`,
+						},
+					},
+				},
+			},
+		};
+		const configText = JSON.stringify(configJson, null, 2);
+
+		const pre = container.createEl('pre');
+		pre.classList.add('mcp-config-example');
+		pre.textContent = configText;
+		this.addCopyButton(container, configText);
+
+		container.createEl('p', {
+			// eslint-disable-next-line obsidianmd/ui/sentence-case -- "claude mcp add --header" is a literal lowercase CLI command; capitalizing it would misrepresent the command users must avoid
+			text: 'Do not use "claude mcp add --header" to register this server — the CLI echoes the resolved token to stdout and (on macOS) the unified log, exposing your API key. Edit the config file directly instead.',
+			cls: 'mcp-security-warning',
 		});
 	}
 
@@ -1654,22 +1705,17 @@ class MCPSettingTab extends PluginSettingTab {
 			}
 		}
 		
-		// Update protocol information section with proper auth handling
+		// Update Claude Code connection section with proper auth handling.
+		// Rebuild via the shared renderer so the live view matches the initial
+		// render exactly (including the JSON-config + warning auth path).
 		const protocolSection = document.querySelector('.protocol-command-example');
-		if (protocolSection) {
-			const codeBlock = protocolSection.querySelector('code');
-			if (codeBlock && info) {
-				// Get correct protocol and port based on HTTPS setting
-				const protocol = this.plugin.settings.httpsEnabled ? 'https' : 'http';
-				const port = this.plugin.settings.httpsEnabled ? this.plugin.settings.httpsPort : info.httpPort;
-				const baseUrl = `${protocol}://localhost:${port}`;
-				
-				const claudeCommand = this.plugin.settings.dangerouslyDisableAuth ? 
-					`claude mcp add --transport http obsidian ${baseUrl}/mcp` :
-					`claude mcp add --transport http obsidian ${baseUrl}/mcp --header "Authorization: Bearer ${this.plugin.settings.apiKey}"`;
-				
-				codeBlock.textContent = claudeCommand;
-			}
+		if (protocolSection instanceof HTMLElement && info) {
+			// Get correct protocol and port based on HTTPS setting
+			const protocol = this.plugin.settings.httpsEnabled ? 'https' : 'http';
+			const port = this.plugin.settings.httpsEnabled ? this.plugin.settings.httpsPort : info.httpPort;
+			const baseUrl = `${protocol}://localhost:${port}`;
+
+			this.renderClaudeCodeConnection(protocolSection, baseUrl);
 		}
 		
 		// Update any other dynamic content areas that need live updates

--- a/styles.css
+++ b/styles.css
@@ -174,6 +174,13 @@ input.mcp-api-key-input {
     margin-bottom: 20px;
 }
 
+.mcp-security-warning {
+    color: var(--text-warning);
+    font-size: 0.85em;
+    margin-top: 4px;
+    margin-bottom: 10px;
+}
+
 .mcp-warning-box {
     background-color: var(--background-modifier-error);
     color: var(--text-error);


### PR DESCRIPTION
## Summary

Reimplements community PR **#143** (@laplaque) against current `main`. The settings UI had been restructured since #143 was opened (CONFLICTING), so this is a faithful reimplementation rather than a rebase — contributor credited via `Co-authored-by`.

`claude mcp add --header "Authorization: Bearer <token>"` defeats secret-at-rest protection:
- the CLI resolves and **echoes the header to stdout** (captured by any parent process, including AI agents that ingest tool output);
- on macOS the spawned MCP child process **argv is written to the unified log**.

Editing the MCP config file directly avoids both.

## Changes

- **`src/main.ts`** — new shared `renderClaudeCodeConnection()` helper renders a ready-to-paste JSON snippet + security warning for the authenticated path, and the safe plain CLI command only when auth is disabled. Single source of truth for both the initial render and the live-refresh handler (the prior two inline copies had **already diverged** on `main` — this fixes that latent bug too).
- **README / SECURITY.md / docs/troubleshooting.md / `.claude-github/issue-32-response.md`** — drop `mcp-remote` + `NODE_TLS_REJECT_UNAUTHORIZED=0`; document native HTTP transport and proper self-signed-cert trust (macOS Keychain + `NODE_EXTRA_CA_CERTS` for Bun-based runtimes); add the `--header` warning.
- **styles.css** — `.mcp-security-warning`.

## Deltas from the original #143

- **ADR-100 left untouched.** #143 edited the body of an Accepted ADR; accepted ADRs are immutable records. The `claude mcp add --header` deprecation rationale is recorded in **ADR-104's** context section instead (PR #191).
- **Config schema unchanged.** #143's nested `transport: { type, url, headers }` form matches the project's existing `configJson` convention in `main.ts` — kept as-is (not "fixed"; if that nested form is wrong for Claude Code that's a separate issue, not this PR's scope).

## Verification

- `npm run build` ✓
- `npm run lint` ✓ 0 errors (one justified `eslint-disable` for the literal lowercase `claude mcp add --header` CLI string vs. the sentence-case rule)
- `npm test` ✓ 209/209

## Closes out

Supersedes #143 — that PR will be closed with thanks and a pointer here on merge.

Co-authored-by: Earl Plak <5597016+laplaque@users.noreply.github.com>