### PR TITLE
feat(vault): combine returns inline when destination omitted (reimplements #146)

### DIFF
--- a/src/formatters/vault.ts
+++ b/src/formatters/vault.ts
@@ -407,7 +407,9 @@ export function formatFileSplit(response: FileSplitResponse): string {
  */
 export interface FileCombineResponse {
   success: boolean;
-  destination: string;
+  destination?: string;
+  inline?: boolean;
+  content?: string;
   filesCombined: number;
   totalSize?: number;
   sourceFiles?: string[];
@@ -417,11 +419,27 @@ export function formatFileCombine(response: FileCombineResponse): string {
   const lines: string[] = [];
 
   const icon = response.success ? '✓' : '✗';
+
+  // Inline mode: no file was written — return the combined content directly
+  if (response.inline && response.content !== undefined) {
+    lines.push(header(1, `${icon} Combined ${response.filesCombined} files (inline)`));
+    lines.push('');
+    if (response.totalSize !== undefined) {
+      lines.push(property('Total size', formatFileSize(response.totalSize), 0));
+      lines.push('');
+    }
+    lines.push(response.content);
+    lines.push('');
+    lines.push(divider());
+    lines.push(summaryFooter());
+    return joinLines(lines);
+  }
+
   lines.push(header(1, `${icon} Combined: ${response.destination}`));
   lines.push('');
 
   if (response.success) {
-    lines.push(property('Destination', response.destination, 0));
+    lines.push(property('Destination', response.destination ?? '(none)', 0));
     lines.push(property('Files combined', response.filesCombined.toString(), 0));
     if (response.totalSize !== undefined) {
       lines.push(property('Total size', formatFileSize(response.totalSize), 0));

--- a/src/semantic/router.ts
+++ b/src/semantic/router.ts
@@ -708,7 +708,10 @@ export class SemanticRouter {
             content: finalContent,
             filesCombined: paths.length,
             totalSize: finalContent.length,
-            sourceFiles: paths,
+            // Reflect the order the content was actually combined in
+            // (sortFiles mutates sourceFiles in place when sortBy is set),
+            // so consumers can map sections back to files correctly.
+            sourceFiles: sourceFiles.map(f => f.path),
             workflow: {
               message: `Combined ${paths.length} files inline (no file written)`,
               suggested_next: [

--- a/src/semantic/router.ts
+++ b/src/semantic/router.ts
@@ -653,20 +653,20 @@ export class SemanticRouter {
           throw new Error('paths array is required for combine operation');
         }
 
-        if (!destination) {
-          throw new Error('destination is required for combine operation');
-        }
-        
-        // Check if destination exists
-        try {
-          const destFile = await this.api.getFile(destination);
-          if (destFile && !overwrite) {
-            throw new Error(`Destination already exists: ${destination}. Set overwrite=true to replace.`);
+        // When a destination is given, refuse to clobber it unless overwrite.
+        // When omitted, the combined content is returned inline (no write) —
+        // see the inline branch below.
+        if (destination) {
+          try {
+            const destFile = await this.api.getFile(destination);
+            if (destFile && !overwrite) {
+              throw new Error(`Destination already exists: ${destination}. Set overwrite=true to replace.`);
+            }
+          } catch {
+            // File doesn't exist, which is what we want
           }
-        } catch {
-          // File doesn't exist, which is what we want
         }
-        
+
         // Validate and get all source files
         const sourceFiles = [];
         for (const path of paths) {
@@ -697,14 +697,37 @@ export class SemanticRouter {
         }
         
         const finalContent = combinedContent.join(separator);
-        
+
+        // No destination → return the combined content inline without writing
+        // to the vault. Lets read-only consumers use combine for multi-file
+        // retrieval with no side effects.
+        if (!destination) {
+          return {
+            success: true,
+            inline: true,
+            content: finalContent,
+            filesCombined: paths.length,
+            totalSize: finalContent.length,
+            sourceFiles: paths,
+            workflow: {
+              message: `Combined ${paths.length} files inline (no file written)`,
+              suggested_next: [
+                {
+                  description: 'Save the combined content to a file',
+                  command: `vault(action='combine', paths=${JSON.stringify(paths)}, destination='combined.md')`
+                }
+              ]
+            }
+          };
+        }
+
         // Create or update destination file
         if (overwrite) {
           await this.api.updateFile(destination, finalContent);
         } else {
           await this.api.createFile(destination, finalContent);
         }
-        
+
         return {
           success: true,
           destination,

--- a/src/tools/semantic-tools.ts
+++ b/src/tools/semantic-tools.ts
@@ -140,8 +140,12 @@ const createSemanticTool = (operation: string, visibility?: ToolVisibility): Sem
     // Check for read-only mode before processing write operations
     const plugin = (api as unknown as { plugin?: PluginWithSettings }).plugin;
     if (plugin?.settings?.readOnlyMode && operation === 'vault') {
-      const writeOperations = ['create', 'update', 'delete', 'move', 'rename', 'copy', 'split', 'combine', 'concatenate'];
-      if (writeOperations.includes(args.action)) {
+      const writeOperations = ['create', 'update', 'delete', 'move', 'rename', 'copy', 'split', 'concatenate'];
+      // combine writes a file only when a destination is given; without one it
+      // returns content inline (no side effects) and is safe in read-only mode.
+      const isWriteOp = writeOperations.includes(args.action) ||
+        (args.action === 'combine' && Boolean(args.destination));
+      if (isWriteOp) {
         return {
           content: [{
             type: 'text' as const,
@@ -454,7 +458,7 @@ function getParametersForOperation(operation: string): Record<string, unknown> {
       },
       destination: {
         type: 'string',
-        description: 'Destination path for move/copy operations'
+        description: 'Destination path for move/copy/combine operations. For combine: omit to return the combined content inline without writing a file'
       },
       newName: {
         type: 'string',

--- a/tests/combine-inline-router.test.ts
+++ b/tests/combine-inline-router.test.ts
@@ -1,0 +1,63 @@
+import { SemanticRouter } from '../src/semantic/router';
+import { ObsidianAPI } from '../src/utils/obsidian-api';
+import { App } from 'obsidian';
+
+// Minimal text-file mock — combine only needs getFile to return content.
+class MockAPI extends ObsidianAPI {
+  private files = new Map<string, string>([
+    ['a.md', 'ALPHA'],
+    ['b.md', 'BRAVO'],
+    ['c.md', 'CHARLIE'],
+  ]);
+
+  constructor() {
+    super({} as App);
+  }
+
+  async getFile(path: string): Promise<any> {
+    const content = this.files.get(path);
+    if (content === undefined) throw new Error(`File not found: ${path}`);
+    return { content, path, type: 'text' };
+  }
+}
+
+describe('vault combine — inline response (router level)', () => {
+  let router: SemanticRouter;
+
+  beforeEach(() => {
+    router = new SemanticRouter(new MockAPI());
+  });
+
+  test('no destination returns inline content, writes nothing', async () => {
+    const { result } = await router.route({
+      operation: 'vault',
+      action: 'combine',
+      params: { paths: ['a.md', 'b.md'], separator: '\n' },
+    }) as any;
+
+    expect(result.success).toBe(true);
+    expect(result.inline).toBe(true);
+    expect(result.destination).toBeUndefined();
+    expect(result.content).toBe('ALPHA\nBRAVO');
+  });
+
+  test('sourceFiles order matches the order content was combined in (regression)', async () => {
+    // sortBy name desc → c, b, a — different from input order a, b, c.
+    // sourceFiles must reflect the combined order, not the input order,
+    // so consumers can map sections of `content` back to files.
+    const { result } = await router.route({
+      operation: 'vault',
+      action: 'combine',
+      params: {
+        paths: ['a.md', 'b.md', 'c.md'],
+        separator: '\n---\n',
+        sortBy: 'name',
+        sortOrder: 'desc',
+      },
+    }) as any;
+
+    expect(result.inline).toBe(true);
+    expect(result.content).toBe('CHARLIE\n---\nBRAVO\n---\nALPHA');
+    expect(result.sourceFiles).toEqual(['c.md', 'b.md', 'a.md']);
+  });
+});

--- a/tests/combine-inline.test.ts
+++ b/tests/combine-inline.test.ts
@@ -1,0 +1,53 @@
+import { formatFileCombine, FileCombineResponse } from '../src/formatters/vault';
+
+describe('formatFileCombine — inline (no destination) mode', () => {
+  test('renders combined content inline without a Destination line', () => {
+    const response: FileCombineResponse = {
+      success: true,
+      inline: true,
+      content: 'alpha\n\n---\n\nbeta',
+      filesCombined: 2,
+      totalSize: 16,
+      sourceFiles: ['a.md', 'b.md'],
+    };
+
+    const out = formatFileCombine(response);
+
+    expect(out).toContain('Combined 2 files (inline)');
+    expect(out).toContain('alpha');
+    expect(out).toContain('beta');
+    // Inline mode wrote no file, so it must not claim a destination
+    expect(out).not.toContain('Destination');
+  });
+
+  test('still renders destination mode when a destination is present', () => {
+    const response: FileCombineResponse = {
+      success: true,
+      destination: 'combined.md',
+      filesCombined: 2,
+      totalSize: 16,
+      sourceFiles: ['a.md', 'b.md'],
+    };
+
+    const out = formatFileCombine(response);
+
+    expect(out).toContain('Combined: combined.md');
+    expect(out).toContain('Destination');
+    expect(out).not.toContain('(inline)');
+  });
+
+  test('inline branch requires content to be defined', () => {
+    // inline:true but content undefined falls through to destination mode
+    const response: FileCombineResponse = {
+      success: true,
+      inline: true,
+      destination: 'fallback.md',
+      filesCombined: 1,
+    };
+
+    const out = formatFileCombine(response);
+
+    expect(out).toContain('Combined: fallback.md');
+    expect(out).not.toContain('(inline)');
+  });
+});


### PR DESCRIPTION
## Summary

Reimplements community PR **#146** (@laplaque) against current `main` — code only. Contributor credited via `Co-authored-by`.

`vault combine` without a `destination` now returns the combined content **inline** in the MCP response instead of erroring with "destination is required". This lets read-only consumers use `combine` for multi-file retrieval with no side effects.

## Changes

- **`src/semantic/router.ts`** — no-destination branch returns `{ success, inline: true, content, filesCombined, totalSize, sourceFiles, workflow }`; the destination-exists guard is skipped when there's no destination.
- **`src/formatters/vault.ts`** — `FileCombineResponse.destination` is now optional; adds `inline`/`content`; `formatFileCombine` renders an inline block (no spurious "Destination" line).
- **`src/tools/semantic-tools.ts`** — `combine` is a write-op (blocked in read-only mode) **only when a destination is given**; without one it's a safe read. Param description updated.
- **`tests/combine-inline.test.ts`** — inline / destination / fallback coverage (the original #146 had only a manual test plan).

## Deltas from the original #146

- **Dropped the `path: destination || '_inline_'` validator workaround.** The `batch.combine` validators (`BatchLimitValidator`, `PathArrayValidator`) never inspect `path` — verified in `input-validator.ts:90` — so the hack was unnecessary. Validation call left unchanged; `destination` undefined is harmless.
- **No docs.** #146 also carried the README + troubleshooting self-signed-cert section, which is **identical** to #143's. That content ships in the #143 reimplementation (PR #192) instead — one copy, no divergence.

## Verification

- `npm run build` ✓ · `npm run lint` ✓ 0 errors · `npm test` ✓ 212/212 (3 new)

## Closes out

Supersedes #146 — that PR will be closed with thanks and a pointer here on merge.

Co-authored-by: Earl Plak <5597016+laplaque@users.noreply.github.com>