### PR TITLE
fix(onboarding): restore one-command Claude Code setup (corrects #192 regression)

### DIFF
--- a/.claude-github/issue-32-response.md
+++ b/.claude-github/issue-32-response.md
@@ -68,7 +68,11 @@ Add a `headers` field to any of the configs above:
 }
 ```
 
-> **Important:** do not register this server with `claude mcp add --header` — the CLI echoes the resolved header to stdout and (on macOS) the unified log, exposing your API key. Edit the config file directly: `~/.claude/settings.json` (user scope) or `.mcp.json` (project scope) for Claude Code, or your client's MCP config file. The plugin's Settings tab has a ready-to-paste snippet.
+> For **Claude Code** specifically, the simplest path is one command — no manual JSON editing:
+> ```bash
+> claude mcp add --transport http obsidian https://localhost:3443/mcp --header "Authorization: Bearer YOUR_API_KEY_HERE"
+> ```
+> (Use `http://localhost:3001/mcp` if you're on HTTP.) The plugin's Settings tab has the ready-made command with your key filled in.
 
 Could you please:
 1. Confirm which URL you're using (HTTP on 3001 or HTTPS on 3443)?

--- a/README.md
+++ b/README.md
@@ -51,28 +51,13 @@ Download `obsidian-mcp-<version>.mcpb` from the [latest release](https://github.
 
 > *Cross-platform note:* `.mcpb` files install via Claude Desktop's bundled handler. If double-click doesn't trigger Claude on your system, drag the file onto Claude Desktop's window instead, or right-click → "Open with…" and pick Claude Desktop (then "always open with" if your OS asks). Behavior varies by platform: macOS usually auto-associates, Windows may need a one-time association, Linux varies by desktop environment.
 
-**Claude Code** — add to `~/.claude/settings.json` (user scope) or `.mcp.json` (project scope):
+**Claude Code** — one command (copy the ready-made version with your API key from the plugin's Settings tab):
 
-```json
-{
-  "mcpServers": {
-    "obsidian-vault": {
-      "transport": {
-        "type": "http",
-        "url": "http://localhost:3001/mcp",
-        "headers": {
-          "Authorization": "Bearer YOUR_API_KEY"
-        }
-      }
-    }
-  }
-}
+```bash
+claude mcp add --transport http obsidian http://localhost:3001/mcp --header "Authorization: Bearer YOUR_API_KEY"
 ```
 
 For HTTPS, use `https://localhost:3443/mcp` instead — see [Trusting the self-signed certificate](#trusting-the-self-signed-certificate) below. **Claude Code runs on Bun, which does not read the macOS system keychain**, so you will need to set `NODE_EXTRA_CA_CERTS`.
-
-> [!WARNING]
-> **Do not use `claude mcp add --header` to register this server.** The CLI resolves and echoes the header value to stdout, exposing your API key to any parent process — including AI agents that capture tool output as context. On macOS the spawned MCP child process arguments are also written to the unified log. Edit the config file directly instead; copy the ready-made snippet from the plugin's Settings tab.
 
 **Other MCP clients (Cline, Continue, custom integrations, multi-vault setups)**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,6 @@ Until security improvements are complete:
 3. **Monitor vault access** for unexpected changes
 4. **Keep backups** of your vault
 5. **Review plugin permissions** in Obsidian
-6. **Edit MCP config files directly** instead of using `claude mcp add --header` — the CLI echoes resolved header values to stdout, exposing your API key to parent processes and (on macOS) the unified log
 
 ## Secure Configuration
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1536,45 +1536,20 @@ class MCPSettingTab extends PluginSettingTab {
 	private renderClaudeCodeConnection(container: HTMLElement, baseUrl: string): void {
 		container.empty();
 
-		if (this.plugin.settings.dangerouslyDisableAuth) {
-			const codeEl = container.createEl('code');
-			codeEl.classList.add('mcp-code-block');
-			const cmd = `claude mcp add --transport http obsidian ${baseUrl}/mcp`;
-			codeEl.textContent = cmd;
-			this.addCopyButton(container, cmd);
-			return;
-		}
+		// One-command copy/paste — the simplest onboarding path for Claude
+		// Code. For HTTP transport the `--header` value is sent as an HTTP
+		// request header and stored in the same config file the CLI would
+		// write anyway; it is NOT placed in any spawned process's argv (that
+		// only applies to stdio transports like the deprecated mcp-remote).
+		// The JSON-config form for other clients is in the Advanced section.
+		const cmd = this.plugin.settings.dangerouslyDisableAuth
+			? `claude mcp add --transport http obsidian ${baseUrl}/mcp`
+			: `claude mcp add --transport http obsidian ${baseUrl}/mcp --header "Authorization: Bearer ${this.plugin.settings.apiKey}"`;
 
-		container.createEl('p', {
-			text: 'Add to ~/.claude/settings.json (user scope) or .mcp.json (project scope):',
-		});
-
-		const vaultName = this.app.vault.getName();
-		const configJson = {
-			mcpServers: {
-				[vaultName]: {
-					transport: {
-						type: 'http',
-						url: `${baseUrl}/mcp`,
-						headers: {
-							Authorization: `Bearer ${this.plugin.settings.apiKey}`,
-						},
-					},
-				},
-			},
-		};
-		const configText = JSON.stringify(configJson, null, 2);
-
-		const pre = container.createEl('pre');
-		pre.classList.add('mcp-config-example');
-		pre.textContent = configText;
-		this.addCopyButton(container, configText);
-
-		container.createEl('p', {
-			// eslint-disable-next-line obsidianmd/ui/sentence-case -- "claude mcp add --header" is a literal lowercase CLI command; capitalizing it would misrepresent the command users must avoid
-			text: 'Do not use "claude mcp add --header" to register this server — the CLI echoes the resolved token to stdout and (on macOS) the unified log, exposing your API key. Edit the config file directly instead.',
-			cls: 'mcp-security-warning',
-		});
+		const codeEl = container.createEl('code');
+		codeEl.classList.add('mcp-code-block');
+		codeEl.textContent = cmd;
+		this.addCopyButton(container, cmd);
 	}
 
 	private addCopyButton(container: HTMLElement, textToCopy: string): void {

--- a/styles.css
+++ b/styles.css
@@ -174,12 +174,6 @@ input.mcp-api-key-input {
     margin-bottom: 20px;
 }
 
-.mcp-security-warning {
-    color: var(--text-warning);
-    font-size: 0.85em;
-    margin-top: 4px;
-    margin-bottom: 10px;
-}
 
 .mcp-warning-box {
     background-color: var(--background-modifier-error);


### PR DESCRIPTION
## Problem

#192 (reimplementation of contributor PR #143) replaced the Claude Code one-command copy/paste with a *hand-edit-this-JSON-blob* + a warning against `claude mcp add --header`. Per the project owner that's a usability regression — "a difficult-to-use json glob" vs. a paste-one-line setup.

## The security premise was wrong for HTTP transport

Verified against current Claude Code docs (via `claude-code-guide`):

| Claimed vector | Reality for **HTTP** transport |
|---|---|
| Token in spawned-process argv / macOS unified log | **Does not apply.** That's **stdio** transport (`npx mcp-remote --header …`). Native HTTP has no spawned child; the header is sent as an HTTP request header. #143's model was conflated with the mcp-remote setup it was *also* removing. |
| "Edit the file instead" avoids cleartext-at-rest | **No.** `~/.claude.json` / `.mcp.json` store the token cleartext whether added by CLI or by hand. No at-rest gain. |
| CLI echoes token to stdout | Not documented; comprehensive Claude Code security docs don't flag it (they *do* flag OAuth-secret handling). Inference: it does not. The project owner: "I'm not worried about api exposure at the cli." |

So the warning was misinformation that degraded onboarding UX for **zero** real security benefit on this transport.

## Change

- `src/main.ts` — Claude Code section back to the single `claude mcp add --transport http obsidian <url> --header "Authorization: Bearer <key>"` command (no-auth variant drops `--header`), with copy button.
- `README.md`, `.claude-github/issue-32-response.md` — restore the one-liner; drop the `[!WARNING]`.
- `SECURITY.md` — remove the conflated bullet.
- `styles.css` — remove now-dead `.mcp-security-warning`; the `eslint-disable` it needed is gone too.

**Kept from #192 (legit):** native HTTP transport over deprecated `mcp-remote`; the self-signed-cert / `NODE_EXTRA_CA_CERTS` trust docs (unrelated, correct).

ADR-104's context has a passing "deprecated" mention of `--header`; left as-is (accepted ADRs are immutable) — this PR is the corrective record.

## Verification

`npm run build` ✓ · `npm run lint` ✓ 0 errors · `npm test` ✓ 225/225

## Note

Surfaced a process lesson about faithfully reimplementing contributor PRs without independently verifying their premises — discussing separately with the maintainer; the `delivery/contributor-prs` way will be refined.