### PR TITLE
fix(edit): serialize concurrent edits to the same file (closes #139)

### DIFF
--- a/src/semantic/router.ts
+++ b/src/semantic/router.ts
@@ -10,6 +10,7 @@ import {
   EfficiencyRule
 } from '../types/semantic';
 import { ContentBufferManager } from '../utils/content-buffer';
+import { FileLockManager } from '../utils/file-lock';
 import { StateTokenManager } from './state-tokens';
 import { limitResponse } from '../utils/response-limiter';
 import { isImageFile, ObsidianFileResponse } from '../types/obsidian';
@@ -1369,12 +1370,17 @@ export class SemanticRouter {
   }
   
   private async executeEditOperation(action: string, params: Params): Promise<unknown> {
-    // Import window edit tools dynamically to avoid circular dependencies
-    const { performWindowEdit } = await import('../tools/window-edit.js');
     const buffer = ContentBufferManager.getInstance();
 
+    // Serialize all edit actions targeting the same file so parallel
+    // edit.window/append/patch/at_line/from_buffer calls from a batched MCP
+    // client can no longer silently clobber each other (#139). Different
+    // files remain fully concurrent.
+    return FileLockManager.getInstance().withLock(String(params.path), async () => {
     switch (action) {
       case 'window': {
+        // Imported dynamically (only when needed) to avoid circular deps.
+        const { performWindowEdit } = await import('../tools/window-edit.js');
         const result = await performWindowEdit(
           this.api,
           String(params.path),
@@ -1446,6 +1452,7 @@ export class SemanticRouter {
         if (!buffered) {
           throw new Error('No buffered content available');
         }
+        const { performWindowEdit } = await import('../tools/window-edit.js');
         return await performWindowEdit(
           this.api,
           String(params.path),
@@ -1457,8 +1464,9 @@ export class SemanticRouter {
       default:
         throw new Error(`Unknown edit action: ${action}`);
     }
+    });
   }
-  
+
   private async executeViewOperation(action: string, params: Params): Promise<unknown> {
     switch (action) {
       case 'file':

--- a/src/utils/file-lock.ts
+++ b/src/utils/file-lock.ts
@@ -1,0 +1,77 @@
+/**
+ * Per-file write serialization (issue #139).
+ *
+ * A new `SemanticRouter` is constructed per request, so a per-instance lock
+ * cannot serialize concurrent requests. This is a process-wide singleton
+ * (same pattern as `ContentBufferManager`) that serializes operations
+ * targeting the *same* file path while leaving operations on *different*
+ * paths fully concurrent.
+ *
+ * Without this, an MCP client that batches several `edit.window`/`append`/
+ * `patch` calls against one file in parallel triggers overlapping
+ * read-modify-write cycles: every call reports success but only one edit
+ * survives, with no error surfaced (#139).
+ */
+
+/** Normalize a vault path to a stable lock key for the same logical file. */
+function lockKey(path: string): string {
+  return path
+    .trim()
+    .replace(/^\.\//, '')   // drop leading "./"
+    .replace(/\/{2,}/g, '/') // collapse duplicate slashes
+    .replace(/^\/+/, '');    // drop leading slashes
+}
+
+export class FileLockManager {
+  private static instance: FileLockManager;
+
+  /**
+   * Tail of the promise chain per file path. Each `withLock` call appends
+   * to the tail, so callers run strictly in arrival order for a given path.
+   * The entry is deleted once its chain fully drains to bound memory.
+   */
+  private chains: Map<string, Promise<unknown>> = new Map();
+
+  private constructor() {}
+
+  static getInstance(): FileLockManager {
+    if (!FileLockManager.instance) {
+      FileLockManager.instance = new FileLockManager();
+    }
+    return FileLockManager.instance;
+  }
+
+  /**
+   * Run `fn` with exclusive access to `path`. Calls for the same path are
+   * serialized in arrival order; calls for different paths run concurrently.
+   * `fn`'s result (or rejection) is propagated to the caller unchanged; a
+   * rejection does not break serialization for subsequent waiters.
+   */
+  async withLock<T>(path: string, fn: () => Promise<T>): Promise<T> {
+    const key = lockKey(path);
+    const prev = this.chains.get(key) ?? Promise.resolve();
+
+    // Chain after the previous holder, swallowing its result/error so this
+    // waiter runs regardless of how the prior one settled.
+    const run = prev.then(() => fn(), () => fn());
+
+    // The chain tail tracks completion (success or failure) without throwing.
+    const tail = run.then(() => undefined, () => undefined);
+    this.chains.set(key, tail);
+
+    // Once this is the last queued operation for the path, drop the entry so
+    // the map does not grow unbounded across many distinct files.
+    void tail.then(() => {
+      if (this.chains.get(key) === tail) {
+        this.chains.delete(key);
+      }
+    });
+
+    return run;
+  }
+
+  /** Test/diagnostic helper: number of paths with an in-flight chain. */
+  activeLockCount(): number {
+    return this.chains.size;
+  }
+}

--- a/tests/file-lock-edit-serialization.test.ts
+++ b/tests/file-lock-edit-serialization.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Regression for #139: parallel edit actions against the same file silently
+ * clobbered each other (every call returned success, only one edit survived).
+ *
+ * Two layers:
+ *  1. FileLockManager unit behaviour (same-path serialized, different-path
+ *     concurrent, error-isolated, map drains).
+ *  2. Router-level repro: a MockAPI whose appendToFile is a realistic
+ *     read-modify-write with an await gap. Without serialization, three
+ *     parallel edit.append calls lose updates; with the #139 fix all land.
+ */
+import { SemanticRouter } from '../src/semantic/router';
+import { ObsidianAPI } from '../src/utils/obsidian-api';
+import { FileLockManager } from '../src/utils/file-lock';
+import { App } from 'obsidian';
+
+describe('FileLockManager (unit)', () => {
+  const mgr = FileLockManager.getInstance();
+
+  test('serializes critical sections for the same path', async () => {
+    const events: string[] = [];
+    const op = (tag: string) => mgr.withLock('same.md', async () => {
+      events.push(`${tag}:start`);
+      await new Promise(r => setTimeout(r, 5));
+      events.push(`${tag}:end`);
+    });
+    await Promise.all([op('A'), op('B'), op('C')]);
+    // No interleaving: each start is immediately followed by its own end.
+    expect(events).toEqual([
+      'A:start', 'A:end',
+      'B:start', 'B:end',
+      'C:start', 'C:end',
+    ]);
+  });
+
+  test('different paths run concurrently', async () => {
+    const order: string[] = [];
+    const slow = mgr.withLock('x.md', async () => {
+      await new Promise(r => setTimeout(r, 20));
+      order.push('x');
+    });
+    const fast = mgr.withLock('y.md', async () => {
+      order.push('y');
+    });
+    await Promise.all([slow, fast]);
+    expect(order).toEqual(['y', 'x']); // y not blocked behind x
+  });
+
+  test('a rejected holder does not break serialization for later waiters', async () => {
+    const seen: string[] = [];
+    const bad = mgr.withLock('z.md', async () => { throw new Error('boom'); });
+    const good = mgr.withLock('z.md', async () => { seen.push('ran'); });
+    await expect(bad).rejects.toThrow('boom');
+    await good;
+    expect(seen).toEqual(['ran']);
+  });
+
+  test('chain entries drain so the map does not grow unbounded', async () => {
+    await mgr.withLock('drain-a.md', async () => {});
+    await mgr.withLock('drain-b.md', async () => {});
+    // allow the post-drain microtask cleanup to run
+    await new Promise(r => setTimeout(r, 0));
+    expect(mgr.activeLockCount()).toBe(0);
+  });
+});
+
+/**
+ * MockAPI.appendToFile mimics a read-modify-write with an await gap — the
+ * exact shape that loses concurrent updates without a per-file lock.
+ */
+class MockAPI extends ObsidianAPI {
+  files = new Map<string, string>([['_test.md', '# Test\n']]);
+
+  constructor() {
+    super({} as App);
+  }
+
+  async appendToFile(path: string, content: string): Promise<any> {
+    const current = this.files.get(path) ?? '';
+    // Yield: a competing append can read the same `current` here if the
+    // edit handler is not serializing per file.
+    await new Promise(r => setTimeout(r, 5));
+    this.files.set(path, current + content);
+    return { success: true, path };
+  }
+}
+
+describe('edit.append parallel calls against one file (#139, router level)', () => {
+  test('all three concurrent appends persist (no silent clobber)', async () => {
+    const api = new MockAPI();
+
+    // Fresh router per call — faithful to production (router is per-request;
+    // FileLockManager is the process-wide singleton that actually serializes).
+    const append = (line: string) =>
+      new SemanticRouter(api).route({
+        operation: 'edit',
+        action: 'append',
+        params: { path: '_test.md', content: line },
+      });
+
+    const results = await Promise.all([
+      append('ALPHA\n'),
+      append('BRAVO\n'),
+      append('CHARLIE\n'),
+    ]);
+
+    // Every call still reports success...
+    for (const r of results) {
+      expect((r as any).error).toBeFalsy();
+    }
+    // ...and every edit actually landed (the #139 bug lost two of three).
+    const final = api.files.get('_test.md')!;
+    expect(final).toContain('ALPHA');
+    expect(final).toContain('BRAVO');
+    expect(final).toContain('CHARLIE');
+    expect(final).toBe('# Test\nALPHA\nBRAVO\nCHARLIE\n');
+  });
+
+  test('edits to different files are not serialized against each other', async () => {
+    const api = new MockAPI();
+    api.files.set('other.md', '');
+
+    const start = Date.now();
+    await Promise.all([
+      new SemanticRouter(api).route({ operation: 'edit', action: 'append', params: { path: '_test.md', content: 'A' } }),
+      new SemanticRouter(api).route({ operation: 'edit', action: 'append', params: { path: 'other.md', content: 'B' } }),
+    ]);
+    // Two independent ~5ms ops in parallel should not take ~10ms+ serially.
+    expect(Date.now() - start).toBeLessThan(40);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves **#139**: parallel `edit.window`/`append`/`patch` calls against the same file silently clobbered each other — every call returned `Edit successful.` but only one edit persisted, with no error. AI clients commonly batch tool calls in parallel (the recommended MCP pattern), so an agent could leave a file in a partial state believing all edits landed.

## Root cause

All `edit.*` actions funnel through `SemanticRouter.executeEditOperation`, which does read-modify-write via `this.api`. Concurrent calls to the same path interleave their read→write cycles → lost updates. A new `SemanticRouter` is constructed **per request**, so a per-instance lock cannot serialize across concurrent requests.

## Fix

- **`src/utils/file-lock.ts`** — `FileLockManager`, a process-wide singleton (same pattern as `ContentBufferManager`). `withLock(path, fn)` chains operations for the **same** normalized path so they run in strict arrival order; **different** paths stay fully concurrent. The per-path chain entry is deleted once it drains (bounded memory), and a rejected holder doesn't break serialization for later waiters.
- **`src/semantic/router.ts`** — `executeEditOperation` runs its entire action switch inside `FileLockManager.getInstance().withLock(String(params.path), …)`. Also moved the `window-edit` dynamic import into only the two cases that use it (`window`, `from_buffer`) — `append`/`patch`/`at_line` no longer load it, and the path is now unit-testable.

## Tests — `tests/file-lock-edit-serialization.test.ts`

- `FileLockManager` unit: same-path serialized (no interleave), different-path concurrent, rejected-holder isolation, chain drains (`activeLockCount` → 0).
- **#139 repro at router level**: a `MockAPI.appendToFile` with a realistic read-modify-write await gap. Three concurrent `edit.append` calls — without the lock the MockAPI loses 2 of 3; **with the fix all three land** (`# Test\nALPHA\nBRAVO\nCHARLIE\n`) and all still report success.
- Edits to **different** files are asserted to remain parallel.

## Scope / non-goals

- Limited to `edit.*` actions (the #139 report). No router extraction — that is **#199**'s own focused PR.
- Concurrent edits to **different** files are unaffected (still parallel), per the issue's stated expectation.

## Verification

`make check` green on a clean `main` base: build ✅, lint 0 errors (5 pre-existing unrelated warnings), **231/231 tests** (+6 new).

This is a good candidate for the **prerelease → BRAT → reconnect** functional test (the original #139 repro: batch 3 `edit.window` calls at one file, read back from disk) when convenient.

Closes #139.