### PR TITLE
Honor includeUnresolved for graph forward links

### DIFF
--- a/src/tools/graph-search.ts
+++ b/src/tools/graph-search.ts
@@ -418,10 +418,14 @@ export class GraphSearchTool {
     }
 
     const forwardLinks = this.graphTraversal.getForwardLinks(params.sourcePath);
+    const unresolvedLinks = params.includeUnresolved
+      ? this.graphTraversal.getUnresolvedForwardLinks(params.sourcePath)
+      : [];
+    const allForwardLinks = [...forwardLinks, ...unresolvedLinks];
     const nodes: GraphSearchResult['nodes'] = [];
     
     // Get node information for each forward link target
-    for (const edge of forwardLinks) {
+    for (const edge of allForwardLinks) {
       const file = this.app.vault.getAbstractFileByPath(edge.target);
       if (file && file instanceof TFile) {
         const cache = this.app.metadataCache.getFileCache(file);
@@ -445,8 +449,8 @@ export class GraphSearchTool {
       operation: 'forwardlinks',
       sourcePath: params.sourcePath,
       nodes,
-      edges: forwardLinks,
-      message: `Found ${forwardLinks.length} files linked from this file`,
+      edges: allForwardLinks,
+      message: `Found ${allForwardLinks.length} files linked from this file`,
       workflow: {
         message: 'Forward links retrieved. You can explore these referenced files.',
         suggested_next: [

--- a/src/utils/graph-traversal.ts
+++ b/src/utils/graph-traversal.ts
@@ -116,8 +116,23 @@ export class GraphTraversal {
    * Get unresolved links from a file
    */
   getUnresolvedLinks(filePath: string): string[] {
-    const unresolvedLinks = this.app.metadataCache.unresolvedLinks[filePath];
+    const unresolvedLinks = this.app.metadataCache.unresolvedLinks?.[filePath];
     return unresolvedLinks ? Object.keys(unresolvedLinks) : [];
+  }
+
+  /**
+   * Get unresolved forward links as graph edges.
+   */
+  getUnresolvedForwardLinks(filePath: string): GraphEdge[] {
+    const unresolvedLinks = this.app.metadataCache.unresolvedLinks?.[filePath];
+    if (!unresolvedLinks) return [];
+
+    return Object.entries(unresolvedLinks).map(([targetPath, count]) => ({
+      source: filePath,
+      target: targetPath,
+      type: 'link',
+      count
+    }));
   }
 
   /**

--- a/tests/graph-search.test.ts
+++ b/tests/graph-search.test.ts
@@ -6,6 +6,9 @@ function makeFile(path: string): TFile {
   const file = new TFile();
   file.path = path;
   file.name = path.split('/').pop() ?? path;
+  // getNodeTitle (added in #207, merged before this PR landed) reads
+  // basename — make the mock match the real TFile API.
+  file.basename = file.name.replace(/\.md$/, '');
   file.extension = 'md';
   return file;
 }

--- a/tests/graph-search.test.ts
+++ b/tests/graph-search.test.ts
@@ -1,0 +1,67 @@
+import { App, TFile } from 'obsidian';
+import { GraphSearchTool } from '../src/tools/graph-search';
+import { ObsidianAPI } from '../src/utils/obsidian-api';
+
+function makeFile(path: string): TFile {
+  const file = new TFile();
+  file.path = path;
+  file.name = path.split('/').pop() ?? path;
+  file.extension = 'md';
+  return file;
+}
+
+describe('GraphSearchTool', () => {
+  let app: App;
+  let tool: GraphSearchTool;
+
+  beforeEach(() => {
+    const resolvedTarget = makeFile('resolved.md');
+
+    app = new App();
+    (app as any).metadataCache = {
+      resolvedLinks: {
+        'source.md': { 'resolved.md': 1 }
+      },
+      unresolvedLinks: {
+        'source.md': { 'Missing Note': 1 }
+      },
+      getFileCache: jest.fn().mockReturnValue({ tags: [] })
+    };
+    app.vault.getAbstractFileByPath = jest.fn((path: string) =>
+      path === 'resolved.md' ? resolvedTarget : null
+    );
+
+    tool = new GraphSearchTool({} as ObsidianAPI, app);
+  });
+
+  it('omits unresolved forward links by default', () => {
+    const result = tool.search({
+      operation: 'forwardlinks',
+      sourcePath: 'source.md'
+    });
+
+    expect(result.edges).toEqual([
+      { source: 'source.md', target: 'resolved.md', type: 'link', count: 1 }
+    ]);
+    expect(result.nodes).toEqual([
+      expect.objectContaining({ path: 'resolved.md', title: 'resolved' })
+    ]);
+  });
+
+  it('includes unresolved forward links when requested', () => {
+    const result = tool.search({
+      operation: 'forwardlinks',
+      sourcePath: 'source.md',
+      includeUnresolved: true
+    });
+
+    expect(result.edges).toEqual([
+      { source: 'source.md', target: 'resolved.md', type: 'link', count: 1 },
+      { source: 'source.md', target: 'Missing Note', type: 'link', count: 1 }
+    ]);
+    expect(result.nodes).toEqual([
+      expect.objectContaining({ path: 'resolved.md', title: 'resolved' })
+    ]);
+    expect(result.message).toBe('Found 2 files linked from this file');
+  });
+});


### PR DESCRIPTION
## Summary

`includeUnresolved` is exposed as an option for graph operations, but `graph.forwardlinks` only returned resolved links.

This updates forward-links handling so:

- default behavior stays unchanged (resolved links only)
- `includeUnresolved: true` adds unresolved outgoing links as graph edges
- unresolved targets do not create file nodes unless they resolve to an actual `TFile`
- missing `metadataCache.unresolvedLinks` is handled defensively

## Tests

- `npm run lint` (passes with existing warnings)
- `npm run build`
- `npm test -- tests/graph-search.test.ts --runInBand`
- `npm test -- --runInBand --forceExit`
