### PR TITLE
Bind MCP server to loopback

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -75,6 +75,7 @@ interface ConnectionPoolStatsResponse {
   };
 }
 
+export const MCP_LISTEN_HOST = '127.0.0.1';
 
 export class MCPHttpServer {
   private app: express.Application;
@@ -635,11 +636,11 @@ export class MCPHttpServer {
         Debug.error('Failed to configure server timeouts:', e);
       }
       
-      this.server.listen(this.port, () => {
+      this.server.listen(this.port, MCP_LISTEN_HOST, () => {
         this.isRunning = true;
-        Debug.log(`🚀 MCP server started on ${protocol}://localhost:${this.port}`);
-        Debug.log(`📍 Health check: ${protocol}://localhost:${this.port}/`);
-        Debug.log(`🔗 MCP endpoint: ${protocol}://localhost:${this.port}/mcp`);
+        Debug.log(`🚀 MCP server started on ${protocol}://${MCP_LISTEN_HOST}:${this.port}`);
+        Debug.log(`📍 Health check: ${protocol}://${MCP_LISTEN_HOST}:${this.port}/`);
+        Debug.log(`🔗 MCP endpoint: ${protocol}://${MCP_LISTEN_HOST}:${this.port}/mcp`);
         
         if (this.isHttps) {
           Debug.log('🔒 HTTPS enabled with certificate');

--- a/src/node-mcp-server.ts
+++ b/src/node-mcp-server.ts
@@ -2,6 +2,8 @@ import { Debug } from './utils/debug';
 import { App } from 'obsidian';
 import type { IncomingMessage, ServerResponse, Server } from 'http';
 
+export const NODE_MCP_LISTEN_HOST = '127.0.0.1';
+
 interface MCPToolCallParams {
   name?: string;
   arguments?: Record<string, unknown>;
@@ -49,9 +51,9 @@ export class NodeMCPServer {
       });
 
       await new Promise<void>((resolve, reject) => {
-        this.server!.listen(this.port, () => {
+        this.server!.listen(this.port, NODE_MCP_LISTEN_HOST, () => {
           this.isRunning = true;
-          Debug.log(`🚀 MCP server started on port ${this.port}`);
+          Debug.log(`🚀 MCP server started on ${NODE_MCP_LISTEN_HOST}:${this.port}`);
           Debug.log(`📍 Health check: /`);
           Debug.log(`🔗 MCP endpoint: /mcp`);
           resolve();

--- a/tests/listen-loopback.test.ts
+++ b/tests/listen-loopback.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { MCP_LISTEN_HOST } from '../src/mcp-server';
+
+describe('MCP listen host', () => {
+  test('HTTP server uses an explicit loopback listen host', () => {
+    expect(MCP_LISTEN_HOST).toBe('127.0.0.1');
+
+    const source = readFileSync(join(__dirname, '../src/mcp-server.ts'), 'utf8');
+    expect(source).toContain('this.server.listen(this.port, MCP_LISTEN_HOST,');
+  });
+
+  test('Node MCP server binds to loopback only', async () => {
+    jest.resetModules();
+
+    const fakeServer: {
+      listen: jest.Mock;
+      on: jest.Mock;
+      close: jest.Mock;
+    } = {
+      listen: jest.fn((_port: number, _host: string, callback: () => void) => {
+        callback();
+        return fakeServer;
+      }),
+      on: jest.fn(() => fakeServer),
+      close: jest.fn((callback: () => void) => {
+        callback();
+        return fakeServer;
+      })
+    };
+
+    const createServer = jest.fn(() => fakeServer);
+    jest.doMock('http', () => ({ createServer }));
+
+    const { NodeMCPServer, NODE_MCP_LISTEN_HOST } = await import('../src/node-mcp-server');
+    const server = new NodeMCPServer({} as never, 4567);
+
+    await server.start();
+
+    expect(NODE_MCP_LISTEN_HOST).toBe('127.0.0.1');
+    expect(createServer).toHaveBeenCalledTimes(1);
+    expect(fakeServer.listen).toHaveBeenCalledWith(4567, NODE_MCP_LISTEN_HOST, expect.any(Function));
+
+    await server.stop();
+  });
+});


### PR DESCRIPTION
## Summary

- bind both MCP HTTP server entry points to `127.0.0.1` instead of Node's default wildcard interface
- update startup logs to show the explicit loopback address
- add regression coverage that asserts the explicit loopback bind is used

## Why

This keeps the local Obsidian MCP HTTP endpoint scoped to the local machine by default.

## Tests

- `npm test -- --runInBand tests/listen-loopback.test.ts`
- `npm run lint` (passes with existing warnings only)
- `npm run build`
- `npm test -- --runInBand --forceExit`
