### PR TITLE
fix(dispatch): require params at the MCP boundary (closes #210)

### DIFF
--- a/src/semantic/operations/shared.ts
+++ b/src/semantic/operations/shared.ts
@@ -32,3 +32,27 @@ export function paramBool(params: Params, key: string): boolean | undefined {
   const val = params[key];
   return typeof val === 'boolean' ? val : undefined;
 }
+
+/**
+ * Require a string param at the MCP dispatch boundary.
+ *
+ * Throws before any vault call when the param is missing or wrong-typed,
+ * so a malformed client call cannot reach a sink like `vault.modify` with
+ * `String(undefined) === "undefined"` and corrupt the file (#210). `hint`
+ * is appended to the message when set — use it to point callers at the
+ * right tool/shape when a known misuse is likely.
+ */
+export function requireParamStr(
+  params: Params,
+  key: string,
+  action: string,
+  hint?: string,
+): string {
+  const val = params[key];
+  if (typeof val !== 'string') {
+    const have = val === undefined ? 'missing' : `got ${typeof val}`;
+    const base = `${action} requires '${key}' (string, ${have}).`;
+    throw new Error(hint ? `${base} ${hint}` : base);
+  }
+  return val;
+}

--- a/src/semantic/operations/vault.ts
+++ b/src/semantic/operations/vault.ts
@@ -10,7 +10,7 @@ import { isImageFile, ObsidianFileResponse } from '../../types/obsidian';
 import { readFileWithFragments } from '../../utils/file-reader';
 import { ValidationException } from '../../validation/input-validator';
 import { RouterContext } from './router-context';
-import { Params, paramStr, paramNum, paramBool } from './shared';
+import { Params, paramStr, paramNum, paramBool, requireParamStr } from './shared';
 
 export async function executeVaultOperation(ctx: RouterContext, action: string, params: Params): Promise<unknown> {
     switch (action) {
@@ -119,12 +119,26 @@ export async function executeVaultOperation(ctx: RouterContext, action: string, 
           };
         }
       }
-      case 'create':
-        return await ctx.api.createFile(paramStr(params, 'path') ?? '', paramStr(params, 'content') ?? '');
-      case 'update':
-        return await ctx.api.updateFile(String(params.path), String(params.content));
-      case 'delete':
-        return await ctx.api.deleteFile(String(params.path));
+      case 'create': {
+        const path = requireParamStr(params, 'path', 'vault.create');
+        // Empty content is a legitimate "touch" — only the path is required.
+        const content = paramStr(params, 'content') ?? '';
+        return await ctx.api.createFile(path, content);
+      }
+      case 'update': {
+        const path = requireParamStr(params, 'path', 'vault.update');
+        const content = requireParamStr(
+          params,
+          'content',
+          'vault.update',
+          "For partial replacement, use vault.patch with operation='replace', oldText, newText — or edit.window for fuzzy in-place edits.",
+        );
+        return await ctx.api.updateFile(path, content);
+      }
+      case 'delete': {
+        const path = requireParamStr(params, 'path', 'vault.delete');
+        return await ctx.api.deleteFile(path);
+      }
       case 'search': {
         // Validate query
         const queryStr = paramStr(params, 'query');

--- a/src/semantic/operations/vault.ts
+++ b/src/semantic/operations/vault.ts
@@ -131,7 +131,7 @@ export async function executeVaultOperation(ctx: RouterContext, action: string, 
           params,
           'content',
           'vault.update',
-          "For partial replacement, use vault.patch with operation='replace', oldText, newText — or edit.window for fuzzy in-place edits.",
+          "For partial replacement, use edit.patch with operation='replace', oldText, newText — or edit.window for fuzzy in-place edits.",
         );
         return await ctx.api.updateFile(path, content);
       }

--- a/src/semantic/router.ts
+++ b/src/semantic/router.ts
@@ -137,7 +137,7 @@ export class SemanticRouter implements RouterContext {
     // client can no longer silently clobber each other (#139). Different
     // files remain fully concurrent.
     // Guard the lock key up-front so a missing path can't take a lock on
-     // the literal string "undefined" and serialize unrelated bad calls.
+    // the literal string "undefined" and serialize unrelated bad calls.
     const lockPath = requireParamStr(params, 'path', `edit.${action}`);
     return FileLockManager.getInstance().withLock(lockPath, async () => {
     switch (action) {

--- a/src/semantic/router.ts
+++ b/src/semantic/router.ts
@@ -22,7 +22,7 @@ import { InputValidator } from '../validation/input-validator';
 import { BaseYAML } from '../types/bases-yaml';
 import { RouterContext } from './operations/router-context';
 import { executeVaultOperation } from './operations/vault';
-import { Params, SearchResultItem, paramStr, paramNum, paramBool } from './operations/shared';
+import { Params, SearchResultItem, paramStr, paramNum, paramBool, requireParamStr } from './operations/shared';
 
 export class SemanticRouter implements RouterContext {
   private config!: WorkflowConfig;
@@ -136,16 +136,21 @@ export class SemanticRouter implements RouterContext {
     // edit.window/append/patch/at_line/from_buffer calls from a batched MCP
     // client can no longer silently clobber each other (#139). Different
     // files remain fully concurrent.
-    return FileLockManager.getInstance().withLock(String(params.path), async () => {
+    // Guard the lock key up-front so a missing path can't take a lock on
+     // the literal string "undefined" and serialize unrelated bad calls.
+    const lockPath = requireParamStr(params, 'path', `edit.${action}`);
+    return FileLockManager.getInstance().withLock(lockPath, async () => {
     switch (action) {
       case 'window': {
+        const oldText = requireParamStr(params, 'oldText', 'edit.window');
+        const newText = requireParamStr(params, 'newText', 'edit.window');
         // Imported dynamically (only when needed) to avoid circular deps.
         const { performWindowEdit } = await import('../tools/window-edit.js');
         const result = await performWindowEdit(
           this.api,
-          String(params.path),
-          String(params.oldText),
-          String(params.newText),
+          lockPath,
+          oldText,
+          newText,
           paramNum(params, 'fuzzyThreshold')
         );
         if (result.isError) {
@@ -153,10 +158,17 @@ export class SemanticRouter implements RouterContext {
         }
         return result;
       }
-      case 'append':
-        return await this.api.appendToFile(String(params.path), String(params.content));
+      case 'append': {
+        const content = requireParamStr(
+          params,
+          'content',
+          'edit.append',
+          "Pass the text to append as 'content'.",
+        );
+        return await this.api.appendToFile(lockPath, content);
+      }
       case 'patch':
-        return await this.api.patchVaultFile(String(params.path), {
+        return await this.api.patchVaultFile(lockPath, {
           operation: paramStr(params, 'operation'),
           targetType: paramStr(params, 'targetType'),
           target: paramStr(params, 'target'),
@@ -176,7 +188,7 @@ export class SemanticRouter implements RouterContext {
         }
 
         // Get file and perform line-based edit
-        const filePath = String(params.path);
+        const filePath = lockPath;
         const file = await this.api.getFile(filePath);
         if (isImageFile(file)) {
           throw new Error('Cannot perform line-based edits on image files');
@@ -215,7 +227,7 @@ export class SemanticRouter implements RouterContext {
         const { performWindowEdit } = await import('../tools/window-edit.js');
         return await performWindowEdit(
           this.api,
-          String(params.path),
+          lockPath,
           paramStr(params, 'oldText') || buffered.searchText || '',
           buffered.content,
           paramNum(params, 'fuzzyThreshold')
@@ -230,10 +242,10 @@ export class SemanticRouter implements RouterContext {
   private async executeViewOperation(action: string, params: Params): Promise<unknown> {
     switch (action) {
       case 'file':
-        return await this.api.getFile(String(params.path));
+        return await this.api.getFile(requireParamStr(params, 'path', 'view.file'));
       case 'window': {
         // View a portion of a file
-        const viewPath = String(params.path);
+        const viewPath = requireParamStr(params, 'path', 'view.window');
         const file = await this.api.getFile(viewPath);
         if (isImageFile(file)) {
           throw new Error('Cannot view window of image files');
@@ -291,7 +303,7 @@ export class SemanticRouter implements RouterContext {
         }
         
       case 'open_in_obsidian':
-        return await this.api.openFile(String(params.path));
+        return await this.api.openFile(requireParamStr(params, 'path', 'view.open_in_obsidian'));
         
       default:
         throw new Error(`Unknown view action: ${action}`);

--- a/src/utils/obsidian-api.ts
+++ b/src/utils/obsidian-api.ts
@@ -437,7 +437,9 @@ export class ObsidianAPI {
     }
 
     await this.app.vault.modify(file, content);
-    return { success: true };
+    // Include `path` so formatFileWrite renders "Updated: <path>" instead of
+    // the misleading "Updated: undefined" that masked #210 client-side.
+    return { success: true, path };
   }
 
   async deleteFile(path: string) {
@@ -447,7 +449,7 @@ export class ObsidianAPI {
     }
 
     await this.app.fileManager.trashFile(file);
-    return { success: true };
+    return { success: true, path };
   }
 
   async appendToFile(path: string, content: string) {

--- a/tests/dispatch-param-guards.test.ts
+++ b/tests/dispatch-param-guards.test.ts
@@ -21,6 +21,7 @@ type Mutation =
 
 class RecordingAPI extends ObsidianAPI {
   readonly mutations: Mutation[] = [];
+  readonly reads: string[] = [];
   private files = new Map<string, string>([['existing.md', 'original']]);
 
   constructor() {
@@ -28,6 +29,7 @@ class RecordingAPI extends ObsidianAPI {
   }
 
   async getFile(path: string): Promise<any> {
+    this.reads.push(path);
     const content = this.files.get(path);
     if (content === undefined) throw new Error(`File not found: ${path}`);
     return { content, path, type: 'text' };
@@ -142,7 +144,7 @@ describe('dispatch-level param guards (#210)', () => {
     expect((await api.getFile('existing.md')).content).toBe('original');
   });
 
-  test('edit.window without oldText/newText rejects before searching the file', async () => {
+  test('edit.window without oldText/newText rejects before reading or writing the file', async () => {
     const response = await router.route({
       operation: 'edit',
       action: 'window',
@@ -150,6 +152,10 @@ describe('dispatch-level param guards (#210)', () => {
     });
     expect((response as any).error).toBeDefined();
     expect(api.mutations).toEqual([]);
+    // The guard must run before performWindowEdit fetches the file —
+    // otherwise a missing oldText could still trigger a search for the
+    // literal string "undefined" with confusing diagnostics.
+    expect(api.reads).toEqual([]);
   });
 
   test('edit.* without path rejects before taking a file lock', async () => {

--- a/tests/dispatch-param-guards.test.ts
+++ b/tests/dispatch-param-guards.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Regression tests for #210 — vault.update with missing `content` wrote the
+ * literal string "undefined" to files. The fix moved required-param checks
+ * to the dispatch boundary so a malformed MCP call cannot reach a vault
+ * sink with `String(undefined)`. These tests cover the corruption-class
+ * cases (update/append/window) plus the path-only guards.
+ *
+ * Strategy: a mock API records every mutation. After a malformed call we
+ * assert the call threw AND that no mutation was recorded — i.e. the guard
+ * runs before any sink, not after.
+ */
+import { SemanticRouter } from '../src/semantic/router';
+import { ObsidianAPI } from '../src/utils/obsidian-api';
+import { App } from 'obsidian';
+
+type Mutation =
+  | { kind: 'update'; path: string; content: string }
+  | { kind: 'append'; path: string; content: string }
+  | { kind: 'delete'; path: string }
+  | { kind: 'create'; path: string; content: string };
+
+class RecordingAPI extends ObsidianAPI {
+  readonly mutations: Mutation[] = [];
+  private files = new Map<string, string>([['existing.md', 'original']]);
+
+  constructor() {
+    super({} as App);
+  }
+
+  async getFile(path: string): Promise<any> {
+    const content = this.files.get(path);
+    if (content === undefined) throw new Error(`File not found: ${path}`);
+    return { content, path, type: 'text' };
+  }
+
+  async updateFile(path: string, content: string): Promise<any> {
+    this.mutations.push({ kind: 'update', path, content });
+    this.files.set(path, content);
+    return { success: true, path };
+  }
+
+  async appendToFile(path: string, content: string): Promise<any> {
+    this.mutations.push({ kind: 'append', path, content });
+    const prev = this.files.get(path) ?? '';
+    this.files.set(path, prev + content);
+    return { success: true, path };
+  }
+
+  async deleteFile(path: string): Promise<any> {
+    this.mutations.push({ kind: 'delete', path });
+    this.files.delete(path);
+    return { success: true, path };
+  }
+
+  async createFile(path: string, content: string): Promise<any> {
+    this.mutations.push({ kind: 'create', path, content });
+    this.files.set(path, content);
+    return { success: true, path };
+  }
+}
+
+describe('dispatch-level param guards (#210)', () => {
+  let api: RecordingAPI;
+  let router: SemanticRouter;
+
+  beforeEach(() => {
+    api = new RecordingAPI();
+    router = new SemanticRouter(api);
+  });
+
+  // The exact corruption shape from #210: client omits `content` while
+  // sending `mode`/`search`/`replacement` as if calling vault.patch. Before
+  // the fix this wrote the 9-byte literal "undefined" to existing.md.
+  test('vault.update without content rejects without touching the vault', async () => {
+    const response = await router.route({
+      operation: 'vault',
+      action: 'update',
+      params: {
+        path: 'existing.md',
+        mode: 'replace',
+        search: 'foo',
+        replacement: 'bar',
+      },
+    });
+
+    expect((response as any).error).toBeDefined();
+    expect(api.mutations).toEqual([]);
+    // Source of truth — file is untouched.
+    expect((await api.getFile('existing.md')).content).toBe('original');
+  });
+
+  test('vault.update without path rejects', async () => {
+    const response = await router.route({
+      operation: 'vault',
+      action: 'update',
+      params: { content: 'whatever' },
+    });
+    expect((response as any).error).toBeDefined();
+    expect(api.mutations).toEqual([]);
+  });
+
+  test('vault.update with both path and content succeeds and returns path', async () => {
+    const response: any = await router.route({
+      operation: 'vault',
+      action: 'update',
+      params: { path: 'existing.md', content: 'new body' },
+    });
+    expect(response.result).toMatchObject({ success: true, path: 'existing.md' });
+    expect(api.mutations).toEqual([
+      { kind: 'update', path: 'existing.md', content: 'new body' },
+    ]);
+  });
+
+  test('vault.delete without path rejects', async () => {
+    const response = await router.route({
+      operation: 'vault',
+      action: 'delete',
+      params: {},
+    });
+    expect((response as any).error).toBeDefined();
+    expect(api.mutations).toEqual([]);
+  });
+
+  test('vault.create without path rejects', async () => {
+    const response = await router.route({
+      operation: 'vault',
+      action: 'create',
+      params: { content: 'body' },
+    });
+    expect((response as any).error).toBeDefined();
+    expect(api.mutations).toEqual([]);
+  });
+
+  test('edit.append without content rejects without touching the vault', async () => {
+    const response = await router.route({
+      operation: 'edit',
+      action: 'append',
+      params: { path: 'existing.md' },
+    });
+    expect((response as any).error).toBeDefined();
+    expect(api.mutations).toEqual([]);
+    expect((await api.getFile('existing.md')).content).toBe('original');
+  });
+
+  test('edit.window without oldText/newText rejects before searching the file', async () => {
+    const response = await router.route({
+      operation: 'edit',
+      action: 'window',
+      params: { path: 'existing.md' },
+    });
+    expect((response as any).error).toBeDefined();
+    expect(api.mutations).toEqual([]);
+  });
+
+  test('edit.* without path rejects before taking a file lock', async () => {
+    const response = await router.route({
+      operation: 'edit',
+      action: 'append',
+      params: { content: 'whatever' },
+    });
+    expect((response as any).error).toBeDefined();
+    expect(api.mutations).toEqual([]);
+  });
+
+  // Belt-and-suspenders for the second fix in #210: even if a guard ever
+  // misses, the response carries `path` so the formatter can't render
+  // "Updated: undefined" to the user.
+  test('updateFile success response includes path for the formatter', async () => {
+    const result = await api.updateFile('existing.md', 'x');
+    expect(result).toMatchObject({ success: true, path: 'existing.md' });
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #210 — `vault.update` with missing `content` was writing the literal 9-byte string `"undefined"` to the target file, with a nominal-success response (`✓ Updated: undefined`).
- Fixes the **class** of bug, not just the instance: the same `String(params.x)` footgun existed at every vault-mutating dispatch site. `edit.append` would have appended `"undefined"`; `edit.window` would have searched for or replaced with `"undefined"`. Path-only `String(params.path)` sites (view, edit.patch, edit.at_line, edit.from_buffer) produced cryptic "File not found: undefined" instead of a clean dispatch rejection.
- Adds `requireParamStr(params, key, action, hint?)` in `operations/shared.ts` — throws at the MCP boundary when a required string param is missing or wrong-typed, so a malformed call cannot reach a vault sink. Sweeps all affected dispatch sites in `vault.ts` and `router.ts`.
- `vault.update`'s `content` guard carries a hint pointing at `vault.patch` / `edit.window` — that's the wrong-tool path that produced the corruption in the wild.
- Lifts `edit.*`'s path guard above `FileLockManager.withLock` so a missing path can't take a lock on the literal string `"undefined"`.
- `updateFile` / `deleteFile` now return `{ success, path }` so `formatFileWrite` renders `Updated: <path>` instead of `Updated: undefined` — belt-and-suspenders for the second issue called out in #210.

## Files changed

- `src/semantic/operations/shared.ts` — `requireParamStr` helper
- `src/semantic/operations/vault.ts` — guards on `create` / `update` / `delete`
- `src/semantic/router.ts` — guards on `edit.window`, `edit.append`, `edit.patch`, `edit.at_line`, `edit.from_buffer`, `view.file`, `view.window`, `view.open_in_obsidian`; lock-key guard hoisted
- `src/utils/obsidian-api.ts` — `updateFile` / `deleteFile` return `path`
- `tests/dispatch-param-guards.test.ts` — new regression suite (9 cases)

## Test plan

- [x] `npm test` — 305/305 across 24 suites, including the new 9
- [x] `npm run build` — type-checks clean
- [x] `npm run lint` — no new warnings (5 pre-existing, unrelated to this change in `main.ts` / `image-handler.ts`)
- [x] Confirmed the exact `#210` reproduction shape (`{action:"update", path, mode, search, replacement}` with no `content`) now throws before any `vault.modify` call — verified by recording-API test that asserts zero mutations on the malformed call AND that `existing.md` content is untouched.
- [ ] Manual smoke against a live Obsidian vault — the unit tests prove the guard runs; would be nice to confirm a real client sees the new error message and recovery hint. Happy to do that if requested before merge.

Closes #210.