### PR TITLE
feat(graph): vault-wide statistics when sourcePath omitted (closes #132)

### DIFF
--- a/src/tools/graph-search.ts
+++ b/src/tools/graph-search.ts
@@ -63,6 +63,14 @@ export interface GraphSearchResult {
     unresolvedCount: number;
     tagCount: number;
   };
+  vaultStatistics?: {
+    totalNotes: number;
+    totalLinks: number;
+    orphanCount: number;
+    averageDegree: number;
+    largestComponentSize: number;
+    isolatedClusters: number;
+  };
   graphStats?: {
     totalNodes: number;
     totalEdges: number;
@@ -315,11 +323,32 @@ export class GraphSearchTool {
   }
 
   /**
-   * Get link statistics for a file
+   * Get link statistics — vault-wide when sourcePath is omitted (#132),
+   * per-node when sourcePath is provided.
    */
   private getStatistics(params: GraphSearchParams): GraphSearchResult {
     if (!params.sourcePath) {
-      throw new Error('Source path is required for statistics operation');
+      const vaultStats = this.graphTraversal.getVaultStatistics();
+      return {
+        operation: 'statistics',
+        vaultStatistics: vaultStats,
+        message: `Vault-wide statistics: ${vaultStats.totalNotes} notes, ${vaultStats.totalLinks} links, ${vaultStats.orphanCount} orphans, ${vaultStats.isolatedClusters} components`,
+        workflow: {
+          message: 'Vault statistics retrieved. You can drill into specific files or explore the largest component.',
+          suggested_next: [
+            {
+              description: 'Get per-node statistics for a specific file',
+              command: 'graph:statistics',
+              reason: 'Pass sourcePath to see degree/tag counts for one note'
+            },
+            {
+              description: 'Traverse from a known hub',
+              command: 'graph:traverse',
+              reason: 'Explore the connected structure of the largest component'
+            }
+          ]
+        }
+      };
     }
 
     const stats = this.graphTraversal.getNodeStatistics(params.sourcePath);
@@ -327,7 +356,7 @@ export class GraphSearchTool {
     const title = file instanceof TFile
       ? this.graphTraversal.getNodeTitle(file)
       : params.sourcePath;
-    
+
     return {
       operation: 'statistics',
       sourcePath: params.sourcePath,
@@ -343,7 +372,7 @@ export class GraphSearchTool {
           },
           {
             description: 'Get forward links',
-            command: 'graph:forwardlinks', 
+            command: 'graph:forwardlinks',
             reason: `To see the ${stats.outDegree} files this file links to`
           },
           {

--- a/src/utils/graph-traversal.ts
+++ b/src/utils/graph-traversal.ts
@@ -482,6 +482,83 @@ export class GraphTraversal {
   }
 
   /**
+   * Calculate vault-wide graph statistics.
+   *
+   * Treats the graph as undirected for component analysis (a link from A to B
+   * means A and B are in the same component) while keeping link counts directed
+   * (each resolved-link occurrence is one totalLink, matching how Obsidian's
+   * metadataCache exposes them). Orphans are nodes with no resolved links in
+   * either direction. isolatedClusters is the total connected-component count,
+   * inclusive of singletons — derive non-trivial cluster count as
+   * `isolatedClusters - orphanCount` if needed.
+   *
+   * O(V + E) over the resolvedLinks adjacency, single pass.
+   */
+  getVaultStatistics(): {
+    totalNotes: number;
+    totalLinks: number;
+    orphanCount: number;
+    averageDegree: number;
+    largestComponentSize: number;
+    isolatedClusters: number;
+  } {
+    const mdFiles = this.app.vault.getFiles().filter(f => f.extension === 'md');
+    const totalNotes = mdFiles.length;
+
+    const resolved = this.app.metadataCache.resolvedLinks ?? {};
+    const adjacency = new Map<string, Set<string>>();
+    for (const file of mdFiles) {
+      adjacency.set(file.path, new Set());
+    }
+
+    let totalLinks = 0;
+    for (const [source, targets] of Object.entries(resolved)) {
+      if (!adjacency.has(source)) continue;
+      const sourceSet = adjacency.get(source)!;
+      for (const [target, count] of Object.entries(targets)) {
+        if (!adjacency.has(target)) continue;
+        sourceSet.add(target);
+        adjacency.get(target)!.add(source);
+        totalLinks += count;
+      }
+    }
+
+    const visited = new Set<string>();
+    const componentSizes: number[] = [];
+    for (const start of adjacency.keys()) {
+      if (visited.has(start)) continue;
+      let size = 0;
+      const queue: string[] = [start];
+      while (queue.length > 0) {
+        const node = queue.pop()!;
+        if (visited.has(node)) continue;
+        visited.add(node);
+        size++;
+        for (const neighbor of adjacency.get(node)!) {
+          if (!visited.has(neighbor)) queue.push(neighbor);
+        }
+      }
+      componentSizes.push(size);
+    }
+
+    const orphanCount = componentSizes.filter(s => s === 1).length;
+    const largestComponentSize = componentSizes.length > 0
+      ? Math.max(...componentSizes)
+      : 0;
+    const isolatedClusters = componentSizes.length;
+    const averageDegree = totalNotes > 0 ? (totalLinks * 2) / totalNotes : 0;
+
+    return {
+      totalNotes,
+      totalLinks,
+      orphanCount,
+      averageDegree,
+      largestComponentSize,
+      isolatedClusters,
+    };
+  }
+
+  /**
    * Calculate graph statistics for a file
    */
   getNodeStatistics(filePath: string): {

--- a/tests/graph-statistics-vault-wide.test.ts
+++ b/tests/graph-statistics-vault-wide.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for #132 — graph.statistics with optional sourcePath.
+ *
+ * Mocks vault.getFiles() and metadataCache.resolvedLinks so the
+ * vault-wide aggregation runs deterministically against a known
+ * adjacency. Per-node stats coverage stays intact.
+ */
+import { App, TFile } from 'obsidian';
+import { GraphSearchTool } from '../src/tools/graph-search';
+import { GraphTraversal } from '../src/utils/graph-traversal';
+import { ObsidianAPI } from '../src/utils/obsidian-api';
+
+function makeFile(path: string, extension = 'md'): TFile {
+  const file = new TFile();
+  file.path = path;
+  file.name = path.split('/').pop() ?? path;
+  file.basename = file.name.replace(new RegExp(`\\.${extension}$`), '');
+  file.extension = extension;
+  return file;
+}
+
+function buildApp(opts: {
+  files: TFile[];
+  resolvedLinks?: Record<string, Record<string, number>>;
+}): App {
+  const app = new App();
+  (app as any).metadataCache = {
+    resolvedLinks: opts.resolvedLinks ?? {},
+    unresolvedLinks: {},
+    getFileCache: jest.fn().mockReturnValue({ tags: [] }),
+  };
+  app.vault.getFiles = jest.fn(() => opts.files);
+  const byPath = new Map(opts.files.map(f => [f.path, f]));
+  app.vault.getAbstractFileByPath = jest.fn((p: string) => byPath.get(p) ?? null);
+  return app;
+}
+
+describe('graph.statistics — vault-wide (#132)', () => {
+  // Topology:
+  //   A → B, A → C  (one component of size 3)
+  //   D → E         (one component of size 2)
+  //   F             (orphan)
+  // = 3 components, 1 orphan, largest = 3, totalLinks = 3
+  const A = makeFile('a.md');
+  const B = makeFile('b.md');
+  const C = makeFile('c.md');
+  const D = makeFile('d.md');
+  const E = makeFile('e.md');
+  const F = makeFile('f.md');
+
+  let tool: GraphSearchTool;
+
+  beforeEach(() => {
+    const app = buildApp({
+      files: [A, B, C, D, E, F],
+      resolvedLinks: {
+        'a.md': { 'b.md': 1, 'c.md': 1 },
+        'd.md': { 'e.md': 1 },
+      },
+    });
+    tool = new GraphSearchTool({} as ObsidianAPI, app);
+  });
+
+  it('returns vaultStatistics when sourcePath is omitted', () => {
+    const result = tool.search({ operation: 'statistics' });
+
+    expect(result.statistics).toBeUndefined();
+    expect(result.vaultStatistics).toEqual({
+      totalNotes: 6,
+      totalLinks: 3,
+      orphanCount: 1,
+      averageDegree: 1, // 2 * 3 / 6
+      largestComponentSize: 3,
+      isolatedClusters: 3,
+    });
+    expect(result.message).toContain('6 notes');
+    expect(result.message).toContain('1 orphans');
+  });
+
+  it('still returns per-node statistics when sourcePath is provided', () => {
+    const result = tool.search({ operation: 'statistics', sourcePath: 'a.md' });
+
+    expect(result.vaultStatistics).toBeUndefined();
+    expect(result.statistics).toMatchObject({
+      outDegree: 2,
+      inDegree: 0,
+      totalDegree: 2,
+    });
+    expect(result.sourcePath).toBe('a.md');
+  });
+
+  it('counts repeated occurrences in totalLinks (Obsidian semantics)', () => {
+    // A → B appears 3 times in the same file → counts as 3 totalLinks.
+    const app = buildApp({
+      files: [A, B],
+      resolvedLinks: { 'a.md': { 'b.md': 3 } },
+    });
+    const t = new GraphSearchTool({} as ObsidianAPI, app);
+
+    const result = t.search({ operation: 'statistics' });
+    expect(result.vaultStatistics).toMatchObject({
+      totalNotes: 2,
+      totalLinks: 3,
+      isolatedClusters: 1,
+      largestComponentSize: 2,
+    });
+  });
+
+  it('handles an empty vault without dividing by zero', () => {
+    const app = buildApp({ files: [], resolvedLinks: {} });
+    const t = new GraphSearchTool({} as ObsidianAPI, app);
+
+    const result = t.search({ operation: 'statistics' });
+    expect(result.vaultStatistics).toEqual({
+      totalNotes: 0,
+      totalLinks: 0,
+      orphanCount: 0,
+      averageDegree: 0,
+      largestComponentSize: 0,
+      isolatedClusters: 0,
+    });
+  });
+
+  it('ignores non-markdown files in totalNotes', () => {
+    const image = makeFile('img.png', 'png');
+    const app = buildApp({
+      files: [A, B, image],
+      resolvedLinks: { 'a.md': { 'b.md': 1 } },
+    });
+    const t = new GraphSearchTool({} as ObsidianAPI, app);
+
+    const result = t.search({ operation: 'statistics' });
+    expect(result.vaultStatistics?.totalNotes).toBe(2);
+  });
+
+  it('treats the graph as undirected for component counting', () => {
+    // B → A and A → B both link A↔B; they're one component, not two.
+    const app = buildApp({
+      files: [A, B],
+      resolvedLinks: {
+        'a.md': { 'b.md': 1 },
+        'b.md': { 'a.md': 1 },
+      },
+    });
+    const t = new GraphSearchTool({} as ObsidianAPI, app);
+
+    const result = t.search({ operation: 'statistics' });
+    expect(result.vaultStatistics).toMatchObject({
+      isolatedClusters: 1,
+      largestComponentSize: 2,
+      totalLinks: 2,
+    });
+  });
+});
+
+describe('GraphTraversal.getVaultStatistics', () => {
+  it('returns zeros for an empty vault', () => {
+    const app = buildApp({ files: [], resolvedLinks: {} });
+    const traversal = new GraphTraversal(app);
+    expect(traversal.getVaultStatistics()).toEqual({
+      totalNotes: 0,
+      totalLinks: 0,
+      orphanCount: 0,
+      averageDegree: 0,
+      largestComponentSize: 0,
+      isolatedClusters: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #132. \`graph.statistics\` previously threw \`Source path is required\` when called without \`sourcePath\`, blocking the baseline use case (vault-health snapshots, dashboards). Users had to pick an arbitrary seed and reason about its neighborhood, which isn't representative of the vault.

When \`sourcePath\` is omitted, the operation now returns a new \`vaultStatistics\` shape (per the issue's proposal):

| Field | Meaning |
|---|---|
| \`totalNotes\` | Count of \`.md\` files in the vault |
| \`totalLinks\` | Sum of resolved link occurrences — Obsidian semantics: A→B referenced 3× counts as 3 |
| \`orphanCount\` | Singletons (no resolved links in either direction) |
| \`averageDegree\` | \`2 * totalLinks / totalNotes\` |
| \`largestComponentSize\` | Biggest connected subgraph (treated as undirected) |
| \`isolatedClusters\` | Total connected-component count, inclusive of singletons (non-trivial = \`isolatedClusters - orphanCount\`) |

Per-node statistics behavior is unchanged when \`sourcePath\` is provided.

## Implementation

- \`GraphTraversal.getVaultStatistics()\` — one O(V+E) pass over the \`resolvedLinks\` adjacency, plus BFS for components. Treats the graph as undirected for component analysis (a link from A to B means A and B are in the same component) while keeping link counts directed (matches how \`metadataCache.resolvedLinks\` exposes them).
- \`GraphSearchTool.getStatistics()\` — branches on \`!sourcePath\` and returns the vault-wide shape with a different message + workflow hints. Throw-on-missing path removed.
- \`GraphSearchResult.vaultStatistics?\` — added alongside existing \`statistics?\` rather than overloading, since the shapes are genuinely different and a discriminated union would just push the question to consumers.

## Tests

\`tests/graph-statistics-vault-wide.test.ts\` (7 cases):
- vault-wide path with a known 3-component topology (A→B,C / D→E / F orphan) → asserts exact \`vaultStatistics\` values
- per-node path with \`sourcePath\` still returns the old \`statistics\` shape
- repeated occurrences count toward \`totalLinks\` (Obsidian semantics)
- empty vault: no divide-by-zero, all zeros returned
- non-\`.md\` files excluded from \`totalNotes\`
- bidirectional links collapse to one undirected component

## Test plan

- [x] \`npm run build\` — type-checks clean
- [x] \`npm test\` — 319/319 across 27 suites (was 312 before, +7 new)
- [x] \`npm run lint\` — no new errors (5 pre-existing warnings unchanged)
- [ ] Live MCP smoke against the running vault — needs this release shipped first to update the local plugin