### PR TITLE
fix(dataview): unwrap query() Result monad + bridge status shape (closes #216)

### DIFF
--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -363,6 +363,26 @@ function normalizeResponse(key: string, response: unknown): NormalizedResponse {
       };
     }
 
+    // dataview.status: detector returns {installed, enabled, apiReady, version},
+    // formatter expects {available, version}. Without this bridge the formatter
+    // reads a non-existent `available` field and always renders "not available"
+    // even when Dataview is fully ready (#216). Treat apiReady as the source of
+    // truth (it already implies installed + enabled), falling back to the
+    // conjunction for older status shapes.
+    case 'dataview.status': {
+      const s = resp as {
+        installed?: boolean;
+        enabled?: boolean;
+        apiReady?: boolean;
+        available?: boolean;
+        version?: string;
+      };
+      return {
+        available: s.available ?? s.apiReady ?? (Boolean(s.installed) && Boolean(s.enabled)),
+        version: s.version
+      };
+    }
+
     // edit.window: router returns {isError, content}, formatter expects {success, path}
     case 'edit.window':
     case 'edit.from_buffer': {

--- a/src/tools/dataview-tool.ts
+++ b/src/tools/dataview-tool.ts
@@ -43,6 +43,21 @@ function toIsoOptional(value: unknown): string | undefined {
   return undefined;
 }
 
+/**
+ * Coerce a Dataview `values` field to a plain array.
+ *
+ * Dataview's `query()` returns plain arrays (`Literal[]` / `Literal[][]`), but
+ * other API surfaces (`pages()`, `page().file.*`) hand back wrapped `DataArray`
+ * collections that expose `.array()`. Accepting either keeps the query path
+ * correct while staying defensive against version drift.
+ */
+function toPlainArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  const wrapped = value as { array?: () => unknown[] } | null | undefined;
+  if (wrapped && typeof wrapped.array === 'function') return wrapped.array();
+  return [];
+}
+
 /** Dataview link value */
 interface DataviewLink {
   path: string;
@@ -80,12 +95,24 @@ interface DataviewPage {
   [key: string]: unknown;
 }
 
-/** Query result from dataviewAPI.query() */
+/**
+ * Query result from `dataviewAPI.query()`.
+ *
+ * Dataview resolves `query()` to a `Result` monad — `{ successful, value, error }`
+ * — NOT a flat `{ type, values }` object. The actual query payload (type /
+ * values / headers) lives under `.value`, and `value.values` is a *plain*
+ * array (`Literal[]` / `Literal[][]`), not a wrapped `DataArray` with `.array()`.
+ * Modelling this faithfully is what fixes #216: reading `result.type` /
+ * `result.values` directly yields `undefined`, collapsing every query to the
+ * `unknown`/"No results found" branch.
+ */
 interface DataviewQueryResult {
   successful?: boolean;
-  type: string;
-  values?: DataviewArray;
-  headers?: string[];
+  value?: {
+    type: string;
+    values?: unknown;
+    headers?: string[];
+  };
   error?: string;
 }
 
@@ -185,7 +212,7 @@ export class DataviewTool {
           query,
           format,
           result: this.formatQueryResult(result),
-          type: result.type || 'unknown',
+          type: result.value?.type || 'unknown',
           error: innerSuccess ? undefined : result.error,
           workflow: this.generateQueryWorkflow(query, result),
           hints: this.generateQueryHints(query)
@@ -338,26 +365,31 @@ export class DataviewTool {
   private formatQueryResult(result: DataviewQueryResult): FormattedQueryResult | null {
     if (!result) return null;
 
+    // Unwrap Dataview's Result monad: the typed payload lives under `.value`.
+    // A failed query (`successful: false`) carries no `value`.
+    const payload = result.value;
+    if (!payload) return null;
+
     // Handle different result types
-    switch (result.type) {
+    switch (payload.type) {
       case 'list':
         return {
           type: 'list',
-          values: result.values?.array() ?? []
+          values: toPlainArray(payload.values)
         };
       case 'table':
         return {
           type: 'table',
-          headers: result.headers ?? [],
-          values: result.values?.array()?.map((row: unknown) => {
+          headers: payload.headers ?? [],
+          values: toPlainArray(payload.values).map((row: unknown) => {
             const tableRow = row as DataviewTableRow;
             return typeof tableRow?.array === 'function' ? tableRow.array() : row;
-          }) ?? []
+          })
         };
       case 'task':
         return {
           type: 'task',
-          values: result.values?.array()?.map((task: unknown) => {
+          values: toPlainArray(payload.values).map((task: unknown) => {
             const dvTask = task as DataviewTask;
             return {
               text: dvTask.text,
@@ -365,12 +397,12 @@ export class DataviewTool {
               line: dvTask.line,
               path: dvTask.path
             };
-          }) ?? []
+          })
         };
       case 'calendar':
         return {
           type: 'calendar',
-          values: result.values?.array() ?? []
+          values: toPlainArray(payload.values)
         };
       default:
         return {

--- a/tests/dataview-integration.test.ts
+++ b/tests/dataview-integration.test.ts
@@ -1,5 +1,6 @@
 import { DataviewTool, isDataviewToolAvailable } from '../src/tools/dataview-tool';
 import { PluginDetector } from '../src/utils/plugin-detector';
+import { formatResponse } from '../src/formatters';
 
 /**
  * Mock Obsidian App for testing
@@ -36,24 +37,29 @@ class MockApp {
  */
 class MockDataviewAPI {
   query(query: string) {
-    // Mock DQL query execution
+    // Mock DQL query execution. Dataview's real query() resolves to a Result
+    // monad — { successful, value, error } — where value.values is a PLAIN
+    // array (not a wrapped DataArray). The previous mock used the wrong flat +
+    // wrapped shape, which is why CI stayed green while real Dataview broke (#216).
     if (query.includes('LIST')) {
       return {
-        type: 'list',
-        values: {
-          array: () => ['Note 1', 'Note 2', 'Note 3']
+        successful: true,
+        value: {
+          type: 'list',
+          values: ['Note 1', 'Note 2', 'Note 3']
         }
       };
     }
-    
+
     if (query.includes('TABLE')) {
       return {
-        type: 'table',
-        headers: ['Name', 'Created', 'Tags'],
-        values: {
-          array: () => [
-            { array: () => ['Note 1', '2024-01-01', '#tag1'] },
-            { array: () => ['Note 2', '2024-01-02', '#tag2'] }
+        successful: true,
+        value: {
+          type: 'table',
+          headers: ['Name', 'Created', 'Tags'],
+          values: [
+            ['Note 1', '2024-01-01', '#tag1'],
+            ['Note 2', '2024-01-02', '#tag2']
           ]
         }
       };
@@ -346,9 +352,10 @@ describe('Dataview Integration', () => {
       const tool = new DataviewTool(api as any);
 
       const dvApi = (app.plugins.plugins['dataview'] as any).api as MockDataviewAPI;
+      // A failed Dataview query resolves the Result monad with no `value`,
+      // only `{ successful: false, error }`.
       dvApi.query = (() => ({
         successful: false,
-        type: 'table',
         error: 'No field "nonexistent" on this page'
       })) as any;
 
@@ -369,6 +376,50 @@ describe('Dataview Integration', () => {
       const invalidResult = await tool.validateQuery('INVALID QUERY') as any;
       expect(invalidResult.valid).toBe(false);
       expect(invalidResult.error).toContain('Query must start with one of');
+    });
+  });
+
+  // #216: the formatted (non-raw) output is what MCP clients see by default.
+  // These exercise the full producer → formatResponse() path that was broken,
+  // not just the raw envelope (which already worked).
+  describe('Formatted output (#216)', () => {
+    test('dataview.query LIST renders results, not "UNKNOWN"/"No results found"', async () => {
+      const app = new MockApp(true, true);
+      const api = new MockObsidianAPI(app);
+      const tool = new DataviewTool(api as any);
+
+      const queryResult = await tool.executeQuery('LIST FROM #tag');
+      const output = formatResponse('dataview', 'query', queryResult, false);
+
+      expect(output).toContain('Dataview: LIST');
+      expect(output).not.toContain('UNKNOWN');
+      expect(output).not.toContain('No results found');
+      expect(output).toContain('Note 1');
+    });
+
+    test('dataview.query TABLE renders its rows', async () => {
+      const app = new MockApp(true, true);
+      const api = new MockObsidianAPI(app);
+      const tool = new DataviewTool(api as any);
+
+      const queryResult = await tool.executeQuery('TABLE name FROM #tag');
+      const output = formatResponse('dataview', 'query', queryResult, false);
+
+      expect(output).toContain('Dataview: TABLE');
+      expect(output).not.toContain('No results found');
+      expect(output).toContain('Note 1');
+    });
+
+    test('dataview.status renders "available" when the plugin is ready', () => {
+      const app = new MockApp(true, true);
+      const api = new MockObsidianAPI(app);
+      const tool = new DataviewTool(api as any);
+
+      const output = formatResponse('dataview', 'status', tool.getStatus(), false);
+
+      expect(output).toContain('✓ Dataview plugin is available');
+      expect(output).not.toContain('✗ Dataview plugin is not available');
+      expect(output).toContain('0.5.64');
     });
   });
 


### PR DESCRIPTION
Closes #216.

## Root cause

Both reported failures trace to the tool misreading Dataview's actual API shape — not, as the issue title supposed, the formatter dispatcher (the dispatcher can't recover the data; the producer has already discarded it).

Dataview's `query()` resolves to a **`Result` monad**: `{ successful, value: { type, values, headers }, error }`, where `value.values` is a **plain array** (`Literal[]` / `Literal[][]`). The tool modelled the return as a flat `{ type, values }` with a wrapped `DataArray`:

- **`dataview.query`** — `formatQueryResult()` switched on `result.type` (undefined; it's `result.value.type`) → `unknown` branch → `# Dataview: UNKNOWN`; and called `result.values?.array()` (undefined; it's `result.value.values`, already a plain array) → `[]` → `No results found`.
- **`dataview.status`** — `getDataviewStatus()` returns `{ installed, enabled, apiReady, version }`, but `formatDataviewStatus` reads `response.available` → always `✗ ... not available`.

The `raw: true` envelope looked partly fine, which masked how broken the default formatted path was.

## Why CI didn't catch it

The test mock encoded the **same wrong flat+wrapped shape** as the code, so unit tests passed while real Dataview v0.5.68 failed. The mock is now corrected to the real monad shape, and the failing scenario is locked in.

## Changes

- Re-model `DataviewQueryResult` as the real `Result` monad; read the payload from `.value`.
- Add a `toPlainArray()` helper — accepts plain arrays (real API) and wrapped `DataArray`s (defensive against version drift).
- Add a `dataview.status` normalizer (`apiReady` → `available`).
- Correct the test mock to the real shape; add formatted-output regression tests through `formatResponse()` for query (LIST/TABLE) and status.

## Verification

- `npm run build` ✅ · `npm run lint` ✅ (0 errors) · `npm test` ✅ (322 passed, +3 new #216 regression tests)

## Out of scope (follow-up)

The same flat-shape mismatch likely also breaks the **non-raw** formatted output of `dataview.list` and `dataview.metadata` (their `formatResponse` dispatch routes through `formatDataviewQuery`, which reads `values`, while `listPages`/`getPageMetadata` return `pages`/`metadata`). Not reported in #216 and unverified against live Dataview, so left for a separate issue rather than widening this PR.