### PR TITLE
fix: pass Obsidian review — drop deprecated setWarning (closes the 0.11.33 gating Error)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1030,12 +1030,11 @@ class MCPSettingTab extends PluginSettingTab {
 			.addButton(button => button
 				.setButtonText('Regenerate')
 				.setTooltip('Generate a new API key')
-				// setDestructive() (the non-deprecated replacement) requires Obsidian
-				// 1.13.0, but our manifest minAppVersion is 1.6.6, so it's not available
-				// to all supported users. Keep setWarning() until minAppVersion is raised
-				// (tracked with the 1.13.0 API adoption in #224).
-				// eslint-disable-next-line @typescript-eslint/no-deprecated
-				.setWarning()
+				// Apply the destructive-button style directly. setWarning() is
+				// deprecated (1.13.0) and setDestructive() requires 1.13.0 > our
+				// minAppVersion 1.6.6; 'mod-warning' is the class both apply and is
+				// available on all supported versions. Full 1.13.0 adoption: #224.
+				.setClass('mod-warning')
 				.onClick(() => {
 					new ConfirmationModal(
 						this.app,


### PR DESCRIPTION
## Problem

The 0.11.33 dev review failed (fail-fast) at `src/main.ts:1037`:
- `Disabling '@typescript-eslint/no-deprecated' is not allowed`
- `Unexpected undescribed directive comment`

This was the scoped `eslint-disable` added in #225 for the `setWarning()` button. Obsidian's review forbids disabling `no-deprecated` outright — so suppression isn't an option.

## Fix

`setWarning()` is deprecated (1.13.0); `setDestructive()` requires 1.13.0 > our minAppVersion 1.6.6 (`no-unsupported-api`). Both blocked. Instead apply the `mod-warning` CSS class directly via `setClass()` — non-deprecated (`@since 0.9.7`), identical destructive styling, no suppression, valid on all supported Obsidian versions.

Swept the rest: remaining inline disables (`no-require-imports`, `no-control-regex`) are described and not on the forbidden-rule list — they passed in 0.11.32 and aren't gating. **This was the only blocker.**

## Test plan
- `npm run lint` ✅ / `npm run build` ✅ / `npm test` ✅ (336)

Refs #224 (full 1.13.0 API adoption when minAppVersion is raised).