### PR TITLE
feat(settings): surface connect/getting-started section at top

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -597,11 +597,14 @@ class MCPSettingTab extends PluginSettingTab {
 
 		containerEl.empty();
 
-		;
+		// Connect / Getting Started Section — the first thing a user needs:
+		// what this does plus the one-click bundle and client config. Kept at the
+		// top so connection details aren't buried beneath the config sections.
+		this.createProtocolInfoSection(containerEl);
 
 		// Connection Status Section
 		this.createConnectionStatusSection(containerEl);
-		
+
 		// Server Configuration Section
 		this.createServerConfigSection(containerEl);
 
@@ -610,21 +613,18 @@ class MCPSettingTab extends PluginSettingTab {
 
 		// HTTPS Configuration Section
 		this.createHTTPSConfigSection(containerEl);
-		
+
 		// Authentication Section
 		this.createAuthenticationSection(containerEl);
-		
+
 		// Security Section
 		this.createSecuritySection(containerEl);
-		
+
 		// Tool Visibility Section
 		this.createToolVisibilitySection(containerEl);
 
 		// UI Options Section
 		this.createUIOptionsSection(containerEl);
-
-		// Protocol Information Section (always show)
-		this.createProtocolInfoSection(containerEl);
 	}
 
 	private createConnectionStatusSection(containerEl: HTMLElement): void {
@@ -1496,7 +1496,7 @@ class MCPSettingTab extends PluginSettingTab {
 	}
 
 	private createProtocolInfoSection(containerEl: HTMLElement): void {
-		new Setting(containerEl).setName("Mcp protocol information").setHeading();
+		new Setting(containerEl).setName("Getting started — connect a client").setHeading();
 		
 		const info = containerEl.createDiv('mcp-protocol-info');
 		


### PR DESCRIPTION
## Changes

- Move the connect / getting-started block (`createProtocolInfoSection`) to render **first** in the settings tab — ahead of Connection status and the config sections. The one-click MCPB bundle download, Claude Code config, and advanced client config are now the first thing a user sees instead of being buried at the bottom.
- Rename its heading `"Mcp protocol information"` → `"Getting started — connect a client"` to match the content.

## Notes

- Stays on the sanctioned `display()`→`render()` fallback; `minAppVersion` unchanged at 1.6.6. Adopting the declarative `getSettingDefinitions()` API would force a 1.13.0 bump (gated by `obsidianmd/no-unsupported-api`), dropping older-Obsidian users — declined for now. Declarative migration remains tracked in #224, which now carries a note to preserve this connect-first ordering.
- `npm run build` passes.

https://claude.ai/code/session_011yowKCMFCBp61DRBu5xQm4