### PR TITLE
ci(release): note Claude Desktop .mcpb re-import in generated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           # (backticks, $vars, etc. in the notes must NOT be evaluated).
           RELEASE_NOTES_INPUT: ${{ inputs.release_notes }}
         run: |
-          NOTES=$(printf '## %s %s\n\n%s\n\n### Installation via BRAT\n1. Install the BRAT plugin if you haven'\''t already\n2. Command palette → "BRAT: Add a beta plugin for testing"\n3. Enter: `aaronsb/obsidian-mcp-plugin`\n4. Enable the plugin in Community Plugins\n' "$RELEASE_NAME" "$RELEASE_VERSION" "$RELEASE_NOTES_INPUT")
+          NOTES=$(printf '## %s %s\n\n%s\n\n### Claude Desktop (.mcpb connector)\nIf you connect Claude Desktop via the `.mcpb` bundle, re-import `obsidian-mcp.mcpb` from this release to update the connector — BRAT updates only the Obsidian plugin, not the Desktop bridge.\n\n### Installation via BRAT (Obsidian plugin)\n1. Install the BRAT plugin if you haven'\''t already\n2. Command palette → "BRAT: Add a beta plugin for testing"\n3. Enter: `aaronsb/obsidian-mcp-plugin`\n4. Enable the plugin in Community Plugins\n' "$RELEASE_NAME" "$RELEASE_VERSION" "$RELEASE_NOTES_INPUT")
 
           gh release create "$RELEASE_VERSION" \
             --title "$RELEASE_NAME $RELEASE_VERSION" \


### PR DESCRIPTION
## Why

The `.mcpb` bridge ships inside the GitHub release bundle. **BRAT updates only the Obsidian plugin — never the Claude Desktop connector.** This session's session-recovery fixes (#243/#247) live *in the bridge*, so a user who updated the plugin via BRAT but didn't re-import the `.mcpb` would not get them — with no signal that they needed to. (This bit us live during 0.11.36 validation.)

## What

Adds a standing **"Claude Desktop (.mcpb connector)"** section to the release workflow's notes template (`.github/workflows/release.yml`), so *every* generated release tells `.mcpb` users to re-import — instead of relying on the per-release `RELEASE_NOTES` input remembering to. Also labels the existing section "Installation via BRAT (Obsidian plugin)" for contrast.

Verified: `release.yml` still parses (YAML), and the `printf` renders the expected markdown.

The 0.11.36 release notes already carry a richer one-off version of this callout (manually edited); this makes the baseline automatic going forward.

https://claude.ai/code/session_011yowKCMFCBp61DRBu5xQm4