### PR TITLE
docs: rewrite community-directory short description

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "semantic-vault-mcp",
   "name": "Semantic Notes Vault MCP",
   "minAppVersion": "1.6.6",
-  "description": "Give Claude Desktop and other AI assistants semantic access to your notes through a built-in Model Context Protocol (MCP) server.",
+  "description": "Read, write, search, and traverse your vault from Claude Desktop and any AI assistant — via an MCP server built into Obsidian, no external server to run.",
   "author": "Aaron Bockelie",
   "authorUrl": "https://github.com/aaronsb",
   "fundingUrl": "https://github.com/sponsors/aaronsb",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian-mcp-plugin",
   "version": "0.11.37",
-  "description": "Give Claude Desktop and other AI assistants semantic access to your notes through a built-in Model Context Protocol (MCP) server.",
+  "description": "Read, write, search, and traverse your vault from Claude Desktop and any AI assistant — via an MCP server built into Obsidian, no external server to run.",
   "main": "main.js",
   "scripts": {
     "dev": "node esbuild.config.mjs",


### PR DESCRIPTION
Rewrites the `package.json` short description (the one-liner shown in Obsidian's in-app community browser — where cold discovery happens) to match the repositioned README from #256.

**Before:** "Give Claude Desktop and other AI assistants **semantic** access to your notes through a built-in **Model Context Protocol (MCP)** server."

**After:** "Read, write, search, and traverse your vault from Claude Desktop and any AI assistant — via an MCP server built into Obsidian, no external server to run."

Verb-first, native/no-server edge stated, "semantic" and the MCP-explainer dropped. Set via `make set-description` (SoT: `package.json` → synced to `manifest.json`). Ships in the next patch release; the directory one-liner refreshes on Obsidian's next portal scan.

Note: `mcpb/manifest.json` keeps its own separate description (the Claude Desktop connector surface) by design — not touched here.
