### PR TITLE
docs(mcpb): align .mcpb connector description with new positioning

### DIFF
--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "name": "obsidian-mcp",
   "display_name": "Obsidian MCP",
   "version": "0.11.38",
-  "description": "Connect Claude Desktop to your Obsidian vault via the Obsidian MCP plugin.",
+  "description": "Read, write, search, and traverse your Obsidian vault from Claude Desktop — bridges to the MCP server built into the Obsidian plugin.",
   "long_description": "Bridges Claude Desktop to the HTTP MCP server exposed by the Obsidian MCP plugin running inside Obsidian. Open Obsidian first, enable the MCP plugin in Settings, copy the URL and API key from the plugin's Settings tab, then paste them into the install prompt below.",
   "author": {
     "name": "Aaron Bockelie",


### PR DESCRIPTION
Aligns the last inconsistent description surface. The `.mcpb` bundle's `description` field shows in **Claude Desktop's connector UI** — a different surface from the Obsidian community-directory one-liner, hand-maintained in `mcpb/manifest.json` (not touched by `make set-description`).

**Before:** "Connect Claude Desktop to your Obsidian vault via the Obsidian MCP plugin."

**After:** "Read, write, search, and traverse your Obsidian vault from Claude Desktop — bridges to the MCP server built into the Obsidian plugin."

Verb-first and consistent with the README (#256) and directory description (#257), while staying accurate to the bundle's role — it's the *bridge* to the in-plugin MCP server, not the server itself. `long_description` (the setup instructions shown in Claude Desktop's install prompt) is already accurate and left as-is.

Ships in the next patch release so the corrected description reaches the `.mcpb` asset users download.
