### PR TITLE
docs(claude-md): correct stale About claim — it's repo-extracted from the README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,10 +419,20 @@ matching stable release tag's assets, not from a scanned branch.
   `package.json`; `sync-version.mjs` propagates it to `manifest.json`; use
   `make set-description DESC='...'` (never hand-edit the JSON). The portal's
   one-liner refreshes on the next scan after release.
-- **Long "About"** — *not* in the repo. Obsidian seeded this portal-side
-  during the community.obsidian.md migration; it is decoupled from
-  `package.json`/`manifest.json` and only editable in the authenticated
-  developer portal. Repo edits will **not** change it — update it there.
+- **Long "About"** — **repo-extracted from the README on scan.** Verified on
+  the 0.11.39 portal scan (2026-07-04): the About rendered the README's
+  top-of-file content — from the "Available in the directory" line through the
+  "New to MCP?" aside — verbatim. This **supersedes** the earlier belief that
+  the About was portal-only and decoupled from the repo: editing the README
+  opening **does** change the About on the next scan. Consequence: the README
+  opening now doubles as the directory About, so author it to read well in
+  *both* places — README-only chrome (the "Available in the directory"
+  self-link, which is circular on the portal; "Quick Start is three steps",
+  which points at a section the About doesn't render) reads awkwardly there.
+  (Historical note: Obsidian *did* seed a decoupled portal-side About during
+  the community.obsidian.md migration; at some point the portal switched to
+  extracting from the README. Trust a fresh scan over this doc if they diverge
+  again.)
 
 ### Reading the scorecard as free signal — `make scorecard`
 


### PR DESCRIPTION
The 0.11.39 portal scan disproved a claim in `CLAUDE.md`.

**What it said:** the community-plugin listing's long "About" is *"not in the repo… decoupled… repo edits will not change it — update it in the developer portal."*

**What the scan showed:** the About rendered the **README's top-of-file content verbatim** — from the "Available in the directory" line through the "New to MCP?" aside. So the portal **extracts the About from the README on scan**; the earlier "portal-only" belief is superseded.

**Why it matters:** I gave the wrong advice twice this session based on that paragraph ("I can't change the About from the repo"). Correcting it so the next session doesn't repeat it. Also records the consequence — the README opening now doubles as the directory About, so README-only chrome (the circular "Available in the directory" self-link; the "Quick Start is three steps" pointer to a section the About doesn't render) reads awkwardly on the portal and is worth tidying in a future README pass.

Docs-only; not shipped in any release.
