### PR TITLE
refactor(router): extract bases operation into operations/ module (#199 stage 2)

### DIFF
--- a/src/semantic/operations/bases.ts
+++ b/src/semantic/operations/bases.ts
@@ -1,0 +1,70 @@
+/**
+ * Bases operation handler — extracted from router.ts (ADR-202, #199).
+ *
+ * Behaviour-preserving move of SemanticRouter.executeBasesOperation. The
+ * router passes itself as the RouterContext, so `ctx.api` is the same
+ * instance as before.
+ */
+import { BaseYAML } from '../../types/bases-yaml';
+import { RouterContext } from './router-context';
+import { Params, paramStr } from './shared';
+
+export async function executeBasesOperation(ctx: RouterContext, action: string, params: Params): Promise<unknown> {
+  switch (action) {
+    case 'list':
+      return await ctx.api.listBases();
+
+    case 'read': {
+      const basePath = paramStr(params, 'path');
+      if (!basePath) {
+        throw new Error('Path parameter is required for reading a base');
+      }
+      return await ctx.api.readBase(basePath);
+    }
+
+    case 'create': {
+      const basePath = paramStr(params, 'path');
+      const config = params.config as BaseYAML | undefined;
+      if (!basePath || !config) {
+        throw new Error('Path and config parameters are required for creating a base');
+      }
+      await ctx.api.createBase(basePath, config);
+      return { success: true, path: basePath };
+    }
+
+    case 'query': {
+      const basePath = paramStr(params, 'path');
+      if (!basePath) {
+        throw new Error('Path parameter is required for querying a base');
+      }
+      return await ctx.api.queryBase(basePath, paramStr(params, 'viewName'));
+    }
+
+    case 'view': {
+      const basePath = paramStr(params, 'path');
+      const viewName = paramStr(params, 'viewName');
+      if (!basePath || !viewName) {
+        throw new Error('Path and viewName parameters are required for getting a base view');
+      }
+      // View is handled by query with viewName
+      return await ctx.api.queryBase(basePath, viewName);
+    }
+
+    case 'export': {
+      const basePath = paramStr(params, 'path');
+      const format = paramStr(params, 'format') as 'csv' | 'json' | 'markdown' | undefined;
+      if (!basePath || !format) {
+        throw new Error('Path and format parameters are required for exporting a base');
+      }
+      const exportData = await ctx.api.exportBase(basePath, format, paramStr(params, 'viewName'));
+      return {
+        success: true,
+        data: exportData,
+        format
+      };
+    }
+
+    default:
+      throw new Error(`Unknown bases action: ${action}`);
+  }
+}

--- a/src/semantic/router.ts
+++ b/src/semantic/router.ts
@@ -19,9 +19,9 @@ import { GraphSearchTool as GraphSearchTraversalTool } from '../tools/graph-sear
 import { GraphTagTool } from '../tools/graph-tag-tool';
 import { App } from 'obsidian';
 import { InputValidator } from '../validation/input-validator';
-import { BaseYAML } from '../types/bases-yaml';
 import { RouterContext } from './operations/router-context';
 import { executeVaultOperation } from './operations/vault';
+import { executeBasesOperation } from './operations/bases';
 import { Params, SearchResultItem, paramStr, paramNum, paramBool, requireParamStr } from './operations/shared';
 
 export class SemanticRouter implements RouterContext {
@@ -123,7 +123,7 @@ export class SemanticRouter implements RouterContext {
       case 'graph':
         return this.executeGraphOperation(action, params);
       case 'bases':
-        return this.executeBasesOperation(action, params);
+        return executeBasesOperation(this, action, params);
       default:
         throw new Error(`Unknown operation: ${operation}`);
     }
@@ -938,63 +938,4 @@ export class SemanticRouter implements RouterContext {
     return suggestions.length > 0 ? { message, suggested_next: suggestions } : null;
   }
 
-  private async executeBasesOperation(action: string, params: Params): Promise<unknown> {
-    switch (action) {
-      case 'list':
-        return await this.api.listBases();
-
-      case 'read': {
-        const basePath = paramStr(params, 'path');
-        if (!basePath) {
-          throw new Error('Path parameter is required for reading a base');
-        }
-        return await this.api.readBase(basePath);
-      }
-
-      case 'create': {
-        const basePath = paramStr(params, 'path');
-        const config = params.config as BaseYAML | undefined;
-        if (!basePath || !config) {
-          throw new Error('Path and config parameters are required for creating a base');
-        }
-        await this.api.createBase(basePath, config);
-        return { success: true, path: basePath };
-      }
-
-      case 'query': {
-        const basePath = paramStr(params, 'path');
-        if (!basePath) {
-          throw new Error('Path parameter is required for querying a base');
-        }
-        return await this.api.queryBase(basePath, paramStr(params, 'viewName'));
-      }
-
-      case 'view': {
-        const basePath = paramStr(params, 'path');
-        const viewName = paramStr(params, 'viewName');
-        if (!basePath || !viewName) {
-          throw new Error('Path and viewName parameters are required for getting a base view');
-        }
-        // View is handled by query with viewName
-        return await this.api.queryBase(basePath, viewName);
-      }
-
-      case 'export': {
-        const basePath = paramStr(params, 'path');
-        const format = paramStr(params, 'format') as 'csv' | 'json' | 'markdown' | undefined;
-        if (!basePath || !format) {
-          throw new Error('Path and format parameters are required for exporting a base');
-        }
-        const exportData = await this.api.exportBase(basePath, format, paramStr(params, 'viewName'));
-        return {
-          success: true,
-          data: exportData,
-          format
-        };
-      }
-      
-      default:
-        throw new Error(`Unknown bases action: ${action}`);
-    }
-  }
 }

--- a/tests/bases-router-dispatch.test.ts
+++ b/tests/bases-router-dispatch.test.ts
@@ -1,0 +1,113 @@
+/**
+ * bases operation — router dispatch (#199 stage 2, operations/bases.ts).
+ *
+ * Drives the real SemanticRouter -> executeBasesOperation path extracted in
+ * ADR-202 stage 2. Only the ObsidianAPI I/O boundary is stubbed, so the
+ * dispatch and validation logic under test is the shipped one. There was no
+ * router-level test for the bases operation before this extraction.
+ */
+import { SemanticRouter } from '../src/semantic/router';
+import { ObsidianAPI } from '../src/utils/obsidian-api';
+import { App } from 'obsidian';
+import { BaseYAML } from '../src/types/bases-yaml';
+
+class MockObsidianAPI extends ObsidianAPI {
+  public created: Array<{ path: string; config: BaseYAML }> = [];
+
+  constructor(private bases: Map<string, BaseYAML>) {
+    super({} as App);
+  }
+
+  async listBases() {
+    return Array.from(this.bases.keys()).map((path) => ({ path, name: path, views: [] }));
+  }
+
+  async readBase(path: string) {
+    const base = this.bases.get(path);
+    if (!base) throw new Error(`Base not found: ${path}`);
+    return base;
+  }
+
+  async createBase(path: string, config: BaseYAML) {
+    this.created.push({ path, config });
+    this.bases.set(path, config);
+  }
+
+  async queryBase(path: string, viewName?: string) {
+    if (!this.bases.has(path)) throw new Error(`Base not found: ${path}`);
+    return { path, viewName, rows: [] } as never;
+  }
+
+  async exportBase(path: string, format: 'csv' | 'json' | 'markdown', viewName?: string) {
+    if (!this.bases.has(path)) throw new Error(`Base not found: ${path}`);
+    return `exported:${path}:${format}:${viewName ?? ''}`;
+  }
+}
+
+function router(bases: Map<string, BaseYAML> = new Map()): { router: SemanticRouter; api: MockObsidianAPI } {
+  const api = new MockObsidianAPI(bases);
+  return { router: new SemanticRouter(api, {} as App), api };
+}
+
+describe('bases operation dispatch (router -> operations/bases.ts)', () => {
+  it('list returns all known bases', async () => {
+    const { router: r } = router(new Map([['areas/work.base', {} as BaseYAML]]));
+    const response = await r.route({ operation: 'bases', action: 'list', params: {} });
+    expect(response.result).toEqual([{ path: 'areas/work.base', name: 'areas/work.base', views: [] }]);
+  });
+
+  it('read returns the requested base config', async () => {
+    const config = { views: [{ name: 'default' }] } as unknown as BaseYAML;
+    const { router: r } = router(new Map([['areas/work.base', config]]));
+    const response = await r.route({ operation: 'bases', action: 'read', params: { path: 'areas/work.base' } });
+    expect(response.result).toEqual(config);
+  });
+
+  it('read without a path throws before touching the API', async () => {
+    const { router: r } = router();
+    const response = await r.route({ operation: 'bases', action: 'read', params: {} });
+    expect(response.error?.message).toBe('Path parameter is required for reading a base');
+  });
+
+  it('create stores the base and returns success', async () => {
+    const { router: r, api } = router();
+    const config = { views: [] } as unknown as BaseYAML;
+    const response = await r.route({
+      operation: 'bases',
+      action: 'create',
+      params: { path: 'areas/new.base', config }
+    });
+    expect(response.result).toEqual({ success: true, path: 'areas/new.base' });
+    expect(api.created).toEqual([{ path: 'areas/new.base', config }]);
+  });
+
+  it('view queries the base with the given view name', async () => {
+    const { router: r } = router(new Map([['areas/work.base', {} as BaseYAML]]));
+    const response = await r.route({
+      operation: 'bases',
+      action: 'view',
+      params: { path: 'areas/work.base', viewName: 'kanban' }
+    });
+    expect(response.result).toEqual({ path: 'areas/work.base', viewName: 'kanban', rows: [] });
+  });
+
+  it('export returns formatted data for the requested format', async () => {
+    const { router: r } = router(new Map([['areas/work.base', {} as BaseYAML]]));
+    const response = await r.route({
+      operation: 'bases',
+      action: 'export',
+      params: { path: 'areas/work.base', format: 'csv' }
+    });
+    expect(response.result).toEqual({
+      success: true,
+      data: 'exported:areas/work.base:csv:',
+      format: 'csv'
+    });
+  });
+
+  it('an unknown action is rejected', async () => {
+    const { router: r } = router();
+    const response = await r.route({ operation: 'bases', action: 'nope', params: {} });
+    expect(response.error?.message).toBe('Unknown bases action: nope');
+  });
+});


### PR DESCRIPTION
## Summary

Continues the router.ts de-monolithing started in #199. Following the same
pattern established by the vault operation extraction (ADR-202 stage 1),
this moves `SemanticRouter.executeBasesOperation` into
`src/semantic/operations/bases.ts`.

- `router.ts`: 999 → 940 lines
- No `RouterContext` changes needed — the bases operation only touches
  `ctx.api`, which was already exposed
- Purely mechanical move: same switch/case logic, same error messages,
  same return shapes

## Tests

There was no router-level test coverage for the bases operation before this
change. Added `tests/bases-router-dispatch.test.ts` (7 cases: list, read,
read validation, create, view, export, unknown action), following the same
mocked-`ObsidianAPI` convention as `tests/vault-rename-extension.test.ts`.

Full suite: 434/434 passing (427 existing + 7 new), no regressions.
`tsc -noEmit` clean.

## Test plan

- [x] `npm test` — full suite green
- [x] `tsc -noEmit -skipLibCheck` — no type errors
- [x] Manually diffed the moved switch/case against the original to confirm
      no behavioral changes

Happy to follow up with `edit`/`view`/`workflow`/`system`/`graph` in
separate PRs if this shape looks right to you.