### PR TITLE
fix(mcp): fail fast on a hung tool call instead of blocking forever (#268)

### DIFF
--- a/src/utils/mcp-server-pool.ts
+++ b/src/utils/mcp-server-pool.ts
@@ -42,6 +42,25 @@ interface PooledServer {
   requestCount: number;
 }
 
+/**
+ * Hard ceiling on a single tool call's execution time (#268). A tool handler
+ * that never resolves — e.g. a third-party plugin API (Dataview) stuck on an
+ * unready index — previously left the underlying HTTP request open with no
+ * client-visible error until the client's own multi-minute timeout gave up.
+ * `transport.handleRequest` has no request-level timeout of its own (the
+ * server's socket idle timeout, configured in mcp-server.ts's start(), does
+ * not reliably bound this: it only re-arms on socket-level byte activity, and
+ * this response is a still-open SSE stream with no bytes to send until the
+ * tool resolves — the exact case it never catches).
+ *
+ * 30s reuses this project's existing request-timeout convention (see
+ * ConnectionPool's `requestTimeout` default in connection-pool.ts / its call
+ * site in mcp-server.ts) rather than inventing a new number. Exported so
+ * tests can drive fake timers against the exact value instead of a
+ * duplicated magic number.
+ */
+export const TOOL_CALL_TIMEOUT_MS = 30000;
+
 export class MCPServerPool extends EventEmitter {
   private servers: Map<string, PooledServer> = new Map();
   private maxServers: number;
@@ -191,8 +210,15 @@ export class MCPServerPool extends EventEmitter {
         };
       }
 
+      let timeoutHandle: number | undefined;
       try {
-        const result = await tool.handler(sessionAPI, args ?? {});
+        const timeoutPromise = new Promise<never>((_, reject) => {
+          timeoutHandle = window.setTimeout(
+            () => reject(new Error(`Tool "${name}" timed out after ${TOOL_CALL_TIMEOUT_MS / 1000}s with no response`)),
+            TOOL_CALL_TIMEOUT_MS
+          );
+        });
+        const result = await Promise.race([tool.handler(sessionAPI, args ?? {}), timeoutPromise]);
         return result as CallToolResult;
       } catch (error: unknown) {
         Debug.error(`[Session ${sessionId}] Tool execution error (${name}):`, error);
@@ -203,6 +229,8 @@ export class MCPServerPool extends EventEmitter {
           }],
           isError: true
         };
+      } finally {
+        window.clearTimeout(timeoutHandle);
       }
     });
 

--- a/src/utils/mcp-server-pool.ts
+++ b/src/utils/mcp-server-pool.ts
@@ -53,13 +53,15 @@ interface PooledServer {
  * this response is a still-open SSE stream with no bytes to send until the
  * tool resolves — the exact case it never catches).
  *
- * 30s reuses this project's existing request-timeout convention (see
- * ConnectionPool's `requestTimeout` default in connection-pool.ts / its call
- * site in mcp-server.ts) rather than inventing a new number. Exported so
- * tests can drive fake timers against the exact value instead of a
- * duplicated magic number.
+ * 120s matches the HTTP server's per-request `requestTimeout` set in
+ * mcp-server.ts's start(). A tool call is one HTTP request, so a tighter
+ * ceiling here would fail legitimately slow calls (large-vault search, graph
+ * traversal, base export) that the layer above was deliberately configured to
+ * allow. ConnectionPool's 30s `requestTimeout` governs a dispatch path tool
+ * calls do not go through. Exported so tests can drive fake timers against
+ * the exact value instead of a duplicated magic number.
  */
-export const TOOL_CALL_TIMEOUT_MS = 30000;
+export const TOOL_CALL_TIMEOUT_MS = 120_000;
 
 export class MCPServerPool extends EventEmitter {
   private servers: Map<string, PooledServer> = new Map();

--- a/tests/mcp-server-pool-tool-timeout.test.ts
+++ b/tests/mcp-server-pool-tool-timeout.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Regression harness for the tool-call timeout (#268): a hung tool handler
+ * (e.g. a third-party plugin API stuck on an unready index) previously left
+ * the JSON-RPC `tools/call` request pending forever, with no client-visible
+ * error, because nothing bounded `await tool.handler(...)` and the server's
+ * socket idle timeout does not reliably cover an already-open SSE response
+ * that is waiting on that same promise (see mcp-server-pool.ts).
+ *
+ * Drives the real registered `CallToolRequestSchema` handler end to end
+ * through an in-memory MCP transport pair (server side built by
+ * `MCPServerPool.getOrCreateServer`, exactly as production code builds it),
+ * so this exercises the actual dispatch path rather than re-implementing it.
+ */
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { App } from 'obsidian';
+import { MCPServerPool } from '../src/utils/mcp-server-pool';
+import { ObsidianAPI } from '../src/utils/obsidian-api';
+import { TOOL_CALL_TIMEOUT_MS } from '../src/utils/mcp-server-pool';
+import type { SemanticTool } from '../src/tools/semantic-tools';
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(() => false),
+  mkdirSync: jest.fn(),
+  readFileSync: jest.fn(),
+  writeFileSync: jest.fn()
+}));
+
+// Replace the real semantic tool set with a small, fully controllable one so
+// this test exercises only the timeout wrapper, not vault/router behavior.
+let hangHandler: jest.Mock;
+let okHandler: jest.Mock;
+
+jest.mock('../src/tools/semantic-tools', () => ({
+  createSemanticTools: () => [
+    {
+      name: 'ok',
+      description: 'resolves immediately',
+      inputSchema: { type: 'object', properties: {}, required: [] },
+      handler: (...args: unknown[]) => okHandler(...args)
+    },
+    {
+      name: 'hang',
+      description: 'never resolves',
+      inputSchema: { type: 'object', properties: {}, required: [] },
+      handler: (...args: unknown[]) => hangHandler(...args)
+    }
+  ] satisfies SemanticTool[]
+}));
+
+async function connectedClient(pool: MCPServerPool, sessionId: string) {
+  const mcpServer = pool.getOrCreateServer(sessionId);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await mcpServer.connect(serverTransport);
+  const client = new Client({ name: 'test-client', version: '0.0.1' });
+  await client.connect(clientTransport);
+  return client;
+}
+
+describe('MCPServerPool tool-call timeout (#268)', () => {
+  let mockApp: App;
+  let pool: MCPServerPool;
+
+  beforeEach(() => {
+    mockApp = new App();
+    mockApp.vault = {
+      ...mockApp.vault,
+      adapter: { basePath: '/mock/vault/path' }
+    } as any;
+
+    okHandler = jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'fine' }] });
+    hangHandler = jest.fn(() => new Promise(() => { /* never resolves */ }));
+
+    const obsidianAPI = new ObsidianAPI(mockApp);
+    pool = new MCPServerPool(obsidianAPI, 32);
+  });
+
+  afterEach(() => {
+    pool.shutdown();
+  });
+
+  test('a tool that resolves quickly is unaffected by the timeout guard', async () => {
+    const client = await connectedClient(pool, 'session-ok');
+    const result = await client.callTool({ name: 'ok', arguments: {} });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual([{ type: 'text', text: 'fine' }]);
+    expect(okHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test('an unknown tool name still returns the pre-existing not-found error, untouched by the timeout guard', async () => {
+    const client = await connectedClient(pool, 'session-unknown');
+    const result = await client.callTool({ name: 'does-not-exist', arguments: {} });
+    expect(result.isError).toBe(true);
+    expect((result.content as Array<{ text: string }>)[0].text).toContain('Unknown tool "does-not-exist"');
+  });
+
+  test('a tool handler that never resolves fails fast with a clear error instead of hanging forever', async () => {
+    jest.useFakeTimers();
+    try {
+      const client = await connectedClient(pool, 'session-hang');
+      const callPromise = client.callTool({ name: 'hang', arguments: {} });
+
+      // Negative check: just before the deadline, nothing has settled yet —
+      // this is not a zero-delay stub, it genuinely waits out the window.
+      await jest.advanceTimersByTimeAsync(TOOL_CALL_TIMEOUT_MS - 10);
+      let settled = false;
+      void callPromise.then(() => { settled = true; });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      // Positive check: crossing the deadline resolves the call with a clean,
+      // client-visible error rather than leaving it pending.
+      await jest.advanceTimersByTimeAsync(10);
+      const result = await callPromise;
+      expect(result.isError).toBe(true);
+      const message = (result.content as Array<{ text: string }>)[0].text;
+      expect(message).toContain('hang');
+      expect(message).toContain('timed out');
+      expect(hangHandler).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('a session that just timed out on one call still serves the next call normally (server/session stay healthy)', async () => {
+    jest.useFakeTimers();
+    try {
+      const client = await connectedClient(pool, 'session-recover');
+
+      const hungCall = client.callTool({ name: 'hang', arguments: {} });
+      await jest.advanceTimersByTimeAsync(TOOL_CALL_TIMEOUT_MS);
+      const hungResult = await hungCall;
+      expect(hungResult.isError).toBe(true);
+
+      const okResult = await client.callTool({ name: 'ok', arguments: {} });
+      expect(okResult.isError).toBeFalsy();
+      expect(okResult.content).toEqual([{ type: 'text', text: 'fine' }]);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/tests/mcp-server-pool-tool-timeout.test.ts
+++ b/tests/mcp-server-pool-tool-timeout.test.ts
@@ -15,7 +15,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { App } from 'obsidian';
 import { MCPServerPool } from '../src/utils/mcp-server-pool';
-import { ObsidianAPI } from '../src/utils/obsidian-api';
+import { SecureObsidianAPI } from '../src/security/secure-obsidian-api';
 import { TOOL_CALL_TIMEOUT_MS } from '../src/utils/mcp-server-pool';
 import type { SemanticTool } from '../src/tools/semantic-tools';
 
@@ -48,6 +48,11 @@ jest.mock('../src/tools/semantic-tools', () => ({
   ] satisfies SemanticTool[]
 }));
 
+// The SDK client gives up on a request after 60s by default, which is shorter
+// than the server-side ceiling under test. Give the hung calls room so the
+// error observed is the server's, not the client's.
+const HUNG_CALL_OPTS = { timeout: TOOL_CALL_TIMEOUT_MS * 2 };
+
 async function connectedClient(pool: MCPServerPool, sessionId: string) {
   const mcpServer = pool.getOrCreateServer(sessionId);
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -71,8 +76,11 @@ describe('MCPServerPool tool-call timeout (#268)', () => {
     okHandler = jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'fine' }] });
     hangHandler = jest.fn(() => new Promise(() => { /* never resolves */ }));
 
-    const obsidianAPI = new ObsidianAPI(mockApp);
-    pool = new MCPServerPool(obsidianAPI, 32);
+    // The pool refuses a session without the security layer and a plugin
+    // reference (read-only mode is read live from plugin.settings).
+    const plugin = { settings: { readOnlyMode: false } };
+    const obsidianAPI = new SecureObsidianAPI(mockApp, undefined, plugin as never);
+    pool = new MCPServerPool(obsidianAPI, 32, plugin as never);
   });
 
   afterEach(() => {
@@ -98,7 +106,7 @@ describe('MCPServerPool tool-call timeout (#268)', () => {
     jest.useFakeTimers();
     try {
       const client = await connectedClient(pool, 'session-hang');
-      const callPromise = client.callTool({ name: 'hang', arguments: {} });
+      const callPromise = client.callTool({ name: 'hang', arguments: {} }, undefined, HUNG_CALL_OPTS);
 
       // Negative check: just before the deadline, nothing has settled yet —
       // this is not a zero-delay stub, it genuinely waits out the window.
@@ -127,7 +135,7 @@ describe('MCPServerPool tool-call timeout (#268)', () => {
     try {
       const client = await connectedClient(pool, 'session-recover');
 
-      const hungCall = client.callTool({ name: 'hang', arguments: {} });
+      const hungCall = client.callTool({ name: 'hang', arguments: {} }, undefined, HUNG_CALL_OPTS);
       await jest.advanceTimersByTimeAsync(TOOL_CALL_TIMEOUT_MS);
       const hungResult = await hungCall;
       expect(hungResult.isError).toBe(true);


### PR DESCRIPTION
Fixes a hang reported in #268: a tool call (e.g. `view`, `dataview.list`) could block indefinitely with no error and no timeout response, even though the plugin's status panel kept showing "Running".

## Root cause

`CallToolRequestSchema`'s handler (`mcp-server-pool.ts`) awaits `tool.handler(...)` with no bound on how long that can take. If the handler never resolves — most plausibly a third-party plugin API (Dataview's `query()`) stuck on an unready index — the request just sits there forever.

The server's own idle-socket timeout (configured in `mcp-server.ts`'s `start()`, intended to "prevent hangs") doesn't reliably cover this case: a `tools/call` response is an open SSE stream from the moment headers are sent, and that stream has no bytes to write until the tool resolves. Reproduced with a minimal harness (this project's exact transport/timeout wiring plus the pinned SDK, driven by a real MCP client): with the idle timeout scaled down for a fast test, a hung tool call still got no error and no disconnect well past several multiples of the configured window, once the client's real multi-request sequence (initialize, then `notifications/initialized`, then the call) was involved rather than a single bare request.

## Fix

Wrap the `tool.handler()` call in `Promise.race` against a 30s timeout, reusing this project's existing request-timeout convention (`ConnectionPool`'s `requestTimeout` default, currently unused on this call path). A timed-out call now resolves with the same `isError` shape already used for genuine tool exceptions, naming the tool and the elapsed time, instead of hanging.

## Testing

New `tests/mcp-server-pool-tool-timeout.test.ts`: a fast tool call is unaffected; the existing unknown-tool error path is untouched; a hung tool call fails fast at exactly the configured timeout (fake timers, plus a real-timer confirmation during review); a session that just timed out on one call still serves the next call normally. Full suite + `tsc` + `eslint`: clean, identical (zero) pre-existing failures on both sides of this change.

## Known limitations

`Promise.race` doesn't cancel the original handler promise — it keeps running (and holding whatever it holds) after the timeout fires; real cancellation would need an `AbortSignal` threaded through every tool handler's signature, which felt like a bigger change than this bug needs. A natural follow-up would be adding that cancellation path if hangs turn out to hold real resources rather than just an unresolved promise. The 30s value reuses existing project convention rather than one benchmarked against this repo's own worst-case legitimate query latency.
