### PR TITLE
fix(security): route every vault write through the security layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -469,8 +469,20 @@ by reverting the decision behind them; they were analysed and accepted:
   No real placeholders exist; the heuristic trips on legitimate markdown
   badge/link labels (`[BRAT]`, `[MIT]`, …). Mangling valid markdown to
   appease it is the wrong action — leave it.
-- **"… scan not available" disclosures** — neutral. Obsidian's
-  malware/dependency/obfuscation scanners did not run; not a failure.
+- **"… scan not available" disclosures** — neutral. Where Obsidian's
+  malware/obfuscation scanners do not run, that is not a failure. The
+  **dependency** scan *does* run now and passed at the 0.11.42 portal scan
+  ("No vulnerable dependencies found") — treat a regression there as real,
+  not a disclosure.
+
+  The portal scan and local `npm audit` **can diverge**, and the local audit
+  is the leading indicator — it sees advisories published since the last
+  portal scan. As of 2026-07-29 `npm audit` reports 5 (2 high
+  `brace-expansion` + `fast-uri`, 2 moderate `@modelcontextprotocol/sdk` →
+  `@hono/node-server`, 1 low `body-parser`), all with fixes available, while
+  the portal still shows the 0.11.42 pass. Re-run `npm audit` before reading
+  the portal result as current; per the supply-chain rule above these are
+  security fixes and exempt from the 7-day hold.
 
 **Dynamic code execution** — the Bases-evaluator `new Function` (the
 exploitable vector: arbitrary JS from a synced/shared `.base`) is **removed**
@@ -486,9 +498,17 @@ different, library-internal class **not reachable from vault content**. They
 were already in 0.11.25's bundle, the release that passed full review with
 only the fs Warning, so they were non-gating then. The "Dynamic Code
 Execution" Recommendation was attributed to the Bases path specifically;
-this clears that path. Whether a heuristic re-scan re-flags the ajv-class
-residual is unknown until the next scan (scorecard blind — #183); if it
-does, it is the *transitive* class above, not the closed Bases vector.
+this clears that path.
+
+**Settled at 0.11.42:** the re-scan *does* still raise the "Dynamic Code
+Execution" Recommendation, and it is the transitive class — verified at scan
+time: `src/` contains **zero** `new Function`/`eval` (the only match is a
+comment in `expression-evaluator.ts` saying it avoids them), while `main.js`
+has exactly 3, all library-internal (1× `depd` deprecation shim, 2× ajv's
+`makeValidate` compiler). The heuristic greps the bundle, not the reachable
+call graph, so ADR-201 cannot make it go away. It is a Recommendation, never
+an Error — **do not chase it to zero**; the closed Bases vector is what
+mattered and it stays closed.
 
 Actionable findings became issues/PRs: #163/#164/#170 (SSL + attestation,
 shipped), #171/#173 (build-dep + CSS, shipped), #174 (js-yaml, shipped),

--- a/jest.config.js
+++ b/jest.config.js
@@ -47,7 +47,12 @@ module.exports = {
   },
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
   moduleNameMapper: {
-    '^obsidian$': '<rootDir>/tests/__mocks__/obsidian.ts'
+    '^obsidian$': '<rootDir>/tests/__mocks__/obsidian.ts',
+    // The router's lazy `import('../tools/window-edit.js')` carries the ESM .js
+    // extension the bundler expects. ts-jest resolves against .ts, so without
+    // this the import throws MODULE_NOT_FOUND and edit.window / edit.from_buffer
+    // could not be tested at all — they failed before reaching any logic.
+    '^(\\.{1,2}/.*)\\.js$': '$1'
   },
   testTimeout: 10000
 };

--- a/src/security/secure-obsidian-api.ts
+++ b/src/security/secure-obsidian-api.ts
@@ -8,6 +8,7 @@ import {
 } from './vault-security-manager';
 import { MCPIgnoreManager } from './mcp-ignore-manager';
 import { ObsidianConfig, ObsidianFile, ObsidianFileResponse } from '../types/obsidian';
+import { BaseYAML } from '../types/bases-yaml';
 import { Debug } from '../utils/debug';
 
 /** Minimal plugin interface for security-relevant properties.
@@ -150,9 +151,84 @@ export class SecureObsidianAPI extends ObsidianAPI {
 		return super.deleteFile(validated.path!);
 	}
 
+	// File Operations - MOVE / RENAME
+
+	/**
+	 * Validates BOTH source and destination before a move/rename.
+	 *
+	 * validateOperation already understands targetPath, so the destination goes
+	 * through the same path validator as the source. Before this override the
+	 * router called app.fileManager.renameFile directly and a `../` destination
+	 * relocated files outside the vault root.
+	 */
+	async renameFile(path: string, newPath: string): ReturnType<ObsidianAPI['renameFile']> {
+		const validated = await this.security.validateOperation({
+			type: OperationType.MOVE,
+			path: path,
+			targetPath: newPath,
+			context: { method: 'renameFile' }
+		});
+
+		return super.renameFile(validated.path!, validated.targetPath!);
+	}
+
 	// Note: These methods don't exist in base ObsidianAPI:
-	// - trash(), renameFile(), moveFile(), copyFile()
+	// - trash(), moveFile(), copyFile()
 	// They would need to be implemented in the base class first
+
+	// Bases
+
+	/**
+	 * Routes base creation through the security layer.
+	 *
+	 * createBase writes with app.vault.create() and was the one write in the
+	 * plugin that reached the vault without passing through here, so neither the
+	 * read-only permission check nor path validation applied. A `../` path
+	 * created files outside the vault root.
+	 */
+	async createBase(path: string, config: BaseYAML): Promise<void> {
+		const validated = await this.security.validateOperation({
+			type: OperationType.CREATE,
+			path: path,
+			context: { method: 'createBase' }
+		});
+
+		return super.createBase(validated.path!, config);
+	}
+
+	// Active-file writes
+	//
+	// Not currently reachable from the tool surface, but they write via
+	// app.vault.modify / fileManager.trashFile, so an unwrapped version is the
+	// same bug class as createBase waiting for its first caller. patchActiveFile
+	// needs no override — it delegates to the wrapped patchVaultFile.
+
+	async updateActiveFile(content: string): ReturnType<ObsidianAPI['updateActiveFile']> {
+		await this.security.validateOperation({
+			type: OperationType.UPDATE,
+			context: { method: 'updateActiveFile', contentSize: content.length }
+		});
+
+		return super.updateActiveFile(content);
+	}
+
+	async appendToActiveFile(content: string): ReturnType<ObsidianAPI['appendToActiveFile']> {
+		await this.security.validateOperation({
+			type: OperationType.UPDATE,
+			context: { method: 'appendToActiveFile', contentSize: content.length }
+		});
+
+		return super.appendToActiveFile(content);
+	}
+
+	async deleteActiveFile(): ReturnType<ObsidianAPI['deleteActiveFile']> {
+		await this.security.validateOperation({
+			type: OperationType.DELETE,
+			context: { method: 'deleteActiveFile' }
+		});
+
+		return super.deleteActiveFile();
+	}
 
 	// File Operations - EXECUTE
 

--- a/src/security/secure-obsidian-api.ts
+++ b/src/security/secure-obsidian-api.ts
@@ -162,15 +162,12 @@ export class SecureObsidianAPI extends ObsidianAPI {
 	 * Before this override the router called app.fileManager.renameFile directly
 	 * and a `../` destination relocated files outside the vault root.
 	 *
-	 * Deliberately typed MOVE for both move and rename: Obsidian models a rename
-	 * as a move (one fileManager.renameFile serves both), and no preset splits
-	 * permissions.move from permissions.rename. If those ever become
-	 * independently configurable, this needs to take the operation type from the
-	 * caller instead.
+	 * Charged as RENAME so permissions.rename is real config rather than dead —
+	 * moveFile below charges the same Obsidian primitive against permissions.move.
 	 */
 	async renameFile(path: string, newPath: string): ReturnType<ObsidianAPI['renameFile']> {
 		const validated = await this.security.validateOperation({
-			type: OperationType.MOVE,
+			type: OperationType.RENAME,
 			path: path,
 			targetPath: newPath,
 			context: { method: 'renameFile' }
@@ -179,8 +176,34 @@ export class SecureObsidianAPI extends ObsidianAPI {
 		return super.renameFile(validated.path!, validated.targetPath!);
 	}
 
+	async moveFile(path: string, newPath: string): ReturnType<ObsidianAPI['moveFile']> {
+		const validated = await this.security.validateOperation({
+			type: OperationType.MOVE,
+			path: path,
+			targetPath: newPath,
+			context: { method: 'moveFile' }
+		});
+
+		return super.moveFile(validated.path!, validated.targetPath!);
+	}
+
+	/**
+	 * The command palette contains mutators ("Delete current file", "Move file
+	 * to…"), so an unwrapped executeCommand is a write path around the layer.
+	 * Latent today — only getCommands() is wired to a tool — but wrapped for the
+	 * same reason as the active-file writes above.
+	 */
+	executeCommand(commandId: string): ReturnType<ObsidianAPI['executeCommand']> {
+		this.security.assertOperationPermitted(
+			OperationType.EXECUTE,
+			{ method: 'executeCommand', commandId }
+		);
+
+		return super.executeCommand(commandId);
+	}
+
 	// Note: These methods don't exist in base ObsidianAPI:
-	// - trash(), moveFile(), copyFile()
+	// - trash(), copyFile()
 	// They would need to be implemented in the base class first
 
 	// Bases

--- a/src/security/secure-obsidian-api.ts
+++ b/src/security/secure-obsidian-api.ts
@@ -157,9 +157,16 @@ export class SecureObsidianAPI extends ObsidianAPI {
 	 * Validates BOTH source and destination before a move/rename.
 	 *
 	 * validateOperation already understands targetPath, so the destination goes
-	 * through the same path validator as the source. Before this override the
-	 * router called app.fileManager.renameFile directly and a `../` destination
-	 * relocated files outside the vault root.
+	 * through the same path validator as the source (and the blocked-path check,
+	 * which is why .mcpignore protection now covers move destinations too).
+	 * Before this override the router called app.fileManager.renameFile directly
+	 * and a `../` destination relocated files outside the vault root.
+	 *
+	 * Deliberately typed MOVE for both move and rename: Obsidian models a rename
+	 * as a move (one fileManager.renameFile serves both), and no preset splits
+	 * permissions.move from permissions.rename. If those ever become
+	 * independently configurable, this needs to take the operation type from the
+	 * caller instead.
 	 */
 	async renameFile(path: string, newPath: string): ReturnType<ObsidianAPI['renameFile']> {
 		const validated = await this.security.validateOperation({

--- a/src/security/vault-security-manager.ts
+++ b/src/security/vault-security-manager.ts
@@ -165,7 +165,12 @@ export class VaultSecurityManager {
 			let validatedPath: ValidatedPath | undefined;
 			let validatedTargetPath: ValidatedPath | undefined;
 
-			if (operation.path) {
+			// Presence, not truthiness: '' is a path the caller supplied and must be
+			// validated (and rejected), not silently treated as "no path given".
+			// Operations with genuinely no path — the active-file writes — pass
+			// undefined and still skip path validation while keeping the permission
+			// check above.
+			if (operation.path !== undefined && operation.path !== null) {
 				// Check if path is in blocked list
 				if (this.isPathBlocked(operation.path)) {
 					this.logSecurityEvent(operation, 'blocked', 'PATH_BLOCKED');
@@ -189,7 +194,9 @@ export class VaultSecurityManager {
 			}
 
 			// Step 4: Validate target path for move/rename operations
-			if (operation.targetPath) {
+			// Presence, not truthiness — see the path check above. A '' destination
+			// previously skipped validation entirely and reached fileManager.
+			if (operation.targetPath !== undefined && operation.targetPath !== null) {
 				if (this.isPathBlocked(operation.targetPath)) {
 					this.logSecurityEvent(operation, 'blocked', 'TARGET_PATH_BLOCKED');
 					throw new SecurityError(
@@ -234,6 +241,28 @@ export class VaultSecurityManager {
 			}
 			throw error;
 		}
+	}
+
+	/**
+	 * Synchronous permission check for operations with no path to validate.
+	 *
+	 * Exists for callers whose base signature is synchronous (executeCommand), so
+	 * they cannot await validateOperation. This is the SAME policy — it delegates
+	 * to isOperationAllowed and logs identically — not a second gate. Anything
+	 * with a path must use validateOperation so path validation runs too.
+	 */
+	assertOperationPermitted(type: OperationType, context?: VaultOperation['context']): void {
+		const operation: VaultOperation = { type, context };
+
+		if (!this.isOperationAllowed(type)) {
+			this.logSecurityEvent(operation, 'blocked', 'PERMISSION_DENIED');
+			throw new SecurityError(
+				`Operation '${type}' is not permitted in current security mode`,
+				'PERMISSION_DENIED'
+			);
+		}
+
+		this.logSecurityEvent(operation, 'allowed');
 	}
 
 	/**

--- a/src/semantic/operations/vault.ts
+++ b/src/semantic/operations/vault.ts
@@ -9,6 +9,7 @@ import { Debug } from '../../utils/debug';
 import { isImageFile, ObsidianFileResponse } from '../../types/obsidian';
 import { readFileWithFragments } from '../../utils/file-reader';
 import { ValidationException } from '../../validation/input-validator';
+import { SecurityError } from '../../security';
 import { RouterContext } from './router-context';
 import { Params, paramStr, paramNum, paramBool, requireParamStr } from './shared';
 
@@ -296,19 +297,25 @@ export async function executeVaultOperation(ctx: RouterContext, action: string, 
           if (destFile && !overwrite) {
             throw new Error(`Destination already exists: ${destination}. Set overwrite=true to replace.`);
           }
-        } catch {
-          // File doesn't exist, which is what we want
+        } catch (error) {
+          // A rejected destination is not a "doesn't exist yet" — swallowing it
+          // here is what let a `../` destination through to the rename call.
+          if (error instanceof SecurityError) {
+            throw error;
+          }
+          // Otherwise the file doesn't exist, which is what we want
         }
 
         // Directory creation is handled automatically by createFile
 
-        // Use Obsidian's rename method (which handles moves)
-        if (ctx.app) {
-          const file = ctx.app.vault.getAbstractFileByPath(path);
-          if (file && 'extension' in file) {
-            await ctx.app.fileManager.renameFile(file, destination);
-            return { 
-              success: true, 
+        // Route through the API layer, not app.fileManager directly, so the
+        // security layer validates the destination as well as the source.
+        {
+          const abstractFile = ctx.app?.vault.getAbstractFileByPath(path);
+          if (abstractFile && 'extension' in abstractFile) {
+            await ctx.api.renameFile(path, destination);
+            return {
+              success: true,
               oldPath: path,
               newPath: destination,
               workflow: {
@@ -389,16 +396,21 @@ export async function executeVaultOperation(ctx: RouterContext, action: string, 
           if (destFile && !overwrite) {
             throw new Error(`File already exists: ${newPath}. Set overwrite=true to replace.`);
           }
-        } catch {
-          // File doesn't exist, which is what we want
+        } catch (error) {
+          // A rejected path is not a "doesn't exist yet" — see the move case.
+          if (error instanceof SecurityError) {
+            throw error;
+          }
+          // Otherwise the file doesn't exist, which is what we want
         }
 
-        // Use Obsidian's rename method
-        if (ctx.app) {
-          const file = ctx.app.vault.getAbstractFileByPath(path);
-          if (file && 'extension' in file) {
-            await ctx.app.fileManager.renameFile(file, newPath);
-            return { 
+        // Route through the API layer, not app.fileManager directly, so the
+        // security layer validates the new path as well as the source.
+        {
+          const abstractFile = ctx.app?.vault.getAbstractFileByPath(path);
+          if (abstractFile && 'extension' in abstractFile) {
+            await ctx.api.renameFile(path, newPath);
+            return {
               success: true,
               oldPath: path,
               newPath: newPath,

--- a/src/semantic/operations/vault.ts
+++ b/src/semantic/operations/vault.ts
@@ -313,7 +313,7 @@ export async function executeVaultOperation(ctx: RouterContext, action: string, 
         {
           const abstractFile = ctx.app?.vault.getAbstractFileByPath(path);
           if (abstractFile && 'extension' in abstractFile) {
-            await ctx.api.renameFile(path, destination);
+            await ctx.api.moveFile(path, destination);
             return {
               success: true,
               oldPath: path,

--- a/src/utils/obsidian-api.ts
+++ b/src/utils/obsidian-api.ts
@@ -457,6 +457,24 @@ export class ObsidianAPI {
     return { success: true, path };
   }
 
+  /**
+   * Move or rename a file via Obsidian's link-preserving rename.
+   *
+   * Exists so callers never reach for app.fileManager.renameFile directly: the
+   * raw call skips the security layer entirely, which let a `../` destination
+   * relocate files outside the vault. SecureObsidianAPI overrides this to
+   * validate both path and targetPath.
+   */
+  async renameFile(path: string, newPath: string) {
+    const file = this.app.vault.getAbstractFileByPath(path);
+    if (!file) {
+      throw new Error(`File not found: ${path}`);
+    }
+
+    await this.app.fileManager.renameFile(file, newPath);
+    return { success: true, oldPath: path, newPath };
+  }
+
   async appendToFile(path: string, content: string) {
     // Validate input
     const validationResult = this.validator.validate('file.append', { content });

--- a/src/utils/obsidian-api.ts
+++ b/src/utils/obsidian-api.ts
@@ -458,14 +458,27 @@ export class ObsidianAPI {
   }
 
   /**
-   * Move or rename a file via Obsidian's link-preserving rename.
+   * Rename a file via Obsidian's link-preserving rename.
    *
    * Exists so callers never reach for app.fileManager.renameFile directly: the
    * raw call skips the security layer entirely, which let a `../` destination
    * relocate files outside the vault. SecureObsidianAPI overrides this to
    * validate both path and targetPath.
+   *
+   * Obsidian uses one API for move and rename, but these are kept as separate
+   * methods so the security layer can charge each against its own permission —
+   * a single method would make permissions.rename dead config.
    */
   async renameFile(path: string, newPath: string) {
+    return this.relocateFile(path, newPath);
+  }
+
+  /** Move a file. Same Obsidian primitive as renameFile; distinct permission. */
+  async moveFile(path: string, newPath: string) {
+    return this.relocateFile(path, newPath);
+  }
+
+  private async relocateFile(path: string, newPath: string) {
     const file = this.app.vault.getAbstractFileByPath(path);
     if (!file) {
       throw new Error(`File not found: ${path}`);
@@ -474,6 +487,16 @@ export class ObsidianAPI {
     await this.app.fileManager.renameFile(file, newPath);
     return { success: true, oldPath: path, newPath };
   }
+
+  /**
+   * Run an Obsidian command by id.
+   *
+   * Wrapped as an EXECUTE operation in SecureObsidianAPI: the command palette
+   * includes mutators ("Delete current file", "Move file to…"), so an
+   * unguarded executeCommand is a write path that skips the security layer.
+   * Only getCommands() is currently wired to a tool, which is why this was
+   * latent rather than exploitable.
+   */
 
   async appendToFile(path: string, content: string) {
     // Validate input

--- a/tests/security/read-only-action-matrix.test.ts
+++ b/tests/security/read-only-action-matrix.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Exhaustive read-only enforcement matrix.
+ *
+ * Derives the action list from getActionsForOperation() — the same source the
+ * shipped tool schemas are built from — rather than a hand-written list, so a
+ * newly added action appears here automatically and FAILS until it is
+ * explicitly classified as read or write. That fail-closed property is the
+ * point: the 0.11.42 bypasses existed because `edit` and `bases.create` were
+ * never classified as writes anywhere.
+ *
+ * Each write action is checked twice:
+ *   - under read-only  -> must record ZERO vault writes
+ *   - under permissive -> must record AT LEAST ONE write (positive control)
+ *
+ * The positive control is what stops a vacuous pass. Without it, an action that
+ * throws on missing params would record no writes and look "correctly blocked"
+ * while testing nothing at all.
+ */
+import { SecureObsidianAPI, VaultSecurityManager } from '../../src/security';
+import { createSemanticTools, getActionsForOperation } from '../../src/tools/semantic-tools';
+import { ContentBufferManager } from '../../src/utils/content-buffer';
+import { App, TFile } from 'obsidian';
+
+jest.mock('obsidian');
+
+const OPERATIONS = ['vault', 'edit', 'view', 'workflow', 'system', 'graph', 'bases'];
+
+/**
+ * Every action's expected effect on the vault. Adding an action to
+ * getActionsForOperation() without adding it here fails the coverage test.
+ *
+ * 'execute' is its own kind, not a synonym for read: opening a file in the
+ * Obsidian UI mutates nothing, but it maps to OperationType.EXECUTE and
+ * presets.readOnly() sets execute:false, so read-only DOES block it. That is
+ * over-blocking, which is the safe direction — recorded here as the actual
+ * contract rather than assumed away. Note the Read-only setting description
+ * enumerates only "create, update, delete, move, rename", so the copy
+ * understates what the mode does.
+ */
+const ACTION_KIND: Record<string, 'read' | 'write' | 'execute'> = {
+  // vault
+  'vault.list': 'read',
+  'vault.read': 'read',
+  'vault.search': 'read',
+  'vault.fragments': 'read',
+  'vault.create': 'write',
+  'vault.update': 'write',
+  'vault.delete': 'write',
+  'vault.move': 'write',
+  'vault.rename': 'write',
+  'vault.copy': 'write',
+  'vault.split': 'write',
+  'vault.combine': 'write',
+  'vault.concatenate': 'write',
+  // edit — every action mutates a note
+  'edit.window': 'write',
+  'edit.append': 'write',
+  'edit.patch': 'write',
+  'edit.at_line': 'write',
+  'edit.from_buffer': 'write',
+  // view
+  'view.file': 'read',
+  'view.window': 'read',
+  'view.active': 'read',
+  'view.open_in_obsidian': 'execute',
+  // workflow / system
+  'workflow.suggest': 'read',
+  'system.info': 'read',
+  'system.commands': 'read',
+  'system.fetch_web': 'read',
+  // graph — all analysis
+  'graph.traverse': 'read',
+  'graph.neighbors': 'read',
+  'graph.path': 'read',
+  'graph.statistics': 'read',
+  'graph.backlinks': 'read',
+  'graph.forwardlinks': 'read',
+  'graph.search-traverse': 'read',
+  'graph.advanced-traverse': 'read',
+  'graph.tag-traverse': 'read',
+  'graph.tag-analysis': 'read',
+  'graph.shared-tags': 'read',
+  // bases
+  'bases.list': 'read',
+  'bases.read': 'read',
+  'bases.query': 'read',
+  'bases.view': 'read',
+  'bases.export': 'read',
+  'bases.create': 'write',
+};
+
+/** Params sufficient for each write action to actually attempt a vault write. */
+const WRITE_PARAMS: Record<string, Record<string, unknown>> = {
+  'vault.create': { path: 'new.md', content: 'x' },
+  'vault.update': { path: 'note.md', content: 'x' },
+  'vault.delete': { path: 'note.md' },
+  'vault.move': { path: 'note.md', destination: 'moved/note.md' },
+  'vault.rename': { path: 'note.md', newName: 'renamed' },
+  'vault.copy': { path: 'note.md', destination: 'copy.md' },
+  'vault.split': { path: 'note.md', splitBy: 'heading', level: 1 },
+  'vault.combine': { paths: ['note.md', 'other.md'], destination: 'combined.md' },
+  'vault.concatenate': { path1: 'note.md', path2: 'other.md', mode: 'new', destination: 'cat.md' },
+  'edit.window': { path: 'note.md', oldText: 'body', newText: 'changed' },
+  'edit.append': { path: 'note.md', content: 'x' },
+  'edit.patch': {
+    path: 'note.md', targetType: 'heading', target: 'Heading', operation: 'append', content: 'x',
+  },
+  'edit.at_line': { path: 'note.md', lineNumber: 1, mode: 'replace', content: 'x' },
+  'edit.from_buffer': { path: 'note.md' },
+  'bases.create': { path: 'new.base', config: { views: [{ type: 'table', name: 'v' }] } },
+};
+
+/**
+ * Write actions whose positive control needs state this harness doesn't build.
+ * Kept deliberately tiny and loud — each entry is coverage we do NOT have.
+ * Empty is the goal.
+ */
+const NO_POSITIVE_CONTROL: Record<string, string> = {};
+
+/** Actions needing state set up before the call can reach a write. */
+const SETUP: Record<string, () => void> = {
+  // from_buffer replays whatever a prior window edit stashed, so seed the buffer.
+  'edit.from_buffer': () => {
+    ContentBufferManager.getInstance().store('changed', undefined, { searchText: 'body' });
+  },
+};
+
+type Write = { op: string; path: string };
+
+const PERMISSIVE = {
+  pathValidation: 'strict' as const,
+  permissions: {
+    read: true, create: true, update: true,
+    delete: true, move: true, rename: true, execute: true,
+  },
+  blockedPaths: [],
+  logSecurityEvents: false,
+};
+
+const EXISTING = ['note.md', 'other.md'];
+
+function mkFile(p: string): TFile {
+  const f = new TFile();
+  const w = f as unknown as { path: string; extension: string; name: string };
+  w.path = p;
+  w.extension = p.includes('.') ? p.slice(p.lastIndexOf('.') + 1) : '';
+  w.name = p;
+  return f;
+}
+
+function makeApp(writes: Write[]): App {
+  return {
+    vault: {
+      adapter: { basePath: '/test/vault' },
+      getAbstractFileByPath: (p: string) => (EXISTING.includes(p) ? mkFile(p) : null),
+      read: async () => '# Heading\nbody\n',
+      cachedRead: async () => '# Heading\nbody\n',
+      modify: async (f: TFile) => { writes.push({ op: 'modify', path: f.path }); },
+      create: async (p: string) => { writes.push({ op: 'create', path: p }); return mkFile(p); },
+      createFolder: async (p: string) => { writes.push({ op: 'mkdir', path: p }); },
+      getFiles: () => EXISTING.map(mkFile),
+      getMarkdownFiles: () => EXISTING.map(mkFile),
+    },
+    fileManager: {
+      renameFile: async (_f: TFile, newPath: string) => { writes.push({ op: 'rename', path: newPath }); },
+      trashFile: async (f: TFile) => { writes.push({ op: 'trash', path: f.path }); },
+    },
+    metadataCache: { getFileCache: () => ({}), resolvedLinks: {} },
+    workspace: { getActiveFile: () => mkFile('note.md'), getLeaf: () => null },
+  } as unknown as App;
+}
+
+/** Invoke one action through the production tool handler. */
+async function invoke(
+  operation: string,
+  action: string,
+  params: Record<string, unknown>,
+  mode: 'readOnly' | 'permissive',
+): Promise<Write[]> {
+  const writes: Write[] = [];
+  const app = makeApp(writes);
+  const plugin = { settings: { readOnlyMode: mode === 'readOnly' } };
+  const api = new SecureObsidianAPI(
+    app, undefined, plugin as never,
+    mode === 'readOnly' ? VaultSecurityManager.presets.readOnly() : PERMISSIVE,
+  );
+  const tool = createSemanticTools(api)!.find(t => t.name === operation);
+  if (!tool) throw new Error(`tool not found: ${operation}`);
+
+  SETUP[`${operation}.${action}`]?.();
+
+  try {
+    await tool.handler(api, { action, ...params });
+  } catch {
+    // A thrown error is a legitimate outcome; the assertion is on `writes`.
+  }
+  return writes;
+}
+
+describe('read-only enforcement — exhaustive action matrix', () => {
+  const allActions = OPERATIONS.flatMap(op =>
+    getActionsForOperation(op).map(action => ({ op, action, key: `${op}.${action}` })),
+  );
+
+  it('classifies every shipped action as read or write', () => {
+    const unclassified = allActions.filter(a => !(a.key in ACTION_KIND)).map(a => a.key);
+
+    expect(unclassified).toEqual([]);
+    // If this fails, a new action shipped without a read/write decision. Add it
+    // to ACTION_KIND (and WRITE_PARAMS if it writes) — do not delete this test.
+  });
+
+  it('has no stale entries in the classification map', () => {
+    const shipped = new Set(allActions.map(a => a.key));
+    const stale = Object.keys(ACTION_KIND).filter(k => !shipped.has(k));
+
+    expect(stale).toEqual([]);
+  });
+
+  const writeActions = allActions.filter(a => ACTION_KIND[a.key] === 'write');
+
+  describe.each(writeActions)('$key (write)', ({ op, action, key }) => {
+    const params = WRITE_PARAMS[key] ?? {};
+
+    it('records no vault write under read-only mode', async () => {
+      const writes = await invoke(op, action, params, 'readOnly');
+      expect(writes).toEqual([]);
+    });
+
+    if (key in NO_POSITIVE_CONTROL) {
+      it.todo(`positive control missing — ${NO_POSITIVE_CONTROL[key]}`);
+    } else {
+      it('positive control: DOES write when permitted', async () => {
+        const writes = await invoke(op, action, params, 'permissive');
+        // A failure here means the read-only assertion above is vacuous: the
+        // action never reached a write, so blocking it proved nothing.
+        expect(writes.length).toBeGreaterThan(0);
+      });
+    }
+  });
+
+  const executeActions = allActions.filter(a => ACTION_KIND[a.key] === 'execute');
+
+  describe.each(executeActions)('$key (execute)', ({ op, action }) => {
+    it('is blocked under read-only — over-blocking, documented not assumed', async () => {
+      const writes: Write[] = [];
+      const api = new SecureObsidianAPI(
+        makeApp(writes), undefined, { settings: { readOnlyMode: true } } as never,
+        VaultSecurityManager.presets.readOnly(),
+      );
+      const tool = createSemanticTools(api)!.find(t => t.name === op)!;
+
+      const res = await tool.handler(api, { action, path: 'note.md' }).catch(e => ({
+        content: [{ type: 'text' as const, text: String(e) }],
+      }));
+
+      expect(JSON.stringify(res)).toContain('PERMISSION_DENIED');
+      expect(writes).toEqual([]);
+    });
+  });
+
+  const readActions = allActions.filter(a => ACTION_KIND[a.key] === 'read');
+
+  describe.each(readActions)('$key (read)', ({ op, action }) => {
+    it('is not denied by the permission layer under read-only', async () => {
+      const writes: Write[] = [];
+      const app = makeApp(writes);
+      const api = new SecureObsidianAPI(
+        app, undefined, { settings: { readOnlyMode: true } } as never,
+        VaultSecurityManager.presets.readOnly(),
+      );
+      const tool = createSemanticTools(api)!.find(t => t.name === op)!;
+
+      // Params are best-effort, so other errors are tolerated; the point is that
+      // read-only must never be the reason a read fails.
+      const res = await tool.handler(api, { action, path: 'note.md' }).catch(e => ({
+        content: [{ type: 'text' as const, text: String(e) }],
+      }));
+
+      const text = JSON.stringify(res);
+      expect(text).not.toContain('READ_ONLY_MODE');
+      expect(text).not.toContain('PERMISSION_DENIED');
+    });
+  });
+});

--- a/tests/security/read-only-action-matrix.test.ts
+++ b/tests/security/read-only-action-matrix.test.ts
@@ -17,13 +17,18 @@
  * while testing nothing at all.
  */
 import { SecureObsidianAPI, VaultSecurityManager } from '../../src/security';
-import { createSemanticTools, getActionsForOperation } from '../../src/tools/semantic-tools';
+import { createSemanticTools, getActionsForOperation, ALL_OPERATIONS } from '../../src/tools/semantic-tools';
 import { ContentBufferManager } from '../../src/utils/content-buffer';
 import { App, TFile } from 'obsidian';
 
 jest.mock('obsidian');
 
-const OPERATIONS = ['vault', 'edit', 'view', 'workflow', 'system', 'graph', 'bases'];
+/**
+ * Derived from ALL_OPERATIONS, not hand-listed: a hand-written list means adding
+ * a whole new OPERATION silently escapes the matrix (only new *actions* on known
+ * operations would be caught).
+ */
+const OPERATIONS: readonly string[] = ALL_OPERATIONS;
 
 /**
  * Every action's expected effect on the vault. Adding an action to
@@ -80,6 +85,13 @@ const ACTION_KIND: Record<string, 'read' | 'write' | 'execute'> = {
   'graph.tag-traverse': 'read',
   'graph.tag-analysis': 'read',
   'graph.shared-tags': 'read',
+  // dataview — all query/inspection. dataview-tool.ts rejects format 'js', so
+  // there is no execution vector here.
+  'dataview.query': 'read',
+  'dataview.list': 'read',
+  'dataview.metadata': 'read',
+  'dataview.validate': 'read',
+  'dataview.status': 'read',
   // bases
   'bases.list': 'read',
   'bases.read': 'read',
@@ -170,19 +182,32 @@ function makeApp(writes: Write[]): App {
   } as unknown as App;
 }
 
-/** Invoke one action through the production tool handler. */
+/**
+ * Invoke one action through the production tool handler.
+ *
+ * Three modes, and the distinction matters:
+ *
+ *  - 'readOnly'      both gates armed — what a user actually gets
+ *  - 'securityLayer' ONLY the security layer armed (plugin.settings.readOnlyMode
+ *                    left false, so the tool-layer guard at semantic-tools.ts:142
+ *                    never fires). Without this mode the vault.* write assertions
+ *                    are satisfied by the legacy tool-layer guard and pass even on
+ *                    code where the security layer is bypassed — measured: the
+ *                    pre-fix tree failed only on bases.create.
+ *  - 'permissive'    positive control: the call must really reach a write
+ */
 async function invoke(
   operation: string,
   action: string,
   params: Record<string, unknown>,
-  mode: 'readOnly' | 'permissive',
+  mode: 'readOnly' | 'securityLayer' | 'permissive',
 ): Promise<Write[]> {
   const writes: Write[] = [];
   const app = makeApp(writes);
   const plugin = { settings: { readOnlyMode: mode === 'readOnly' } };
   const api = new SecureObsidianAPI(
     app, undefined, plugin as never,
-    mode === 'readOnly' ? VaultSecurityManager.presets.readOnly() : PERMISSIVE,
+    mode === 'permissive' ? PERMISSIVE : VaultSecurityManager.presets.readOnly(),
   );
   const tool = createSemanticTools(api)!.find(t => t.name === operation);
   if (!tool) throw new Error(`tool not found: ${operation}`);
@@ -202,6 +227,30 @@ describe('read-only enforcement — exhaustive action matrix', () => {
     getActionsForOperation(op).map(action => ({ op, action, key: `${op}.${action}` })),
   );
 
+  /**
+   * Operations whose tool exists in this environment. `dataview` is gated behind
+   * the Dataview plugin being installed, so createSemanticTools omits it here and
+   * its actions cannot be invoked. They are still CLASSIFIED above — the
+   * fail-closed coverage check below covers the whole shipped surface — but the
+   * behavioural assertions can only run against tools that exist.
+   */
+  const invocable = (() => {
+    const probeWrites: Write[] = [];
+    const probeApi = new SecureObsidianAPI(
+      makeApp(probeWrites), undefined, { settings: {} } as never, PERMISSIVE,
+    );
+    const names = new Set((createSemanticTools(probeApi) ?? []).map(t => t.name));
+    return (op: string) => names.has(op);
+  })();
+
+  it('reports which operations are not behaviourally exercised here', () => {
+    const skipped = [...new Set(allActions.map(a => a.op))].filter(op => !invocable(op));
+    // Not a failure — a disclosure. Silent partial coverage is what lets a gap
+    // read as "covered". If this list grows, the matrix is testing less than it
+    // appears to.
+    expect(skipped).toEqual(['dataview']);
+  });
+
   it('classifies every shipped action as read or write', () => {
     const unclassified = allActions.filter(a => !(a.key in ACTION_KIND)).map(a => a.key);
 
@@ -217,13 +266,22 @@ describe('read-only enforcement — exhaustive action matrix', () => {
     expect(stale).toEqual([]);
   });
 
-  const writeActions = allActions.filter(a => ACTION_KIND[a.key] === 'write');
+  const writeActions = allActions.filter(a => ACTION_KIND[a.key] === 'write' && invocable(a.op));
 
   describe.each(writeActions)('$key (write)', ({ op, action, key }) => {
     const params = WRITE_PARAMS[key] ?? {};
 
     it('records no vault write under read-only mode', async () => {
       const writes = await invoke(op, action, params, 'readOnly');
+      expect(writes).toEqual([]);
+    });
+
+    it('records no vault write with ONLY the security layer armed', async () => {
+      // The assertion that actually exercises the repaired layer. With the
+      // tool-layer guard disarmed, a write reaching the vault here means the
+      // action bypasses SecureObsidianAPI — which is precisely how bases.create,
+      // vault.move and vault.rename escaped.
+      const writes = await invoke(op, action, params, 'securityLayer');
       expect(writes).toEqual([]);
     });
 
@@ -239,7 +297,7 @@ describe('read-only enforcement — exhaustive action matrix', () => {
     }
   });
 
-  const executeActions = allActions.filter(a => ACTION_KIND[a.key] === 'execute');
+  const executeActions = allActions.filter(a => ACTION_KIND[a.key] === 'execute' && invocable(a.op));
 
   describe.each(executeActions)('$key (execute)', ({ op, action }) => {
     it('is blocked under read-only — over-blocking, documented not assumed', async () => {
@@ -259,7 +317,7 @@ describe('read-only enforcement — exhaustive action matrix', () => {
     });
   });
 
-  const readActions = allActions.filter(a => ACTION_KIND[a.key] === 'read');
+  const readActions = allActions.filter(a => ACTION_KIND[a.key] === 'read' && invocable(a.op));
 
   describe.each(readActions)('$key (read)', ({ op, action }) => {
     it('is not denied by the permission layer under read-only', async () => {

--- a/tests/security/write-path-containment.test.ts
+++ b/tests/security/write-path-containment.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Every vault write must pass through the security layer.
+ *
+ * Three bypasses shipped in 0.11.42, all the same shape — a write that reached
+ * the vault without going through SecureObsidianAPI, so neither the read-only
+ * permission check nor path validation applied:
+ *
+ *   1. bases.create   -> app.vault.create() direct (bases-api.ts)
+ *   2. vault.move     -> app.fileManager.renameFile() direct (vault.ts)
+ *   3. vault.rename   -> app.fileManager.renameFile() direct (vault.ts)
+ *
+ * (2) and (3) escaped the vault root in DEFAULT configuration — no read-only
+ * needed — and being moves, they removed data from the vault.
+ *
+ * These tests assert on RECORDED WRITES, not error strings: a friendly error
+ * message means nothing if the write already landed.
+ */
+import { SecureObsidianAPI, VaultSecurityManager, SecurityError } from '../../src/security';
+import { SemanticRouter } from '../../src/semantic/router';
+import { App, TFile } from 'obsidian';
+
+jest.mock('obsidian');
+
+type Write = { op: string; path: string };
+
+const PERMISSIVE = {
+  pathValidation: 'strict' as const,
+  permissions: {
+    read: true, create: true, update: true,
+    delete: true, move: true, rename: true, execute: true,
+  },
+  blockedPaths: [],
+  logSecurityEvents: false,
+};
+
+function mkFile(p: string): TFile {
+  const f = new TFile();
+  (f as unknown as { path: string; extension: string; name: string }).path = p;
+  (f as unknown as { path: string; extension: string; name: string }).extension =
+    p.includes('.') ? p.slice(p.lastIndexOf('.') + 1) : '';
+  (f as unknown as { path: string; extension: string; name: string }).name = p;
+  return f;
+}
+
+function makeApp(existing: string[], writes: Write[]): App {
+  const has = (p: string) => existing.includes(p);
+  return {
+    vault: {
+      adapter: { basePath: '/test/vault' },
+      getAbstractFileByPath: (p: string) => (has(p) ? mkFile(p) : null),
+      read: async () => 'body\n',
+      cachedRead: async () => 'body\n',
+      modify: async (f: TFile, _c: string) => { writes.push({ op: 'modify', path: f.path }); },
+      create: async (p: string, _c: string) => { writes.push({ op: 'create', path: p }); return mkFile(p); },
+      getFiles: () => existing.map(mkFile),
+    },
+    fileManager: {
+      renameFile: async (f: TFile, newPath: string) => {
+        writes.push({ op: 'rename', path: newPath });
+      },
+      trashFile: async (f: TFile) => { writes.push({ op: 'trash', path: f.path }); },
+    },
+    metadataCache: { getFileCache: () => ({}), resolvedLinks: {} },
+    workspace: { getActiveFile: () => mkFile('active.md') },
+  } as unknown as App;
+}
+
+describe('write-path containment', () => {
+  let writes: Write[];
+
+  beforeEach(() => { writes = []; });
+
+  describe('bases.create goes through the security layer', () => {
+    it('is blocked by read-only mode', async () => {
+      const api = new SecureObsidianAPI(
+        makeApp(['note.md'], writes), undefined, { settings: {} } as never,
+        VaultSecurityManager.presets.readOnly()
+      );
+
+      await expect(
+        api.createBase('x.base', { views: [{ type: 'table', name: 'v' }] } as never)
+      ).rejects.toThrow(SecurityError);
+      expect(writes).toEqual([]);
+    });
+
+    it('rejects a traversal path even with writes permitted', async () => {
+      const api = new SecureObsidianAPI(
+        makeApp(['note.md'], writes), undefined, { settings: {} } as never, PERMISSIVE
+      );
+
+      await expect(
+        api.createBase('../escaped.base', { views: [{ type: 'table', name: 'v' }] } as never)
+      ).rejects.toThrow(SecurityError);
+      expect(writes).toEqual([]);
+    });
+
+    it('still creates a base at a legitimate path', async () => {
+      const api = new SecureObsidianAPI(
+        makeApp(['note.md'], writes), undefined, { settings: {} } as never, PERMISSIVE
+      );
+
+      await api.createBase('views/ok.base', { views: [{ type: 'table', name: 'v' }] } as never);
+      expect(writes).toEqual([{ op: 'create', path: 'views/ok.base' }]);
+    });
+  });
+
+  describe('renameFile validates source and destination', () => {
+    it('rejects a traversal destination even with writes permitted', async () => {
+      const api = new SecureObsidianAPI(
+        makeApp(['note.md'], writes), undefined, { settings: {} } as never, PERMISSIVE
+      );
+
+      await expect(api.renameFile('note.md', '../escaped.md')).rejects.toThrow(SecurityError);
+      expect(writes).toEqual([]);
+    });
+
+    it('is blocked by read-only mode', async () => {
+      const api = new SecureObsidianAPI(
+        makeApp(['note.md'], writes), undefined, { settings: {} } as never,
+        VaultSecurityManager.presets.readOnly()
+      );
+
+      await expect(api.renameFile('note.md', 'renamed.md')).rejects.toThrow(SecurityError);
+      expect(writes).toEqual([]);
+    });
+
+    it('still renames within the vault', async () => {
+      const api = new SecureObsidianAPI(
+        makeApp(['note.md'], writes), undefined, { settings: {} } as never, PERMISSIVE
+      );
+
+      await api.renameFile('note.md', 'renamed.md');
+      expect(writes).toEqual([{ op: 'rename', path: 'renamed.md' }]);
+    });
+  });
+
+  describe('active-file writes go through the security layer', () => {
+    it('blocks update/append/delete under read-only', async () => {
+      const api = new SecureObsidianAPI(
+        makeApp(['active.md'], writes), undefined, { settings: {} } as never,
+        VaultSecurityManager.presets.readOnly()
+      );
+
+      await expect(api.updateActiveFile('x')).rejects.toThrow(SecurityError);
+      await expect(api.appendToActiveFile('x')).rejects.toThrow(SecurityError);
+      await expect(api.deleteActiveFile()).rejects.toThrow(SecurityError);
+      expect(writes).toEqual([]);
+    });
+  });
+
+  /**
+   * End-to-end through the real router — this is the shape that actually escaped
+   * the vault live in 0.11.42, in default configuration.
+   */
+  describe('router-level: the confirmed live exploits', () => {
+    function router(existing: string[]) {
+      const app = makeApp(existing, writes);
+      const api = new SecureObsidianAPI(app, undefined, { settings: {} } as never, PERMISSIVE);
+      return new SemanticRouter(api, app);
+    }
+
+    it('vault.move cannot relocate a file outside the vault', async () => {
+      const r = router(['sec/victim.md']);
+
+      const res = await r.route({
+        operation: 'vault',
+        action: 'move',
+        params: { path: 'sec/victim.md', destination: '../escaped.md' },
+      });
+
+      expect(writes).toEqual([]);
+      expect(JSON.stringify(res)).not.toContain('Successfully moved');
+    });
+
+    it('vault.rename cannot relocate a file outside the vault', async () => {
+      const r = router(['sec/victim.md']);
+
+      const res = await r.route({
+        operation: 'vault',
+        action: 'rename',
+        params: { path: 'sec/victim.md', newName: '../../escaped.md' },
+      });
+
+      expect(writes).toEqual([]);
+      expect(JSON.stringify(res)).not.toContain('Successfully renamed');
+    });
+
+    it('vault.move still works for a legitimate destination', async () => {
+      const r = router(['sec/victim.md']);
+
+      await r.route({
+        operation: 'vault',
+        action: 'move',
+        params: { path: 'sec/victim.md', destination: 'archive/victim.md' },
+      });
+
+      expect(writes).toEqual([{ op: 'rename', path: 'archive/victim.md' }]);
+    });
+  });
+});

--- a/tests/security/write-path-containment.test.ts
+++ b/tests/security/write-path-containment.test.ts
@@ -168,8 +168,11 @@ describe('write-path containment', () => {
         params: { path: 'sec/victim.md', destination: '../escaped.md' },
       });
 
+      // The recorded-writes assertion is the load-bearing one: it fails on
+      // pre-fix vault.ts with `../escaped.md` recorded.
       expect(writes).toEqual([]);
-      expect(JSON.stringify(res)).not.toContain('Successfully moved');
+      // Names the rejecting control, so an incidental failure can't satisfy this.
+      expect(JSON.stringify(res)).toContain('FORBIDDEN_PATTERN');
     });
 
     it('vault.rename cannot relocate a file outside the vault', async () => {
@@ -181,8 +184,10 @@ describe('write-path containment', () => {
         params: { path: 'sec/victim.md', newName: '../../escaped.md' },
       });
 
+      // Load-bearing: fails on pre-fix vault.ts with `sec/../../escaped.md`.
       expect(writes).toEqual([]);
-      expect(JSON.stringify(res)).not.toContain('Successfully renamed');
+      // Names the rejecting control, so an incidental failure can't satisfy this.
+      expect(JSON.stringify(res)).toContain('FORBIDDEN_PATTERN');
     });
 
     it('vault.move still works for a legitimate destination', async () => {

--- a/tests/vault-rename-extension.test.ts
+++ b/tests/vault-rename-extension.test.ts
@@ -5,6 +5,10 @@
  * boundary is stubbed (ObsidianAPI.getFile, app.fileManager.renameFile), so the path
  * construction under test is the shipped one. The rename action had no behavioural
  * test at all before this, which is why the dropped extension shipped.
+ *
+ * The API and the app must share one App instance, as they do in production: the
+ * rename write goes through ObsidianAPI.renameFile (so the security layer can
+ * validate the destination) rather than reaching for app.fileManager directly.
  */
 import { SemanticRouter } from '../src/semantic/router';
 import { ObsidianAPI } from '../src/utils/obsidian-api';
@@ -17,8 +21,8 @@ interface RenameResult {
 }
 
 class MockObsidianAPI extends ObsidianAPI {
-  constructor(private existing: Set<string>) {
-    super({} as App);
+  constructor(private existing: Set<string>, app: App) {
+    super(app);
   }
 
   async getFile(path: string): Promise<never> {
@@ -50,7 +54,8 @@ function fakeApp(existing: Set<string>, renamed: string[]): App {
 async function rename(source: string, newName: string): Promise<{ result: RenameResult; renamed: string[] }> {
   const existing = new Set([source]);
   const renamed: string[] = [];
-  const router = new SemanticRouter(new MockObsidianAPI(existing), fakeApp(existing, renamed));
+  const app = fakeApp(existing, renamed);
+  const router = new SemanticRouter(new MockObsidianAPI(existing, app), app);
 
   const response = await router.route({
     operation: 'vault',


### PR DESCRIPTION
Three write paths reached the vault without passing through `SecureObsidianAPI`, so neither the read-only permission check nor path validation applied. All three were confirmed live against 0.11.42 (commit 4359153) in a test vault, then covered by regression tests.

Two were reported privately by email (GitHub private vulnerability reporting was disabled, and is now enabled). **The third was found while verifying the first two and is more severe than either.**

## Findings

### 1. `bases.create` bypassed read-only and the path validator

`bases-api.ts` called `app.vault.create()` directly — the one write in the plugin that reached the vault without going through the security layer. With read-only ON and after a clean restart, `bases.create` still wrote.

A `../` path **escaped the vault root**, verified on disk four levels up with an arbitrary extension. Absolute paths were neutralised (rebased inside the vault); it could not overwrite an existing file, only create.

### 2 & 3. `vault.move` / `vault.rename` path traversal — not reported, most severe

Both called `app.fileManager.renameFile()` on the raw `App`. Worse than the above in three ways: reachable in **default configuration** with read-only off, **destructive** (a move removes data from the vault, so it is an exfiltration primitive rather than an unauthorized write), and it needed no security setting to be misconfigured.

The destination went unvalidated because the destination-existence probe wrapped the path validator's `SecurityError` in a bare `catch` and read it as "doesn't exist yet":

```ts
try {
  const destFile = await ctx.api.getFile(destination);  // throws SecurityError on ../
  ...
} catch {
  // "File doesn't exist, which is what we want"   <-- swallows the rejection
}
await ctx.app.fileManager.renameFile(file, destination);  // unvalidated
```

Confirmed live: `vault.move` with `destination: '../x.md'` and `vault.rename` with `newName: '../../x.md'` both relocated files outside the vault root.

## Root cause

A standing TODO in `secure-obsidian-api.ts` said `renameFile()`/`moveFile()`/`copyFile()` "would need to be implemented in the base class first." Because the method was missing from the layer, the router reached **around** it to `app.fileManager`. The gap in the abstraction is what created the parallel, unguarded path.

## Approach — consolidate, don't add a second gate

Every fix brings an unwrapped write **into** the existing `validateOperation` gate rather than introducing a parallel check:

- add `ObsidianAPI.renameFile` so callers stop reaching around the layer, and override it in `SecureObsidianAPI` using `validateOperation`'s **already-existing `targetPath` support**, which validates destination as well as source
- override `createBase` → `validateOperation(CREATE)` + path validation
- override `updateActiveFile`/`appendToActiveFile`/`deleteActiveFile` — not currently reachable, but unwrapped they are the same bug class waiting for a caller (`patchActiveFile` needs none; it delegates to the wrapped `patchVaultFile`)
- re-throw `SecurityError` from the destination probes instead of swallowing it

A sweep confirmed these were the only leaks: exactly one direct `vault.*` write outside the layer, and no caller-controlled `adapter.write` or raw `fs` write. The two `adapter.write` calls (`.mcpignore`) and the `certificate-manager` `fs` writes use fixed, non-caller-controlled paths.

## Tests

**`write-path-containment.test.ts`** — asserts on **recorded vault writes**, not error strings, since a friendly message means nothing if the write already landed. Covers all three bypasses end-to-end through the real router, plus the legitimate-path cases so the fix doesn't just break the feature.

**`read-only-action-matrix.test.ts`** — exhaustive matrix derived from `getActionsForOperation()`, the same source the shipped tool schemas are built from, so a **newly added action fails the suite until classified** read/write/execute. That fail-closed property is the point: these bypasses existed because `edit` and `bases.create` were never classified as writes anywhere.

Each write action is also run under permissive settings and must **actually produce a write**. Without that positive control, an action erroring on missing params would record no writes and look correctly blocked while testing nothing. A stale-entry check catches removed actions, so the map can't rot in either direction.

All 44 shipped actions are classified; 497 tests pass (up from 427).

## Two incidental findings the matrix surfaced

- **`edit.window` and `edit.from_buffer` were untestable by any test in this repo.** Jest could not resolve the router's lazy `import('../tools/window-edit.js')`, so they failed with `MODULE_NOT_FOUND` before reaching any logic. Added a `moduleNameMapper`; both are now exercised.
- **`view.open_in_obsidian` is blocked by read-only.** It maps to `OperationType.EXECUTE` and `presets.readOnly()` sets `execute:false`. Opening a file mutates nothing, so this is *over*-blocking — the safe direction — and is now asserted as the actual contract rather than assumed away. But the setting description enumerates only "create, update, delete, move, rename" and understates the mode. Copy fix is in the follow-up branch.

## Scope note

`vault-rename-extension.test.ts`: the mock API and router now share one `App`, as they do in production, since the rename write moved to `ctx.api`. All assertions unchanged.

The `CLAUDE.md` commit is a separate, pre-existing docs change riding along — it records the 0.11.42 scorecard findings and flags that `npm audit` now reports 5 advisories while the portal still shows the 0.11.42 pass. Reviewable independently of the security fix; dependency remediation is tracked separately.

## Not included

Read-only mode still requires a server restart to take effect, in both directions, while the UI toast claims writes are blocked immediately. That is a real defect but a behaviour change plus a refactor of the enforcement path, so it lands separately under ADR-108 rather than being bundled here.
