### PR TITLE
fix(security): make read-only mode take effect immediately (ADR-108)

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -28,6 +28,7 @@ _Server architecture, transport, connection handling, plugin lifecycle_
 | [ADR-105](./core/ADR-105-remove-dormant-worker-offload-path-partial-reversal-of-adr-104.md) | Remove dormant worker-offload path (partial reversal of ADR-104) | Accepted |
 | [ADR-106](./core/ADR-106-client-driven-session-re-initialization-via-spec-compliant-http-404.md) | Client-driven session re-initialization via spec-compliant HTTP 404 | Accepted |
 | [ADR-107](./core/ADR-107-network-exposure-modes-as-a-classified-state-machine.md) | Network exposure modes as a classified state machine | Accepted |
+| [ADR-108](./core/ADR-108-consolidate-read-only-enforcement-onto-the-security-layer-and-make-it-live.md) | Consolidate read-only enforcement onto the security layer and make it live | Draft |
 
 ## Tools & API
 _MCP tool design, semantic operations, graph operations, formatters_

--- a/docs/architecture/core/ADR-108-consolidate-read-only-enforcement-onto-the-security-layer-and-make-it-live.md
+++ b/docs/architecture/core/ADR-108-consolidate-read-only-enforcement-onto-the-security-layer-and-make-it-live.md
@@ -70,18 +70,40 @@ permission state is read live rather than snapshotted.**
    fail-open shape as the original bug. A live predicate is correct by
    construction: new and existing sessions consult one source.
 
-3. **Demote the tool-layer guard to presentation.** It stops deciding anything.
+3. **The baseline ruleset must stay permissive.** The predicate can only *add*
+   denial; it cannot grant. That asymmetry is deliberate — a user who configures
+   restrictive permissions should not have them loosened by a read-only toggle —
+   but it makes a restrictive baseline a one-way door. `mcp-server.ts` previously
+   installed `presets.readOnly()` when the server booted with read-only on, so
+   toggling read-only *off* left every permission false until the next restart:
+   the OFF direction of the very bug this ADR set out to fix, surviving in a file
+   the first draft of this decision did not touch. The branch is removed and the
+   single permissive `BASELINE_SECURITY_SETTINGS` is exported so a test can pin
+   the invariant. Path validation and `.mcpignore` blocking are unaffected —
+   those are not permissions.
+
+4. **Demote the tool-layer guard to presentation.** It stops deciding anything.
    `PERMISSION_DENIED` from the security layer is relabelled to
    `READ_ONLY_MODE` when read-only is on, preserving the clearer error without a
    second gate. Removing enforcement here is the point: the duplicate is the
    defect.
 
-4. **Correct the user-facing copy.** The toggle notice stops asserting an
-   immediate guarantee it cannot make (now it can, so the notice becomes true),
-   and the setting description stops enumerating an incomplete list of blocked
-   operations. Read-only also blocks `view.open_in_obsidian` — it maps to
-   `OperationType.EXECUTE`, which `presets.readOnly()` denies — and the
-   description said only "create, update, delete, move, rename".
+5. **Correct the user-facing copy.** The toggle notice stops asserting an
+   immediate guarantee it cannot make — now it can, so the notice becomes true.
+   The setting description stops enumerating an incomplete list
+   ("create, update, delete, move, rename") and states the actual rule: every
+   operation that changes the vault is blocked, reads and opens still work, and
+   it takes effect immediately.
+
+6. **Split `openFile` off `EXECUTE`.** `EXECUTE` originally meant `openFile`
+   alone, and read-only denied it, so read-only blocked opening a note — which
+   mutates nothing. Wrapping `executeCommand` (needed, since the command palette
+   reaches "Delete current file") put a genuinely dangerous operation behind the
+   same permission, forcing a choice between blocking a harmless open and
+   permitting arbitrary commands under read-only. `openFile` is now charged as
+   `READ` and works under read-only; `EXECUTE` covers `executeCommand` and stays
+   denied. Path validation still applies to `openFile`, so it cannot probe outside
+   the vault or open an excluded file.
 
 ## Consequences
 
@@ -91,8 +113,12 @@ permission state is read live rather than snapshotted.**
   both directions, matching what the UI has always claimed.
 - One place to reason about. A future operation is enforced by the gate it
   already flows through; there is no second list to remember to update.
-- Restart-order bugs in this area become structurally impossible rather than
-  merely fixed — there is no snapshot left to go stale.
+- Restart-order bugs in this area are structurally closed for the *permission*
+  state: there is no read-only snapshot left to go stale. This claim was too broad
+  in the first draft — the predicate's add-only asymmetry meant a restrictive
+  *baseline* still had to be removed separately (decision 3) before the OFF
+  direction worked. The remaining snapshot is the non-read-only settings, which
+  the toggle does not touch.
 - The notice stops lying, which is the part of the reported finding that
   actually harmed users.
 
@@ -117,7 +143,11 @@ permission state is read live rather than snapshotted.**
   demotion lands, or the demotion removes the thing that was masking the gap
   and nothing notices.
 - `presets.readOnly()` remains for explicit/API use; it is no longer the
-  mechanism by which the settings toggle takes effect.
+  mechanism by which the settings toggle takes effect, and is no longer installed
+  at server construction.
+- A restrictive baseline still cannot be loosened at runtime, by design. Anything
+  that wants runtime-adjustable permissions beyond read-only needs its own
+  predicate rather than a snapshot.
 
 ## Alternatives Considered
 

--- a/docs/architecture/core/ADR-108-consolidate-read-only-enforcement-onto-the-security-layer-and-make-it-live.md
+++ b/docs/architecture/core/ADR-108-consolidate-read-only-enforcement-onto-the-security-layer-and-make-it-live.md
@@ -1,0 +1,138 @@
+---
+status: Draft
+date: 2026-07-29
+deciders:
+  - aaronsb
+related:
+  - ADR-101
+---
+
+# ADR-108: Consolidate read-only enforcement onto the security layer and make it live
+
+## Context
+
+Read-only mode is enforced in **two** places that derive their state from
+different sources and disagree with each other:
+
+1. **Tool layer** — `src/tools/semantic-tools.ts:142` reads
+   `plugin.settings.readOnlyMode` **live** on every dispatch, but only for
+   `operation === 'vault'`.
+2. **Security layer** — `src/mcp-server.ts:132` picks
+   `VaultSecurityManager.presets.readOnly()` **once, in the server
+   constructor**, and hands it to `SecureObsidianAPI`.
+
+The split produces a state neither author intended. Toggling read-only on a
+running server arms the live tool-layer check immediately while the security
+layer keeps the permissive ruleset it was constructed with, so `vault.create` is
+refused while `edit.append` writes to disk. Disabling read-only has the mirror
+problem: writes stay blocked until the next restart.
+
+The settings toggle claims otherwise. `src/main.ts:1100` shows
+*"🔒 Read-only mode enabled. All write operations are blocked."* while the debug
+line beside it concedes *"Server restart required for activation."* A user who
+believes the notice gets a containment boundary that is not in effect.
+
+This was reported externally as an `edit`-bypasses-read-only vulnerability. The
+reporter attributed it to the tool-layer guard's `operation === 'vault'`
+narrowness. That narrowness is real, but it is not sufficient to explain the
+write: every `edit` action routes through a method wrapped by the security layer
+(`appendToFile`, `patchVaultFile`, `updateFile`), and those correctly reject when
+the layer holds the read-only preset. The write landed because the layer was
+holding a **stale** ruleset. The finding reproduces only without a restart.
+
+A related structural problem sits behind ADR-108's sibling fix (#276): three
+write paths reached the vault without passing through the security layer at all.
+The cause there was a **missing method on the abstraction** — the layer had no
+move/rename method, so calling code reached around it to `app.fileManager`.
+Widening the tool-layer guard into a general write-action registry was
+considered and rejected during that work: adding a second policy engine is what
+created this class of bug, and a registry would have to be kept in sync with
+every new action forever.
+
+The constraint that shapes this decision: **one enforcement path, not two.**
+
+## Decision
+
+**Enforcement lives solely in `VaultSecurityManager.validateOperation`, and its
+permission state is read live rather than snapshotted.**
+
+1. **Make the permission source live.** `isOperationAllowed` consults a
+   read-only predicate injected from the plugin settings before consulting the
+   settings snapshot. When read-only is on, `READ` is permitted and everything
+   else is denied — which is exactly `presets.readOnly()`, evaluated per call
+   instead of per construction.
+
+2. **Pull, not push.** Session-scoped `SecureObsidianAPI` instances are created
+   inside `MCPServerPool.createPooledServer` and captured in closures; the
+   `servers` map holds `PooledServer`, not the API. There is no registry of live
+   API instances to iterate, so a "broadcast the new settings on toggle" design
+   has nothing to broadcast to and would silently miss instances — the same
+   fail-open shape as the original bug. A live predicate is correct by
+   construction: new and existing sessions consult one source.
+
+3. **Demote the tool-layer guard to presentation.** It stops deciding anything.
+   `PERMISSION_DENIED` from the security layer is relabelled to
+   `READ_ONLY_MODE` when read-only is on, preserving the clearer error without a
+   second gate. Removing enforcement here is the point: the duplicate is the
+   defect.
+
+4. **Correct the user-facing copy.** The toggle notice stops asserting an
+   immediate guarantee it cannot make (now it can, so the notice becomes true),
+   and the setting description stops enumerating an incomplete list of blocked
+   operations. Read-only also blocks `view.open_in_obsidian` — it maps to
+   `OperationType.EXECUTE`, which `presets.readOnly()` denies — and the
+   description said only "create, update, delete, move, rename".
+
+## Consequences
+
+### Positive
+
+- The switch behaves as a switch. Toggling read-only takes effect immediately in
+  both directions, matching what the UI has always claimed.
+- One place to reason about. A future operation is enforced by the gate it
+  already flows through; there is no second list to remember to update.
+- Restart-order bugs in this area become structurally impossible rather than
+  merely fixed — there is no snapshot left to go stale.
+- The notice stops lying, which is the part of the reported finding that
+  actually harmed users.
+
+### Negative
+
+- A per-call predicate is marginally more work than reading a cached boolean.
+  Negligible against the vault I/O and path validation in the same call, but it
+  is no longer a pure field read.
+- `validateOperation` gains a dependency on plugin settings, coupling the
+  security layer to the plugin shape a little more tightly. Mitigated by
+  injecting a predicate rather than the plugin object.
+- Demoting the tool-layer guard removes a redundant check. Redundancy has value
+  against a bug in the remaining gate, so the gate's test coverage has to carry
+  more weight — see below.
+
+### Neutral
+
+- Requires the enforcement tests added in #276 to keep a mode that arms **only**
+  the security layer. Those tests originally passed on vulnerable code because
+  the legacy tool-layer guard satisfied them; a `securityLayer` invoke mode was
+  added so the layer is exercised directly. That mode must exist **before** this
+  demotion lands, or the demotion removes the thing that was masking the gap
+  and nothing notices.
+- `presets.readOnly()` remains for explicit/API use; it is no longer the
+  mechanism by which the settings toggle takes effect.
+
+## Alternatives Considered
+
+- **Widen the tool-layer guard into a fail-closed write-action registry.**
+  Rejected: it entrenches two enforcement paths, which is the cause of this
+  defect, and requires perpetual sync with every new action. Explicitly ruled
+  out by the maintainer during #276.
+- **Push updated settings to every live API instance on toggle.** Rejected: the
+  session APIs are closure-captured with no registry to iterate, so the push
+  would be partial and fail open — the original bug's shape. It also leaves the
+  snapshot in place, so the class of bug survives.
+- **Keep restart-required and only fix the wording** (notice says "takes effect
+  after restart"). Rejected: honest, but a toggle that needs a restart
+  contradicts what a switch means to a user, and this is a containment control
+  where the gap between belief and reality is the harm. Cheapest option, and the
+  fallback if liveness proves unstable.
+- **Recreate the server on toggle.** Rejected: correct but disproportionate —
+  it drops every live MCP session to change one boolean.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1087,19 +1087,22 @@ class MCPSettingTab extends PluginSettingTab {
 		
 		new Setting(containerEl)
 			.setName('Read-only mode')
-			.setDesc('Enable read-only mode - blocks all write operations (create, update, delete, move, rename)')
+			.setDesc('Blocks every operation that changes the vault, and blocks opening files in Obsidian. Reads, searches and graph queries still work. Takes effect immediately.')
 			.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.readOnlyMode)
 				.onChange(async (value) => {
 					this.plugin.settings.readOnlyMode = value;
 					await this.plugin.saveSettings();
 					
-					// Debug logging for read-only mode changes
+					// Effective immediately, no restart (ADR-108): the security layer
+					// reads this setting live per operation. The notices below used to
+					// claim writes were blocked while the running server still held a
+					// permissive ruleset until restart — the claim is now true.
 					if (value) {
-						Debug.log('🔒 READ-ONLY MODE ENABLED via settings - Server restart required for activation');
-						new Notice('🔒 Read-only mode enabled. All write operations are blocked.');
+						Debug.log('🔒 READ-ONLY MODE ENABLED via settings - effective immediately');
+						new Notice('🔒 Read-only mode enabled. Write operations are blocked.');
 					} else {
-						Debug.log('✅ READ-ONLY MODE DISABLED via settings - Server restart required for deactivation');
+						Debug.log('✅ READ-ONLY MODE DISABLED via settings - effective immediately');
 						new Notice('✅ Read-only mode disabled. All operations are allowed.');
 					}
 					

--- a/src/main.ts
+++ b/src/main.ts
@@ -1087,7 +1087,7 @@ class MCPSettingTab extends PluginSettingTab {
 		
 		new Setting(containerEl)
 			.setName('Read-only mode')
-			.setDesc('Blocks every operation that changes the vault, and blocks opening files in Obsidian. Reads, searches and graph queries still work. Takes effect immediately.')
+			.setDesc('Blocks every operation that changes the vault. Reads, searches, graph queries and opening notes still work. Takes effect immediately — no restart needed.')
 			.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.readOnlyMode)
 				.onChange(async (value) => {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -120,7 +120,11 @@ export class MCPHttpServer {
   private mcpServerPool!: MCPServerPool;
   private transports: Map<string, StreamableHTTPServerTransport> = new Map();
   private obsidianApp: App;
-  private obsidianAPI: ObsidianAPI;
+  // Deliberately the narrow type, not ObsidianAPI. Every session's API is built
+  // from this one, and MCPServerPool now refuses to create a session when it is
+  // not a SecureObsidianAPI — so a future assignment of a plain ObsidianAPI here
+  // should fail to compile rather than fail at session creation.
+  private obsidianAPI: SecureObsidianAPI;
   private port: number;
   private isRunning: boolean = false;
   private connectionCount: number = 0;

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -156,7 +156,7 @@ export class MCPHttpServer {
     Debug.log('🔐 Initializing VaultSecurityManager firewall');
     
     // One baseline ruleset, regardless of read-only (ADR-108). See
-    // BASELINE_SECURITY_SETTINGS below for why it must stay permissive.
+    // BASELINE_SECURITY_SETTINGS above for why it must stay permissive.
     //
     // This used to branch on readOnlyMode and install presets.readOnly() when it
     // was set. That snapshot was the whole bug: read-only became whatever it was

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -11,7 +11,7 @@ import {
 import { randomUUID } from 'crypto';
 import { getVersion } from './version';
 import { ObsidianAPI } from './utils/obsidian-api';
-import { SecureObsidianAPI, VaultSecurityManager } from './security';
+import { SecureObsidianAPI } from './security';
 import { semanticTools } from './tools/semantic-tools';
 import { Debug } from './utils/debug';
 import { ConnectionPool, PooledRequest } from './utils/connection-pool';
@@ -86,6 +86,34 @@ interface ConnectionPoolStatsResponse {
 }
 
 
+/**
+ * The security baseline every server and session API is built with.
+ *
+ * Permissions are all TRUE on purpose, and must stay that way (ADR-108).
+ * Read-only is enforced by VaultSecurityManager's live predicate, which only
+ * ever ADDS denial — it cannot grant. So a restrictive baseline is a one-way
+ * door: installing presets.readOnly() here (which is what this used to do when
+ * the server booted with read-only on) meant toggling read-only OFF could not
+ * restore writes until the next restart.
+ *
+ * Path validation and .mcpignore blocking are unaffected — those are not
+ * permissions and still apply.
+ */
+export const BASELINE_SECURITY_SETTINGS = {
+  pathValidation: 'strict' as const,  // Always validate paths for security
+  permissions: {
+    read: true,
+    create: true,
+    update: true,
+    delete: true,
+    move: true,
+    rename: true,
+    execute: true
+  },
+  blockedPaths: [],  // .mcpignore will handle blocking
+  logSecurityEvents: false
+};
+
 export class MCPHttpServer {
   private app: express.Application;
   private server?: Server | HttpsServer;
@@ -127,30 +155,22 @@ export class MCPHttpServer {
     // Always use SecureObsidianAPI with VaultSecurityManager as our firewall
     Debug.log('🔐 Initializing VaultSecurityManager firewall');
     
-    // Configure security rules based on mode
-    let securitySettings;
-    if (plugin?.settings?.readOnlyMode) {
-      Debug.log('🔒 READ-ONLY MODE ACTIVATED - Loading restrictive ruleset');
-      securitySettings = VaultSecurityManager.presets.readOnly();
-    } else {
-      Debug.log('✅ READ-ONLY MODE DEACTIVATED - Loading permissive ruleset');
-      // Minimal security - just path validation and .mcpignore blocking
-      securitySettings = {
-        pathValidation: 'strict' as const,  // Always validate paths for security
-        permissions: {
-          read: true,
-          create: true,
-          update: true,
-          delete: true,
-          move: true,
-          rename: true,
-          execute: true
-        },
-        blockedPaths: [],  // .mcpignore will handle blocking
-        logSecurityEvents: false
-      };
-    }
-    
+    // One baseline ruleset, regardless of read-only (ADR-108). See
+    // BASELINE_SECURITY_SETTINGS below for why it must stay permissive.
+    //
+    // This used to branch on readOnlyMode and install presets.readOnly() when it
+    // was set. That snapshot was the whole bug: read-only became whatever it was
+    // at construction. The live predicate in VaultSecurityManager only ever ADDS
+    // denial, so a readOnly snapshot here could not be un-done by toggling the
+    // setting off — every write stayed denied until the next restart, for exactly
+    // the user who runs read-only by default and flips it off for one edit.
+    //
+    // Read-only is now enforced solely by that predicate, which reads the setting
+    // per call. Baseline permissions stay permissive so the predicate is the only
+    // thing that decides.
+    const securitySettings = BASELINE_SECURITY_SETTINGS;
+    Debug.log(`🔐 Baseline ruleset loaded; read-only currently ${plugin?.settings?.readOnlyMode ? 'ON' : 'OFF'} (live)`);
+
     // Always use SecureObsidianAPI for consistent security layer
     this.obsidianAPI = new SecureObsidianAPI(obsidianApp, undefined, plugin, securitySettings);
     

--- a/src/security/secure-obsidian-api.ts
+++ b/src/security/secure-obsidian-api.ts
@@ -202,12 +202,16 @@ export class SecureObsidianAPI extends ObsidianAPI {
 	 * to…"), so an unwrapped executeCommand is a write path around the layer.
 	 * Latent today — only getCommands() is wired to a tool — but wrapped for the
 	 * same reason as the active-file writes above.
+	 *
+	 * Goes through validateOperation like every other write, rather than a
+	 * separate synchronous permission check: one gate function, and no entry
+	 * point that silently cannot validate a path.
 	 */
-	executeCommand(commandId: string): ReturnType<ObsidianAPI['executeCommand']> {
-		this.security.assertOperationPermitted(
-			OperationType.EXECUTE,
-			{ method: 'executeCommand', commandId }
-		);
+	async executeCommand(commandId: string): ReturnType<ObsidianAPI['executeCommand']> {
+		await this.security.validateOperation({
+			type: OperationType.EXECUTE,
+			context: { method: 'executeCommand', commandId }
+		});
 
 		return super.executeCommand(commandId);
 	}

--- a/src/security/secure-obsidian-api.ts
+++ b/src/security/secure-obsidian-api.ts
@@ -18,6 +18,7 @@ interface SecurePluginRef {
 		security?: Partial<SecuritySettings>;
 		validation?: Partial<import('../validation/input-validator').ValidationConfig>;
 		httpPort?: number;
+		readOnlyMode?: boolean;
 	};
 	ignoreManager?: MCPIgnoreManager;
 	mcpServer?: { isServerRunning(): boolean; getConnectionCount(): number };
@@ -37,7 +38,16 @@ export class SecureObsidianAPI extends ObsidianAPI {
 		// Initialize security manager with provided or default settings
 		const settings: Partial<SecuritySettings> = securitySettings || plugin?.settings?.security || {};
 		const ignoreManager: MCPIgnoreManager | undefined = plugin?.ignoreManager;
-		this.security = new VaultSecurityManager(app, settings, ignoreManager);
+
+		// Read-only is read live off the plugin settings, not captured here
+		// (ADR-108). Reading `plugin.settings.readOnlyMode` inside the closure
+		// rather than dereferencing it now is what makes the toggle take effect
+		// without a server restart.
+		const isReadOnly = plugin
+			? (): boolean => plugin.settings?.readOnlyMode === true
+			: undefined;
+
+		this.security = new VaultSecurityManager(app, settings, ignoreManager, isReadOnly);
 		
 		Debug.log('🔐 SecureObsidianAPI initialized with security settings:', this.security.getSettings());
 		Debug.log('🔐 SecureObsidianAPI has ignoreManager:', !!ignoreManager);

--- a/src/security/secure-obsidian-api.ts
+++ b/src/security/secure-obsidian-api.ts
@@ -42,10 +42,22 @@ export class SecureObsidianAPI extends ObsidianAPI {
 		// Read-only is read live off the plugin settings, not captured here
 		// (ADR-108). Reading `plugin.settings.readOnlyMode` inside the closure
 		// rather than dereferencing it now is what makes the toggle take effect
-		// without a server restart.
+		// without a server restart — and it survives loadSettings() replacing the
+		// settings object wholesale, which main.ts does.
+		//
+		// Without a plugin ref there is no setting to read, so read-only CANNOT be
+		// enforced on this instance. Every production call site passes one; a
+		// future one that forgets would silently lose read-only, so say so loudly
+		// rather than leaving it to be discovered.
 		const isReadOnly = plugin
 			? (): boolean => plugin.settings?.readOnlyMode === true
 			: undefined;
+		if (!plugin) {
+			Debug.error(
+				'⚠️ SecureObsidianAPI built without a plugin reference: read-only mode ' +
+				'cannot be enforced on this instance. Path validation still applies.'
+			);
+		}
 
 		this.security = new VaultSecurityManager(app, settings, ignoreManager, isReadOnly);
 		

--- a/src/security/secure-obsidian-api.ts
+++ b/src/security/secure-obsidian-api.ts
@@ -274,15 +274,30 @@ export class SecureObsidianAPI extends ObsidianAPI {
 		return super.deleteActiveFile();
 	}
 
-	// File Operations - EXECUTE
+	// File Operations - OPEN
 
+	/**
+	 * Charged as READ, not EXECUTE.
+	 *
+	 * Opening a note changes nothing in the vault — it asks Obsidian to show a
+	 * document the caller is already allowed to read, so read-only has no reason
+	 * to deny it. EXECUTE originally meant exactly this method, but it now also
+	 * covers executeCommand, which can reach destructive commands ("Delete current
+	 * file"). Sharing one permission between the two would force a choice between
+	 * blocking a harmless open and permitting arbitrary commands under read-only.
+	 * Splitting them keeps executeCommand denied while `view.open_in_obsidian`
+	 * keeps working.
+	 *
+	 * Path validation still applies, so this cannot be used to probe outside the
+	 * vault or to open an .mcpignore-excluded file.
+	 */
 	async openFile(path: string): ReturnType<ObsidianAPI['openFile']> {
 		const validated = await this.security.validateOperation({
-			type: OperationType.EXECUTE,
+			type: OperationType.READ,
 			path: path,
 			context: { method: 'openFile' }
 		});
-		
+
 		return super.openFile(validated.path!);
 	}
 

--- a/src/security/vault-security-manager.ts
+++ b/src/security/vault-security-manager.ts
@@ -261,28 +261,6 @@ export class VaultSecurityManager {
 	}
 
 	/**
-	 * Synchronous permission check for operations with no path to validate.
-	 *
-	 * Exists for callers whose base signature is synchronous (executeCommand), so
-	 * they cannot await validateOperation. This is the SAME policy — it delegates
-	 * to isOperationAllowed and logs identically — not a second gate. Anything
-	 * with a path must use validateOperation so path validation runs too.
-	 */
-	assertOperationPermitted(type: OperationType, context?: VaultOperation['context']): void {
-		const operation: VaultOperation = { type, context };
-
-		if (!this.isOperationAllowed(type)) {
-			this.logSecurityEvent(operation, 'blocked', 'PERMISSION_DENIED');
-			throw new SecurityError(
-				`Operation '${type}' is not permitted in current security mode`,
-				'PERMISSION_DENIED'
-			);
-		}
-
-		this.logSecurityEvent(operation, 'allowed');
-	}
-
-	/**
 	 * Checks if an operation type is allowed
 	 */
 	private isOperationAllowed(type: OperationType): boolean {

--- a/src/security/vault-security-manager.ts
+++ b/src/security/vault-security-manager.ts
@@ -17,7 +17,10 @@ export enum OperationType {
 	MOVE = 'move',        // moveFile
 	RENAME = 'rename',    // renameFile
 	COPY = 'copy',        // copyFile
-	EXECUTE = 'execute'   // openFile (opens in Obsidian)
+	// Running an Obsidian command by id. Originally meant openFile, which is now
+	// charged as READ: opening a note mutates nothing, while the command palette
+	// reaches destructive commands, so they cannot share one permission.
+	EXECUTE = 'execute'
 }
 
 /**

--- a/src/security/vault-security-manager.ts
+++ b/src/security/vault-security-manager.ts
@@ -155,19 +155,17 @@ export class VaultSecurityManager {
 					);
 				}
 
-				// Return operation as-is without path validation
-				// Cast paths to ValidatedPath since we're bypassing validation
+				// Paths pass through unvalidated — that is what 'disabled' means.
+				// The spread already carries path and targetPath; two `if
+				// (operation.path)` re-assignments used to sit here writing the same
+				// values back. They were pure no-ops, but read as the presence
+				// semantics the strict branch below now uses, which made this look
+				// like a spot someone forgot to update. A false parallel is worse
+				// than none.
 				const result = {
 					...operation,
 					validatedAt: Date.now()
 				};
-
-				if (operation.path) {
-					result.path = operation.path;
-				}
-				if (operation.targetPath) {
-					result.targetPath = operation.targetPath;
-				}
 
 				return result as ValidatedOperation;
 			}

--- a/src/security/vault-security-manager.ts
+++ b/src/security/vault-security-manager.ts
@@ -109,11 +109,28 @@ export class VaultSecurityManager {
 	private auditLog: SecurityLogEntry[] = [];
 	private readonly maxLogEntries = 1000;
 	private ignoreManager?: MCPIgnoreManager;
+	private isReadOnly?: () => boolean;
 
-	constructor(app: App, settings: Partial<SecuritySettings> = {}, ignoreManager?: MCPIgnoreManager) {
+	/**
+	 * @param isReadOnly - Live read-only predicate, consulted per call (ADR-108).
+	 *   Passed as a function rather than a boolean on purpose: the settings
+	 *   snapshot taken at construction is what let read-only go stale, blocking
+	 *   `vault` writes via the tool layer while `edit` writes kept working
+	 *   through a permissive security layer until the next server restart.
+	 *   Session-scoped API instances are closure-captured with no registry to
+	 *   push updates to, so pulling from one live source is the only design that
+	 *   cannot miss an instance.
+	 */
+	constructor(
+		app: App,
+		settings: Partial<SecuritySettings> = {},
+		ignoreManager?: MCPIgnoreManager,
+		isReadOnly?: () => boolean
+	) {
 		this.validator = new SecurePathValidator(app);
 		this.settings = { ...DEFAULT_SECURITY_SETTINGS, ...settings };
 		this.ignoreManager = ignoreManager;
+		this.isReadOnly = isReadOnly;
 		Debug.log(`VaultSecurityManager initialized with ignoreManager: ${!!ignoreManager}`);
 	}
 
@@ -269,8 +286,17 @@ export class VaultSecurityManager {
 	 * Checks if an operation type is allowed
 	 */
 	private isOperationAllowed(type: OperationType): boolean {
+		// Live read-only check, ahead of the snapshot (ADR-108). Equivalent to
+		// presets.readOnly() but evaluated per call, so toggling the setting takes
+		// effect immediately in both directions instead of at the next server
+		// start. READ is the only operation read-only permits; EXECUTE is denied
+		// too, matching presets.readOnly().
+		if (this.isReadOnly?.() && type !== OperationType.READ) {
+			return false;
+		}
+
 		const perms = this.settings.permissions;
-		
+
 		switch (type) {
 			case OperationType.READ:
 				return perms.read;

--- a/src/semantic/operations/vault.ts
+++ b/src/semantic/operations/vault.ts
@@ -473,14 +473,24 @@ export async function executeVaultOperation(ctx: RouterContext, action: string, 
         try {
           const sourceFile = await ctx.api.getFile(path);
           return await copyFile(ctx, path, destination, overwrite, sourceFile);
-        } catch {
+        } catch (error) {
+          // A security refusal is not "maybe it's a directory". Retrying as a
+          // directory and then reporting a missing source told a read-only user
+          // their file did not exist — same swallow that hid the move/rename
+          // traversal, with a misleading error instead of a bypass.
+          if (error instanceof SecurityError) {
+            throw error;
+          }
           // If file operation failed, try as directory (this will also go through security validation)
           try {
             // Test if it's a directory by trying to list its contents
             await ctx.api.listFiles(path);
             // If listing succeeds, it's a directory
             return await copyDirectoryRecursive(ctx, path, destination, overwrite);
-          } catch {
+          } catch (dirError) {
+            if (dirError instanceof SecurityError) {
+              throw dirError;
+            }
             // Neither file nor directory worked
             throw new Error(`Source not found or inaccessible: ${path}`);
           }

--- a/src/tools/semantic-tools.ts
+++ b/src/tools/semantic-tools.ts
@@ -137,35 +137,15 @@ const createSemanticTool = (operation: string, visibility?: ToolVisibility): Sem
       };
     }
 
-    // Check for read-only mode before processing write operations
+    // Read-only mode is NOT enforced here (ADR-108). It is enforced once, in
+    // VaultSecurityManager.validateOperation, which now reads the setting live.
+    // This layer previously enforced it too — for `operation === 'vault'` only —
+    // and the two disagreed: the live check here blocked `vault` writes while a
+    // security layer holding a stale snapshot let `edit` writes through until the
+    // next server restart. The duplicate gate was the defect, so it is gone
+    // rather than widened. What remains below is presentation.
     const plugin = (api as unknown as { plugin?: PluginWithSettings }).plugin;
-    if (plugin?.settings?.readOnlyMode && operation === 'vault') {
-      const writeOperations = ['create', 'update', 'delete', 'move', 'rename', 'copy', 'split', 'concatenate'];
-      // combine writes a file only when a destination is given; without one it
-      // returns content inline (no side effects) and is safe in read-only mode.
-      const isWriteOp = writeOperations.includes(args.action) ||
-        (args.action === 'combine' && Boolean(args.destination));
-      if (isWriteOp) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: JSON.stringify({
-              error: {
-                code: 'READ_ONLY_MODE',
-                message: `Write operation '${args.action}' is blocked - read-only mode is enabled`
-              },
-              context: {
-                readOnlyMode: true,
-                operation: operation,
-                action: args.action,
-                blockedOperation: true
-              }
-            }, null, 2)
-          }]
-        };
-      }
-    }
-    
+
     // Handle Dataview operations separately
     if (operation === 'dataview') {
       const dataviewTool = new DataviewTool(api);
@@ -279,11 +259,27 @@ const createSemanticTool = (operation: string, visibility?: ToolVisibility): Sem
     
     // Format for MCP
     if (response.error) {
+      // Presentation only: relabel the security layer's generic
+      // PERMISSION_DENIED as READ_ONLY_MODE when read-only is what caused it, so
+      // callers get an actionable reason instead of "not permitted in current
+      // security mode". This makes no policy decision — the operation was already
+      // refused by the gate. Deciding here is what ADR-108 removed.
+      const error = plugin?.settings?.readOnlyMode &&
+        (response.error as { code?: string }).code === 'PERMISSION_DENIED'
+        ? {
+            ...response.error,
+            code: 'READ_ONLY_MODE',
+            // Not "write operation" — read-only also denies EXECUTE
+            // (view.open_in_obsidian), which writes nothing.
+            message: `Operation '${args.action}' is blocked - read-only mode is enabled`
+          }
+        : response.error;
+
       return {
         content: [{
           type: 'text' as const,
           text: JSON.stringify({
-            error: response.error,
+            error,
             workflow: response.workflow,
             context: response.context
           }, null, 2)

--- a/src/utils/mcp-server-pool.ts
+++ b/src/utils/mcp-server-pool.ts
@@ -152,9 +152,16 @@ export class MCPServerPool extends EventEmitter {
       );
       Debug.log(`🔐 Created secure session API for session ${sessionId}`);
     } else {
-      // Fallback to regular ObsidianAPI
-      sessionAPI = new ObsidianAPI(this.obsidianAPI.getApp(), undefined, this.plugin);
-      Debug.log(`⚠️ Created regular session API for session ${sessionId} (no security)`);
+      // Previously this fell back to a plain ObsidianAPI and logged "(no
+      // security)" — a session with NOTHING between it and vault writes: no
+      // read-only, no path validation, no .mcpignore. Unreachable today because
+      // mcp-server.ts always builds a SecureObsidianAPI, but a silent fail-open
+      // is exactly the shape of the bugs this enforcement work exists to close,
+      // so it fails loudly instead of quietly serving an unguarded session.
+      throw new Error(
+        'Refusing to create a session without the security layer: the parent API ' +
+        'is not a SecureObsidianAPI. This is a wiring bug, not a runtime condition.'
+      );
     }
 
     // Get available tools (filtered by visibility settings)

--- a/src/utils/obsidian-api.ts
+++ b/src/utils/obsidian-api.ts
@@ -488,16 +488,6 @@ export class ObsidianAPI {
     return { success: true, oldPath: path, newPath };
   }
 
-  /**
-   * Run an Obsidian command by id.
-   *
-   * Wrapped as an EXECUTE operation in SecureObsidianAPI: the command palette
-   * includes mutators ("Delete current file", "Move file to…"), so an
-   * unguarded executeCommand is a write path that skips the security layer.
-   * Only getCommands() is currently wired to a tool, which is why this was
-   * latent rather than exploitable.
-   */
-
   async appendToFile(path: string, content: string) {
     // Validate input
     const validationResult = this.validator.validate('file.append', { content });
@@ -933,7 +923,20 @@ export class ObsidianAPI {
     }));
   }
 
-  executeCommand(commandId: string) {
+  /**
+   * Run an Obsidian command by id.
+   *
+   * `async` purely so SecureObsidianAPI's override can await validateOperation,
+   * keeping a single gate function rather than adding a synchronous entry point
+   * that cannot validate paths. Nothing calls this yet — only getCommands() is
+   * wired to a tool — so widening the signature costs nothing today.
+   *
+   * It needs the gate because the command palette contains mutators ("Delete
+   * current file", "Move file to…"), making an unguarded executeCommand a write
+   * path around the security layer.
+   */
+  async executeCommand(commandId: string) {
+    await Promise.resolve();
     const appInternal = this.app as unknown as AppInternal;
     const success = appInternal.commands?.executeCommandById?.(commandId);
     return {

--- a/tests/security/read-only-action-matrix.test.ts
+++ b/tests/security/read-only-action-matrix.test.ts
@@ -312,7 +312,10 @@ describe('read-only enforcement — exhaustive action matrix', () => {
         content: [{ type: 'text' as const, text: String(e) }],
       }));
 
-      expect(JSON.stringify(res)).toContain('PERMISSION_DENIED');
+      // Surfaced as READ_ONLY_MODE: the security layer denies it as
+      // PERMISSION_DENIED and the tool layer relabels for the caller (ADR-108).
+      // Either code means the gate refused it.
+      expect(JSON.stringify(res)).toMatch(/READ_ONLY_MODE|PERMISSION_DENIED/);
       expect(writes).toEqual([]);
     });
   });

--- a/tests/security/read-only-action-matrix.test.ts
+++ b/tests/security/read-only-action-matrix.test.ts
@@ -37,13 +37,13 @@ const OPERATIONS: readonly string[] = ALL_OPERATIONS;
  * Every action's expected effect on the vault. Adding an action to
  * getActionsForOperation() without adding it here fails the coverage test.
  *
- * 'execute' is its own kind, not a synonym for read: opening a file in the
- * Obsidian UI mutates nothing, but it maps to OperationType.EXECUTE and
- * presets.readOnly() sets execute:false, so read-only DOES block it. That is
- * over-blocking, which is the safe direction — recorded here as the actual
- * contract rather than assumed away. Note the Read-only setting description
- * enumerates only "create, update, delete, move, rename", so the copy
- * understates what the mode does.
+ * 'execute' is kept as a distinct kind even though no shipped action maps to it
+ * today. view.open_in_obsidian used to: it was charged as EXECUTE, which
+ * presets.readOnly() denies, so read-only blocked opening a note. Opening mutates
+ * nothing, so openFile is now charged as READ and works under read-only. EXECUTE
+ * survives for executeCommand — unreachable from any tool, and denied under
+ * read-only because the command palette reaches destructive commands. If an
+ * action ever maps to it again, classify it here.
  */
 const ACTION_KIND: Record<string, 'read' | 'write' | 'execute'> = {
   // vault
@@ -70,7 +70,7 @@ const ACTION_KIND: Record<string, 'read' | 'write' | 'execute'> = {
   'view.file': 'read',
   'view.window': 'read',
   'view.active': 'read',
-  'view.open_in_obsidian': 'execute',
+  'view.open_in_obsidian': 'read',
   // workflow / system
   'workflow.suggest': 'read',
   'system.info': 'read',
@@ -314,8 +314,17 @@ describe('read-only enforcement — exhaustive action matrix', () => {
 
   const executeActions = allActions.filter(a => ACTION_KIND[a.key] === 'execute' && invocable(a.op));
 
-  describe.each(executeActions)('$key (execute)', ({ op, action }) => {
-    it('is blocked under read-only — over-blocking, documented not assumed', async () => {
+  // Empty today: openFile moved to READ, and executeCommand is not tool-reachable.
+  // describe.each throws on an empty table, so this is guarded by a plain `if`
+  // rather than describe.skip — the repo's test contract forbids skipped tests,
+  // and a skipped block would read as coverage that isn't there. The assertion
+  // above is what notices if an execute action ever appears.
+  it('records that no shipped action currently maps to execute', () => {
+    expect(executeActions).toEqual([]);
+  });
+
+  if (executeActions.length) describe.each(executeActions)('$key (execute)', ({ op, action }) => {
+    it('is blocked under read-only', async () => {
       const writes: Write[] = [];
       const api = new SecureObsidianAPI(
         makeApp(writes), undefined, { settings: { readOnlyMode: true } } as never,

--- a/tests/security/read-only-action-matrix.test.ts
+++ b/tests/security/read-only-action-matrix.test.ts
@@ -8,13 +8,16 @@
  * point: the 0.11.42 bypasses existed because `edit` and `bases.create` were
  * never classified as writes anywhere.
  *
- * Each write action is checked twice:
- *   - under read-only  -> must record ZERO vault writes
- *   - under permissive -> must record AT LEAST ONE write (positive control)
+ * Each write action is checked three times:
+ *   - read-only (live predicate)  -> must record ZERO vault writes
+ *   - security layer (preset)     -> ZERO writes, AND the refusal must name the
+ *                                   gate (PERMISSION_DENIED / READ_ONLY_MODE)
+ *   - permissive                  -> AT LEAST ONE write (positive control)
  *
- * The positive control is what stops a vacuous pass. Without it, an action that
- * throws on missing params would record no writes and look "correctly blocked"
- * while testing nothing at all.
+ * The positive control and the named-refusal check are what stop vacuous passes.
+ * Without them, an action that throws on missing params — or one whose error is
+ * swallowed and re-reported as something unrelated, as vault.copy's was — records
+ * no writes and looks "correctly blocked" while testing nothing at all.
  */
 import { SecureObsidianAPI, VaultSecurityManager } from '../../src/security';
 import { createSemanticTools, getActionsForOperation, ALL_OPERATIONS } from '../../src/tools/semantic-tools';
@@ -185,15 +188,20 @@ function makeApp(writes: Write[]): App {
 /**
  * Invoke one action through the production tool handler.
  *
- * Three modes, and the distinction matters:
+ * Three modes. What they isolate CHANGED with ADR-108: the tool-layer guard no
+ * longer enforces anything, so these no longer separate "tool gate" from
+ * "security gate". They now separate the two ways the security layer can be told
+ * to deny — which is still worth distinguishing:
  *
- *  - 'readOnly'      both gates armed — what a user actually gets
- *  - 'securityLayer' ONLY the security layer armed (plugin.settings.readOnlyMode
- *                    left false, so the tool-layer guard at semantic-tools.ts:142
- *                    never fires). Without this mode the vault.* write assertions
- *                    are satisfied by the legacy tool-layer guard and pass even on
- *                    code where the security layer is bypassed — measured: the
- *                    pre-fix tree failed only on bases.create.
+ *  - 'readOnly'      plugin.settings.readOnlyMode true -> the LIVE predicate
+ *                    denies. What a user toggling the setting actually gets.
+ *  - 'securityLayer' readOnlyMode false + presets.readOnly() -> the SNAPSHOT
+ *                    denies, with the predicate inactive. Keeps the preset path
+ *                    covered so ADR-108's predicate isn't the only thing holding
+ *                    the boundary. Historically this mode existed because the
+ *                    legacy tool-layer guard satisfied the vault.* assertions and
+ *                    hid a bypass; that guard is gone, but the mode still pins
+ *                    the preset path.
  *  - 'permissive'    positive control: the call must really reach a write
  */
 async function invoke(
@@ -201,7 +209,7 @@ async function invoke(
   action: string,
   params: Record<string, unknown>,
   mode: 'readOnly' | 'securityLayer' | 'permissive',
-): Promise<Write[]> {
+): Promise<{ writes: Write[]; text: string }> {
   const writes: Write[] = [];
   const app = makeApp(writes);
   const plugin = { settings: { readOnlyMode: mode === 'readOnly' } };
@@ -214,12 +222,15 @@ async function invoke(
 
   SETUP[`${operation}.${action}`]?.();
 
+  let text = '';
   try {
-    await tool.handler(api, { action, ...params });
-  } catch {
-    // A thrown error is a legitimate outcome; the assertion is on `writes`.
+    text = JSON.stringify(await tool.handler(api, { action, ...params }));
+  } catch (e) {
+    // A thrown error is a legitimate outcome; the assertions are on `writes`
+    // and on the refusal actually naming the gate.
+    text = String(e);
   }
-  return writes;
+  return { writes, text };
 }
 
 describe('read-only enforcement — exhaustive action matrix', () => {
@@ -272,7 +283,7 @@ describe('read-only enforcement — exhaustive action matrix', () => {
     const params = WRITE_PARAMS[key] ?? {};
 
     it('records no vault write under read-only mode', async () => {
-      const writes = await invoke(op, action, params, 'readOnly');
+      const { writes } = await invoke(op, action, params, 'readOnly');
       expect(writes).toEqual([]);
     });
 
@@ -281,15 +292,19 @@ describe('read-only enforcement — exhaustive action matrix', () => {
       // tool-layer guard disarmed, a write reaching the vault here means the
       // action bypasses SecureObsidianAPI — which is precisely how bases.create,
       // vault.move and vault.rename escaped.
-      const writes = await invoke(op, action, params, 'securityLayer');
+      const { writes, text } = await invoke(op, action, params, 'securityLayer');
       expect(writes).toEqual([]);
+      // Not just "no write happened" — the refusal must NAME the gate. An action
+      // that errors early for an unrelated reason records no write either, and
+      // would otherwise look correctly blocked while proving nothing.
+      expect(text).toMatch(/PERMISSION_DENIED|READ_ONLY_MODE/);
     });
 
     if (key in NO_POSITIVE_CONTROL) {
       it.todo(`positive control missing — ${NO_POSITIVE_CONTROL[key]}`);
     } else {
       it('positive control: DOES write when permitted', async () => {
-        const writes = await invoke(op, action, params, 'permissive');
+        const { writes } = await invoke(op, action, params, 'permissive');
         // A failure here means the read-only assertion above is vacuous: the
         // action never reached a write, so blocking it proved nothing.
         expect(writes.length).toBeGreaterThan(0);

--- a/tests/security/read-only-liveness.test.ts
+++ b/tests/security/read-only-liveness.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Read-only mode takes effect immediately, in both directions (ADR-108).
+ *
+ * The reported bypass was that `edit` wrote to disk with Read-only mode on. The
+ * cause was not the tool layer's `operation === 'vault'` narrowness but a STALE
+ * ruleset: the security layer chose presets.readOnly() once, in the server
+ * constructor, while the tool-layer guard read the setting live. Toggling on a
+ * running server therefore refused `vault.create` and allowed `edit.append` —
+ * while the settings notice claimed all writes were blocked.
+ *
+ * These tests construct the API in one state and flip the setting WITHOUT
+ * rebuilding anything, which is exactly what the settings toggle does.
+ */
+import { SecureObsidianAPI } from '../../src/security';
+import { createSemanticTools } from '../../src/tools/semantic-tools';
+import { App, TFile } from 'obsidian';
+
+jest.mock('obsidian');
+
+type Write = { op: string; path: string };
+
+function mkFile(p: string): TFile {
+  const f = new TFile();
+  const w = f as unknown as { path: string; extension: string; name: string };
+  w.path = p;
+  w.extension = 'md';
+  w.name = p;
+  return f;
+}
+
+function makeApp(writes: Write[]): App {
+  return {
+    vault: {
+      adapter: { basePath: '/test/vault' },
+      getAbstractFileByPath: (p: string) => (p === 'note.md' ? mkFile(p) : null),
+      read: async () => 'body\n',
+      cachedRead: async () => 'body\n',
+      modify: async (f: TFile) => { writes.push({ op: 'modify', path: f.path }); },
+      create: async (p: string) => { writes.push({ op: 'create', path: p }); return mkFile(p); },
+      getFiles: () => [mkFile('note.md')],
+    },
+    fileManager: {
+      renameFile: async (_f: TFile, n: string) => { writes.push({ op: 'rename', path: n }); },
+      trashFile: async (f: TFile) => { writes.push({ op: 'trash', path: f.path }); },
+    },
+    metadataCache: { getFileCache: () => ({}), resolvedLinks: {} },
+    workspace: { getActiveFile: () => mkFile('note.md') },
+  } as unknown as App;
+}
+
+/** Mutable settings object, as the real plugin holds. */
+function setup(readOnlyMode: boolean) {
+  const writes: Write[] = [];
+  const plugin = { settings: { readOnlyMode } };
+  const api = new SecureObsidianAPI(makeApp(writes), undefined, plugin as never);
+  const tools = createSemanticTools(api)!;
+  return {
+    writes,
+    plugin,
+    vault: tools.find(t => t.name === 'vault')!,
+    edit: tools.find(t => t.name === 'edit')!,
+    bases: tools.find(t => t.name === 'bases')!,
+    api,
+  };
+}
+
+describe('read-only mode liveness', () => {
+  it('blocks edit.append the moment it is switched ON, with no restart', async () => {
+    const s = setup(false);
+
+    // Baseline: writes work.
+    await s.edit.handler(s.api, { action: 'append', path: 'note.md', content: 'x' });
+    expect(s.writes.length).toBe(1);
+
+    // The settings toggle. Nothing is reconstructed.
+    s.plugin.settings.readOnlyMode = true;
+
+    const res = await s.edit.handler(s.api, { action: 'append', path: 'note.md', content: 'y' });
+
+    // Still 1 — the second append did not reach the vault. This is the exact
+    // case that previously returned "Edit successful" and modified the file.
+    expect(s.writes.length).toBe(1);
+    expect(JSON.stringify(res)).toContain('READ_ONLY_MODE');
+  });
+
+  it('allows writes again the moment it is switched OFF, with no restart', async () => {
+    const s = setup(true);
+
+    await s.edit.handler(s.api, { action: 'append', path: 'note.md', content: 'x' });
+    expect(s.writes).toEqual([]);
+
+    // Disabling had the mirror-image bug: writes stayed blocked until restart.
+    s.plugin.settings.readOnlyMode = false;
+
+    await s.edit.handler(s.api, { action: 'append', path: 'note.md', content: 'y' });
+    expect(s.writes.length).toBe(1);
+  });
+
+  it('covers vault and bases too, not just edit', async () => {
+    const s = setup(false);
+    s.plugin.settings.readOnlyMode = true;
+
+    await s.vault.handler(s.api, { action: 'create', path: 'new.md', content: 'x' });
+    await s.bases.handler(s.api, {
+      action: 'create', path: 'new.base', config: { views: [{ type: 'table', name: 'v' }] },
+    });
+    await s.vault.handler(s.api, {
+      action: 'move', path: 'note.md', destination: 'moved.md',
+    });
+
+    expect(s.writes).toEqual([]);
+  });
+
+  it('never blocks reads', async () => {
+    const s = setup(true);
+
+    const res = await s.vault.handler(s.api, { action: 'read', path: 'note.md' });
+
+    const text = JSON.stringify(res);
+    expect(text).not.toContain('READ_ONLY_MODE');
+    expect(text).not.toContain('PERMISSION_DENIED');
+  });
+});

--- a/tests/security/read-only-liveness.test.ts
+++ b/tests/security/read-only-liveness.test.ts
@@ -13,6 +13,7 @@
  */
 import { SecureObsidianAPI } from '../../src/security';
 import { createSemanticTools } from '../../src/tools/semantic-tools';
+import { BASELINE_SECURITY_SETTINGS } from '../../src/mcp-server';
 import { App, TFile } from 'obsidian';
 
 jest.mock('obsidian');
@@ -109,6 +110,73 @@ describe('read-only mode liveness', () => {
     });
 
     expect(s.writes).toEqual([]);
+  });
+
+  /**
+   * The quadrant that shipped broken.
+   *
+   * The other cases build the API without an explicit snapshot, so it defaults to
+   * DEFAULT_SECURITY_SETTINGS (all permissions true) and the OFF direction passes
+   * for free — the predicate only ever ADDS denial. Production was different:
+   * mcp-server.ts installed presets.readOnly() when the server booted with
+   * read-only on, and no predicate returning false can undo an all-false
+   * snapshot. Toggling off left every write denied until restart.
+   *
+   * Passing presets.readOnly() explicitly reproduces a read-only boot. This must
+   * hold for the user who runs read-only by default and flips it off for one edit.
+   */
+  it('re-allows writes after a read-only BOOT, using the shipped baseline', async () => {
+    const writes: Write[] = [];
+    const plugin = { settings: { readOnlyMode: true } };
+    // Exactly what mcp-server.ts builds every API with, read-only or not.
+    const api = new SecureObsidianAPI(
+      makeApp(writes), undefined, plugin as never, BASELINE_SECURITY_SETTINGS,
+    );
+    const edit = createSemanticTools(api)!.find(t => t.name === 'edit')!;
+
+    await edit.handler(api, { action: 'append', path: 'note.md', content: 'x' });
+    expect(writes).toEqual([]);
+
+    plugin.settings.readOnlyMode = false;
+
+    await edit.handler(api, { action: 'append', path: 'note.md', content: 'y' });
+    expect(writes.length).toBe(1);
+  });
+
+  /**
+   * The invariant that makes the case above work, stated directly.
+   *
+   * The predicate can only ADD denial, never grant, so a restrictive baseline is
+   * a one-way door — and that is correct, since a user who configures restrictive
+   * permissions should not have them loosened by a read-only toggle. The
+   * consequence is that the baseline itself must stay permissive. mcp-server.ts
+   * previously installed presets.readOnly() when booting read-only, which is why
+   * toggling read-only off required a restart.
+   */
+  it('ships a permissive baseline, so read-only is the only thing denying', () => {
+    expect(BASELINE_SECURITY_SETTINGS.permissions).toEqual({
+      read: true, create: true, update: true,
+      delete: true, move: true, rename: true, execute: true,
+    });
+    // Path validation is not a permission and must stay on regardless.
+    expect(BASELINE_SECURITY_SETTINGS.pathValidation).toBe('strict');
+  });
+
+  it('confirms a restrictive baseline is NOT undone by the predicate', async () => {
+    // Documents the one-way door rather than asserting it away: this is why the
+    // baseline above must never be restrictive.
+    const writes: Write[] = [];
+    const plugin = { settings: { readOnlyMode: true } };
+    const api = new SecureObsidianAPI(
+      makeApp(writes), undefined, plugin as never,
+      { permissions: { read: true, create: false, update: false, delete: false, move: false, rename: false, execute: false } },
+    );
+    const edit = createSemanticTools(api)!.find(t => t.name === 'edit')!;
+
+    plugin.settings.readOnlyMode = false;
+    await edit.handler(api, { action: 'append', path: 'note.md', content: 'y' });
+
+    expect(writes).toEqual([]);
   });
 
   /**

--- a/tests/security/read-only-liveness.test.ts
+++ b/tests/security/read-only-liveness.test.ts
@@ -111,6 +111,41 @@ describe('read-only mode liveness', () => {
     expect(s.writes).toEqual([]);
   });
 
+  /**
+   * The path real MCP clients take. MCPServerPool.createPooledServer builds each
+   * session's API with BOTH the plugin ref and a *snapshot* of the parent's
+   * security settings (`getSecuritySettings()`), captured when the server was
+   * constructed. If that snapshot won over the live predicate, every session
+   * would keep enforcing the state read-only had at server start — reproducing
+   * the original bug for exactly the callers that matter.
+   */
+  it('live predicate beats the settings snapshot a session API is built with', async () => {
+    const writes: Write[] = [];
+    const plugin = { settings: { readOnlyMode: false } };
+
+    // Permissive snapshot, as taken when read-only was off at construction.
+    const permissiveSnapshot = {
+      pathValidation: 'strict' as const,
+      permissions: {
+        read: true, create: true, update: true,
+        delete: true, move: true, rename: true, execute: true,
+      },
+      blockedPaths: [],
+      logSecurityEvents: false,
+    };
+
+    const sessionApi = new SecureObsidianAPI(
+      makeApp(writes), undefined, plugin as never, permissiveSnapshot,
+    );
+    const edit = createSemanticTools(sessionApi)!.find(t => t.name === 'edit')!;
+
+    plugin.settings.readOnlyMode = true;
+
+    await edit.handler(sessionApi, { action: 'append', path: 'note.md', content: 'x' });
+
+    expect(writes).toEqual([]);
+  });
+
   it('never blocks reads', async () => {
     const s = setup(true);
 

--- a/tests/security/session-api-enforcement.test.ts
+++ b/tests/security/session-api-enforcement.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Sessions must get real enforcement, not just the parent API.
+ *
+ * Real MCP clients never touch the API the server constructs directly — they get
+ * a per-session SecureObsidianAPI built inside
+ * MCPServerPool.createPooledServer, captured in a closure with no registry
+ * exposing it. Two assumptions hold read-only together for those clients, and
+ * neither was covered by a test:
+ *
+ *   1. the pool passes the live plugin reference, so the read-only predicate has
+ *      a setting to read (without it, read-only silently does not apply)
+ *   2. the pool never builds an unsecured session API
+ *
+ * Both previously rested on reading the code. If someone changed the pool to
+ * pass a derived settings object, or omitted the plugin, the other liveness
+ * tests would still pass while production regressed to the original bug.
+ */
+import { App, TFile } from 'obsidian';
+
+jest.mock('obsidian');
+
+/**
+ * Wrap SecureObsidianAPI so constructor arguments can be inspected. The pool
+ * imports from this exact specifier, so it receives the wrapper, and the
+ * `instanceof` check inside the pool still works because the wrapper extends
+ * the real class.
+ */
+const constructorCalls: unknown[][] = [];
+jest.mock('../../src/security/secure-obsidian-api', () => {
+  const actual = jest.requireActual('../../src/security/secure-obsidian-api');
+  class Recording extends actual.SecureObsidianAPI {
+    constructor(...args: unknown[]) {
+      constructorCalls.push(args);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- forwarding the real signature verbatim
+      super(...(args as Parameters<typeof actual.SecureObsidianAPI>));
+    }
+  }
+  return { ...actual, SecureObsidianAPI: Recording };
+});
+
+// Imported after the mock so the pool binds to the wrapper.
+import { MCPServerPool } from '../../src/utils/mcp-server-pool';
+import { SecureObsidianAPI } from '../../src/security/secure-obsidian-api';
+import { ObsidianAPI } from '../../src/utils/obsidian-api';
+import { BASELINE_SECURITY_SETTINGS } from '../../src/mcp-server';
+
+function mkFile(p: string): TFile {
+  const f = new TFile();
+  const w = f as unknown as { path: string; extension: string; name: string };
+  w.path = p;
+  w.extension = 'md';
+  w.name = p;
+  return f;
+}
+
+function makeApp(): App {
+  return {
+    vault: {
+      adapter: { basePath: '/test/vault' },
+      getAbstractFileByPath: (p: string) => (p === 'note.md' ? mkFile(p) : null),
+      read: async () => 'body\n',
+      cachedRead: async () => 'body\n',
+      modify: async () => undefined,
+      create: async (p: string) => mkFile(p),
+      getFiles: () => [mkFile('note.md')],
+    },
+    fileManager: { renameFile: async () => undefined, trashFile: async () => undefined },
+    metadataCache: { getFileCache: () => ({}), resolvedLinks: {} },
+    workspace: { getActiveFile: () => mkFile('note.md') },
+  } as unknown as App;
+}
+
+describe('session API enforcement', () => {
+  beforeEach(() => { constructorCalls.length = 0; });
+
+  it('hands each session the live plugin reference, by identity', () => {
+    const app = makeApp();
+    const plugin = { settings: { readOnlyMode: false } };
+    const parent = new SecureObsidianAPI(app, undefined, plugin as never, BASELINE_SECURITY_SETTINGS);
+
+    const pool = new MCPServerPool(parent, 4, plugin as never);
+    constructorCalls.length = 0;   // ignore the parent's own construction
+    pool.getOrCreateServer('session-1');
+
+    expect(constructorCalls.length).toBeGreaterThan(0);
+    const [, , sessionPlugin] = constructorCalls[0];
+    // Identity, not shape: a copy would read stale settings after a toggle, which
+    // is precisely the staleness ADR-108 removed.
+    expect(sessionPlugin).toBe(plugin);
+  });
+
+  it('refuses to build a session without the security layer', () => {
+    const app = makeApp();
+    const plugin = { settings: { readOnlyMode: true } };
+    // A plain ObsidianAPI used to make the pool fall back to an unsecured
+    // session API and merely log "(no security)".
+    const parent = new ObsidianAPI(app, undefined, plugin as never);
+
+    const pool = new MCPServerPool(parent, 4, plugin as never);
+
+    expect(() => pool.getOrCreateServer('session-2')).toThrow(/without the security layer/);
+  });
+});

--- a/tests/security/write-path-containment.test.ts
+++ b/tests/security/write-path-containment.test.ts
@@ -134,6 +134,45 @@ describe('write-path containment', () => {
     });
   });
 
+  /**
+   * move and rename are the same Obsidian primitive, so it is tempting to charge
+   * both against one permission. Doing that makes permissions.rename dead config
+   * — it can be set to anything with no effect. No shipped preset distinguishes
+   * them today, which is exactly why this needs a test: reverting renameFile to
+   * OperationType.MOVE undoes the split and every other test still passes.
+   */
+  describe('move and rename are charged against their own permissions', () => {
+    function apiWith(perms: { move: boolean; rename: boolean }) {
+      return new SecureObsidianAPI(
+        makeApp(['note.md'], writes), undefined, { settings: {} } as never,
+        {
+          ...PERMISSIVE,
+          permissions: { ...PERMISSIVE.permissions, move: perms.move, rename: perms.rename },
+        },
+      );
+    }
+
+    it('rename works and move is denied when only rename is permitted', async () => {
+      const api = apiWith({ move: false, rename: true });
+
+      await api.renameFile('note.md', 'renamed.md');
+      expect(writes).toEqual([{ op: 'rename', path: 'renamed.md' }]);
+
+      await expect(api.moveFile('note.md', 'moved.md')).rejects.toThrow(SecurityError);
+      expect(writes).toHaveLength(1);
+    });
+
+    it('move works and rename is denied when only move is permitted', async () => {
+      const api = apiWith({ move: true, rename: false });
+
+      await api.moveFile('note.md', 'moved.md');
+      expect(writes).toEqual([{ op: 'rename', path: 'moved.md' }]);
+
+      await expect(api.renameFile('note.md', 'renamed.md')).rejects.toThrow(SecurityError);
+      expect(writes).toHaveLength(1);
+    });
+  });
+
   describe('active-file writes go through the security layer', () => {
     it('blocks update/append/delete under read-only', async () => {
       const api = new SecureObsidianAPI(


### PR DESCRIPTION
Closes the last of the privately reported findings. Documented in **ADR-108** (core domain).

## The problem

Read-only mode was enforced in **two places that derived their state differently and disagreed**:

| | source | scope |
|---|---|---|
| Tool layer (`semantic-tools.ts:142`) | `plugin.settings.readOnlyMode`, read **live** | `operation === 'vault'` only |
| Security layer (`mcp-server.ts:132`) | `presets.readOnly()`, chosen **once in the constructor** | all wrapped writes |

Toggling read-only on a running server armed the live check immediately while the security layer kept the permissive ruleset it was built with. Result: `vault.create` refused, `edit.append` **wrote to disk**. Disabling had the mirror problem — writes stayed blocked until restart.

Meanwhile `main.ts:1100` announced *"🔒 Read-only mode enabled. All write operations are blocked."* while the debug line beside it conceded *"Server restart required for activation."* A user trusting the notice got a containment boundary that wasn't in effect. **That was the part that actually harmed users.**

## Correcting the reported mechanism

This was reported as `edit` bypassing read-only, attributed to the tool-layer guard's `operation === 'vault'` narrowness. That narrowness is real but **not sufficient to explain the write**: every `edit` action routes through a method the security layer wraps (`appendToFile`, `patchVaultFile`, `updateFile`), and those reject correctly when the layer holds the read-only preset.

The write landed because the ruleset was **stale**. Confirmed live: with a restart, `edit.append` returns `PERMISSION_DENIED`; without one, it returns "Edit successful" and modifies the file. The reporter almost certainly toggled and probed without restarting — reasonable, given the notice.

## Approach — one gate, live state

Per the maintainer's constraint: consolidate, don't add a parallel enforcement path.

- **`VaultSecurityManager` takes an `isReadOnly` predicate**, consulted per call ahead of the settings snapshot. `READ` permitted, everything else denied — `presets.readOnly()` evaluated per call rather than per construction.
- **Pull, not push.** Session-scoped `SecureObsidianAPI` instances are created inside `MCPServerPool.createPooledServer` and captured in closures; `this.servers` holds `PooledServer`, not the API. There is no registry to iterate, so "broadcast new settings on toggle" has nothing to broadcast to and would silently miss instances — the same fail-open shape as the original bug. A pulled predicate is correct by construction.
- **The tool-layer guard is demoted to presentation.** It decides nothing now; it relabels the gate's `PERMISSION_DENIED` to `READ_ONLY_MODE` when read-only is the cause, preserving the actionable error without a second gate. Widening it into a fail-closed write-action registry was considered and rejected — two disagreeing gates are what produced this defect.

## Why this is safe to land now and wasn't before

Demoting the tool-layer guard removes a redundant check, so the remaining gate's coverage carries more weight. The `securityLayer` invoke mode added while fixing the #276 review findings is what makes this safe: it arms **only** the security layer, so the tests exercise the gate directly.

Without that mode, this PR would have removed the very thing that was masking the coverage gap, and nothing would have noticed.

## Tests

`read-only-liveness.test.ts` flips `plugin.settings.readOnlyMode` on a **live** API with nothing reconstructed — exactly what the settings toggle does:

- blocks `edit.append` the moment it's switched ON (the reported case, which previously returned "Edit successful")
- allows writes again the moment it's switched OFF (the mirror bug)
- covers `vault` and `bases`, not just `edit`
- never blocks reads

**Verified to fail without the fix:** reverting only the security layer to `main` fails 3 of its 4 cases. The reads case correctly passes either way.

517 tests pass; build and lint clean.

## User-facing copy

The notice no longer asserts a guarantee the process hasn't adopted — it now has. The description said *"blocks all write operations (create, update, delete, move, rename)"*, which understated the mode: read-only also denies `EXECUTE`, so `view.open_in_obsidian` is blocked. New text: *"Blocks every operation that changes the vault, and blocks opening files in Obsidian. Reads, searches and graph queries still work. Takes effect immediately."*

The relabel message says "Operation" rather than "Write operation" for the same reason — the matrix test caught that inaccuracy when `open_in_obsidian` was described as a write.

## Follow-ups, not in this PR

- `npm audit` reports advisories with fixes available (Dependabot shows more on `main`); security-exempt from the repo's 7-day version-age hold, taken as its own increment.
- `dangerouslyDisableAuth` and `toolVisibility`/`ACTION_DISABLED` still have no test coverage. `toolVisibility` matters most — it's the mechanism the reporter is relying on as a containment boundary today.
