### PR TITLE
fix(deps): clear all runtime advisories (lockfile only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,28 +471,42 @@ by reverting the decision behind them; they were analysed and accepted:
   appease it is the wrong action — leave it.
 - **"… scan not available" disclosures** — neutral. Where Obsidian's
   malware/obfuscation scanners do not run, that is not a failure. The
-  **dependency** scan *does* run now and passed at the 0.11.42 portal scan
-  ("No vulnerable dependencies found") — treat a regression there as real,
-  not a disclosure.
+  **dependency** scan *does* run, so treat a regression there as real, not a
+  disclosure.
 
-  The portal scan and local `npm audit` **can diverge**, and the local audit
-  is the leading indicator — it sees advisories published since the last
-  portal scan. Re-run `npm audit` before reading the portal result as current;
-  per the supply-chain rule above these are security fixes and exempt from the
-  7-day hold.
+  The portal scan and local `npm audit` **can diverge**, and the local audit is
+  the leading indicator — it sees advisories published since the last portal
+  scan. Re-run `npm audit` before reading a portal result as current.
 
-  **Read `npm audit` with `--omit=dev`, not the headline count.** The bare
-  number conflates runtime exposure with build-tool exposure, and the two have
-  very different consequences for a plugin that ships a bundle. At 0.12.0:
-  `npm audit --omit=dev` reports **0**, while the bare count reports ~29 —
-  every one of them the *same* `brace-expansion` DoS advisory
-  (GHSA-mh99-v99m-4gvg) fanning out through nested copies inside the
-  jest/eslint trees. Production resolves `brace-expansion@5.0.8`, above the
-  `<=5.0.7` range; the vulnerable copies are dev-only.
-  Clearing them needs `npm audit fix --force`, which bumps jest/eslint across
-  majors — not worth breaking the toolchain for a DoS reachable only by our own
-  build processing adversarial input. **Do not chase the headline count to
-  zero**; check `--omit=dev` and confirm anything remaining is dev-only.
+### Reading `npm audit` — procedure, not a headline
+
+The bare vulnerability count conflates two things with very different
+consequences for a plugin that ships a bundle: what reaches users, and what only
+runs on the maintainer's build machine. Judge them separately, in this order.
+
+1. **`npm audit --omit=dev` is the number that gates a release.** Anything it
+   reports reaches users through `main.js`. Non-zero means fix now — per the
+   supply-chain rule above, security fixes are exempt from the 7-day hold.
+2. **If that is zero, the bare count is not a release problem.** Confirm the
+   remainder is dev-only rather than assuming it: `npm ls <pkg> --omit=dev`
+   shows whether a package is in the production tree at all, and a production
+   copy can sit *outside* an advisory's range while an older nested copy inside
+   the toolchain sits within it. Note the count can be much larger than the
+   number of distinct advisories — one issue in a widely-shared transitive
+   package fans out across every dependent, so read the advisory IDs, not the
+   total.
+3. **Do not run `npm audit fix --force` to clear a dev-only finding.** It moves
+   dev dependencies across majors. Breaking the toolchain that verifies the
+   security work is a worse trade than carrying a vulnerability reachable only
+   by our own build processing adversarial input. Plain `npm audit fix`
+   (lockfile-only, no `package.json` change) is the tool for this job.
+4. **Record the split in the release notes** when the two numbers differ, so the
+   next reader is not startled by a large count that represents no user
+   exposure.
+
+**Do not chase the headline count to zero** — the same trap as the
+`new Function` scorecard finding below. Zero on `--omit=dev` is the goal; the
+bare count is context.
 
 **Dynamic code execution** — the Bases-evaluator `new Function` (the
 exploitable vector: arbitrary JS from a synced/shared `.base`) is **removed**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -477,12 +477,22 @@ by reverting the decision behind them; they were analysed and accepted:
 
   The portal scan and local `npm audit` **can diverge**, and the local audit
   is the leading indicator — it sees advisories published since the last
-  portal scan. As of 2026-07-29 `npm audit` reports 5 (2 high
-  `brace-expansion` + `fast-uri`, 2 moderate `@modelcontextprotocol/sdk` →
-  `@hono/node-server`, 1 low `body-parser`), all with fixes available, while
-  the portal still shows the 0.11.42 pass. Re-run `npm audit` before reading
-  the portal result as current; per the supply-chain rule above these are
-  security fixes and exempt from the 7-day hold.
+  portal scan. Re-run `npm audit` before reading the portal result as current;
+  per the supply-chain rule above these are security fixes and exempt from the
+  7-day hold.
+
+  **Read `npm audit` with `--omit=dev`, not the headline count.** The bare
+  number conflates runtime exposure with build-tool exposure, and the two have
+  very different consequences for a plugin that ships a bundle. At 0.12.0:
+  `npm audit --omit=dev` reports **0**, while the bare count reports ~29 —
+  every one of them the *same* `brace-expansion` DoS advisory
+  (GHSA-mh99-v99m-4gvg) fanning out through nested copies inside the
+  jest/eslint trees. Production resolves `brace-expansion@5.0.8`, above the
+  `<=5.0.7` range; the vulnerable copies are dev-only.
+  Clearing them needs `npm audit fix --force`, which bumps jest/eslint across
+  majors — not worth breaking the toolchain for a DoS reachable only by our own
+  build processing adversarial input. **Do not chase the headline count to
+  zero**; check `--omit=dev` and confirm anything remaining is dev-only.
 
 **Dynamic code execution** — the Bases-evaluator `new Function` (the
 exploitable vector: arbitrary JS from a synced/shared `.base`) is **removed**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1154,9 +1154,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1283,12 +1283,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1897,12 +1897,12 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -3358,20 +3358,20 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -3381,10 +3381,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4736,9 +4749,9 @@
       }
     },
     "node_modules/eslint-plugin-obsidianmd/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5395,9 +5408,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -7715,15 +7728,15 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/minimist": {
@@ -9440,9 +9453,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9750,17 +9763,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {


### PR DESCRIPTION
`npm audit` reported 5 advisories (2 high, 2 moderate, 1 low). All five are resolved. **`package.json` is untouched** — lockfile only, so no pins moved and no majors were adopted.

Per the repo's supply-chain rule, security fixes are exempt from the 7-day version-age hold, so these land now rather than ageing.

## Resolved

| Severity | Package | Advisory |
|---|---|---|
| high | `fast-uri` → 3.1.4 | host confusion via literal backslash authority delimiter + failed IDN canonicalization |
| high | `brace-expansion` | DoS via exponential-time expansion |
| moderate | `@hono/node-server` → 2.0.12 | path traversal in `serve-static` on Windows via encoded `%5C` |
| moderate | `@modelcontextprotocol/sdk` → 1.30.0 | reached the above transitively |
| low | `body-parser` → 2.3.0 | DoS when an invalid limit silently disabled size enforcement |

## The count afterwards reads 29 high. That is not a regression.

Every one of the 29 is the **same** advisory — `brace-expansion` [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), DoS via unbounded expansion — fanning out through nested copies in the jest/eslint dependency trees.

```
npm audit --omit=dev   →  found 0 vulnerabilities
```

Production resolves `brace-expansion@5.0.8`, **above** the vulnerable `<=5.0.7` range. The vulnerable `1.1.17` and `2.1.3` copies live under `@eslint/eslintrc`, `eslint-plugin-obsidianmd` and `test-exclude` — all dev.

So runtime exposure goes from **four advisories to zero**, which is the number that matters for a plugin shipping a bundle.

## Deliberately not running `--force`

Clearing the dev-only copies requires `npm audit fix --force`, which bumps jest, ts-jest and eslint across majors. That trades a working toolchain — the one that verifies the security work in #276, #277 and #278 — against a denial-of-service reachable only by our own build machine processing adversarial input. Not worth it.

## CLAUDE.md updated

The bare audit count is misleading in exactly the direction that invites someone to "fix" it with `--force`, so the guidance now says to read `--omit=dev` and confirm anything remaining is dev-only, rather than chasing the headline to zero. Same shape as the existing note about not chasing the `new Function` scorecard finding.

Build, lint and 558 tests pass on the updated lockfile.
