### PR TITLE
fix(security): restore Basic auth parity, enforce operation-level visibility live

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -13,9 +13,8 @@ import { getVersion } from './version';
 import { ObsidianAPI } from './utils/obsidian-api';
 import { SecureObsidianAPI } from './security';
 import { authorizeRequest } from './security/http-auth';
-import { semanticTools } from './tools/semantic-tools';
 import { Debug } from './utils/debug';
-import { ConnectionPool, PooledRequest } from './utils/connection-pool';
+import { ConnectionPool } from './utils/connection-pool';
 import { SessionManager } from './utils/session-manager';
 import { MCPServerPool } from './utils/mcp-server-pool';
 import { CertificateManager, CertificateConfig } from './utils/certificate-manager';
@@ -210,40 +209,21 @@ export class MCPHttpServer {
     });
     void this.connectionPool.initialize();
 
-    // Set up connection pool request processing
-    this.connectionPool.on('process', (request: PooledRequest) => {
-      void (async () => {
-        try {
-          if (request.sessionId && this.sessionManager) {
-            this.sessionManager.touchSession(request.sessionId);
-          }
-
-          const toolName = request.method.replace('tool.', '');
-          const tool = semanticTools.find(t => t.name === toolName);
-
-          if (!tool) {
-            this.connectionPool!.completeRequest(request.id, {
-              id: request.id,
-              error: new Error(`Tool not found: ${toolName}`)
-            });
-            return;
-          }
-
-          const sessionAPI = this.getSessionAPI(request.sessionId);
-          const result = await tool.handler(sessionAPI, request.params);
-
-          this.connectionPool!.completeRequest(request.id, {
-            id: request.id,
-            result
-          });
-        } catch (error) {
-          this.connectionPool!.completeRequest(request.id, {
-            id: request.id,
-            error
-          });
-        }
-      })();
-    });
+    // No 'process' dispatch handler is registered here, deliberately.
+    //
+    // There was one, and it resolved tools from the module-level `semanticTools`
+    // const — which is built with NO visibility argument, so neither the enum
+    // filter nor the ACTION_DISABLED check existed on that path: a complete
+    // bypass of tool visibility. It was dead code (nothing calls the pool's
+    // submitRequest/submitPriorityRequest), but it would have become a live
+    // bypass the moment anything enqueued a request, which is the same shape as
+    // the unsecured-session fallback removed from MCPServerPool.
+    //
+    // Real dispatch goes through MCPServerPool, which builds per-session tools
+    // WITH the live visibility settings. If request queueing is ever wanted, it
+    // must route through that path rather than re-introducing a second dispatcher.
+    // The pool itself stays — it is still used for stats, session context, and
+    // shutdown.
 
     // Initialize MCP Server Pool
     this.mcpServerPool = new MCPServerPool(this.obsidianAPI, maxConnections, plugin);
@@ -294,6 +274,8 @@ export class MCPHttpServer {
           Debug.log('⚠️ Authentication is DISABLED - allowing access without credentials');
         } else if (decision.reason === 'no-key-configured') {
           Debug.log('🔓 No API key configured, allowing access');
+        } else if (decision.reason === 'authenticated') {
+          Debug.log('✅ Auth successful');
         }
         return next();
       }

--- a/src/security/http-auth.ts
+++ b/src/security/http-auth.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from 'crypto';
+import { createHash, timingSafeEqual } from 'crypto';
 
 /**
  * The HTTP auth decision, extracted from the express middleware so it can be
@@ -27,24 +27,23 @@ export interface AuthInput {
 }
 
 /**
- * Constant-time string comparison.
+ * Constant-time secret comparison, independent of input length.
  *
- * A plain `===` short-circuits on the first differing byte, which leaks a key
- * prefix through response timing. The server is loopback by default so this is
- * a small window, but it is not zero when binding is widened, and the fix is
- * free.
+ * A plain `===` short-circuits on the first differing byte, leaking a key prefix
+ * through response timing. The server is loopback by default so the window is
+ * small, but not zero once binding is widened, and the fix is free.
+ *
+ * Both sides are hashed to a fixed 32 bytes before comparing. An earlier version
+ * compared the raw buffers and bailed early on a length mismatch, which still
+ * did work proportional to the attacker's input — so it leaked the key's LENGTH
+ * even though each individual comparison was constant-time. Hashing removes the
+ * length signal entirely and lets timingSafeEqual see two equal-length buffers
+ * always, so it can never throw.
  */
 function secretsMatch(a: string, b: string): boolean {
-  const bufA = Buffer.from(a, 'utf8');
-  const bufB = Buffer.from(b, 'utf8');
-  // timingSafeEqual throws on length mismatch, which would itself be a leak, so
-  // compare lengths separately and still run the full comparison.
-  if (bufA.length !== bufB.length) {
-    // Compare against itself to keep the work roughly constant, then fail.
-    timingSafeEqual(bufA, bufA);
-    return false;
-  }
-  return timingSafeEqual(bufA, bufB);
+  const digestA = createHash('sha256').update(a, 'utf8').digest();
+  const digestB = createHash('sha256').update(b, 'utf8').digest();
+  return timingSafeEqual(digestA, digestB);
 }
 
 export function authorizeRequest(input: AuthInput): AuthDecision {
@@ -80,9 +79,19 @@ export function authorizeRequest(input: AuthInput): AuthDecision {
 
   if (input.authHeader.startsWith('Basic ')) {
     const decoded = Buffer.from(input.authHeader.slice(6), 'base64').toString('utf8');
+    const sep = decoded.indexOf(':');
+    // RFC 7617 requires the colon. Rejecting a credential without one also keeps
+    // parity with the previous implementation, whose destructuring yielded
+    // `password === undefined` and failed — without this guard, slice(-1 + 1)
+    // would treat the ENTIRE decoded string as the password, widening the
+    // accepted credential encodings for no reason.
+    if (sep === -1) {
+      return { allow: false, status: 401, error: 'Invalid API key', reason: 'bad-format' };
+    }
     // Only the password carries the key; the username is ignored, which is what
-    // lets `curl -u anything:KEY` work.
-    const password = decoded.slice(decoded.indexOf(':') + 1);
+    // lets `curl -u anything:KEY` work. Slicing after the FIRST colon (rather
+    // than splitting on every one) keeps a key that itself contains a colon.
+    const password = decoded.slice(sep + 1);
     return secretsMatch(password, apiKey)
       ? { allow: true, reason: 'authenticated' }
       : { allow: false, status: 401, error: 'Invalid API key', reason: 'bad-key' };

--- a/src/tools/semantic-tools.ts
+++ b/src/tools/semantic-tools.ts
@@ -122,15 +122,28 @@ const createSemanticTool = (operation: string, visibility?: ToolVisibility): Sem
     const args = (rawArgs ?? {}) as ToolArgs;
     const app = api.getApp();
 
-    // Defense in depth: block actions disabled by visibility even if tool is enumerated
-    if (visibility && visibility[`${operation}.${args.action}`] === false) {
+    // Defense in depth: block actions disabled by visibility even if tool is
+    // enumerated.
+    //
+    // Both the operation-level and action-level toggles are checked here, not
+    // just the action-level one. Operation-level used to be enforced ONLY by the
+    // tool being absent from the built list — which is enumeration, and
+    // enumeration is advisory: the settings UI mutates toolVisibility in place,
+    // so switching a whole operation off left every live MCP session with full
+    // access to it until eviction or restart. Same staleness class as the
+    // read-only bug in ADR-108, in the sibling control.
+    if (visibility && (visibility[operation] === false ||
+        visibility[`${operation}.${args.action}`] === false)) {
+      const operationDisabled = visibility[operation] === false;
       return {
         content: [{
           type: 'text' as const,
           text: JSON.stringify({
             error: {
               code: 'ACTION_DISABLED',
-              message: `Action '${args.action}' is disabled in tool visibility settings`
+              message: operationDisabled
+                ? `Operation '${operation}' is disabled in tool visibility settings`
+                : `Action '${args.action}' is disabled in tool visibility settings`
             }
           }, null, 2)
         }]
@@ -789,12 +802,13 @@ export function createSemanticTools(api?: ObsidianAPI, visibility?: ToolVisibili
 export const ALL_OPERATIONS = ['vault', 'edit', 'view', 'workflow', 'system', 'graph', 'bases', 'dataview'] as const;
 
 // Export the base semantic tools (for backward compatibility, no visibility filtering)
-export const semanticTools = [
-  createSemanticTool('vault'),
-  createSemanticTool('edit'),
-  createSemanticTool('view'),
-  createSemanticTool('workflow'),
-  createSemanticTool('system'),
-  createSemanticTool('graph'),
-  createSemanticTool('bases')
-].filter((tool): tool is SemanticTool => tool !== null);
+// There is deliberately no exported module-level tool list.
+//
+// One existed, built by calling createSemanticTool() with no visibility argument,
+// which produced tools that neither filtered their action enum nor performed the
+// ACTION_DISABLED check — a complete bypass of tool visibility for any caller
+// that picked it up. mcp-server.ts did, on a dead request-dispatch path.
+//
+// Tools must be built per session via createSemanticTools(api, visibility) so the
+// live settings apply. Anything needing the list of operations wants
+// ALL_OPERATIONS; anything needing a tool wants createSemanticTools().

--- a/tests/security/http-auth.test.ts
+++ b/tests/security/http-auth.test.ts
@@ -77,6 +77,16 @@ describe('authorizeRequest', () => {
       expect(d).toMatchObject({ allow: false, reason: 'bad-key' });
     });
 
+    it('rejects a Basic credential with no colon', () => {
+      // RFC 7617 requires the colon. Also a parity guard: slicing after
+      // indexOf(':') would, at -1, treat the ENTIRE decoded string as the
+      // password and authenticate `Basic base64(KEY)` — which the previous
+      // destructuring implementation rejected.
+      const noColon = `Basic ${Buffer.from(KEY, 'utf8').toString('base64')}`;
+      const d = authorizeRequest({ method: 'POST', authHeader: noColon, apiKey: KEY });
+      expect(d).toMatchObject({ allow: false, status: 401, reason: 'bad-format' });
+    });
+
     it('rejects malformed base64 rather than throwing', () => {
       const d = authorizeRequest({ method: 'POST', authHeader: 'Basic !!!not-base64!!!', apiKey: KEY });
       expect(d.allow).toBe(false);
@@ -152,12 +162,23 @@ describe('authorizeRequest', () => {
 
   describe('constant-time comparison', () => {
     it('does not throw on length mismatch', () => {
-      // timingSafeEqual throws when lengths differ, so the length check has to
-      // come first — otherwise every wrong-length key is a 500, not a 401.
+      // Both sides are hashed to a fixed width before comparing, so
+      // timingSafeEqual always sees equal lengths and can never throw. An
+      // earlier version compared raw buffers and bailed early on a length
+      // mismatch, which leaked the key's LENGTH even though each comparison was
+      // itself constant-time.
       expect(() => authorizeRequest({ method: 'POST', authHeader: 'Bearer x', apiKey: KEY }))
         .not.toThrow();
       expect(() => authorizeRequest({ method: 'POST', authHeader: `Bearer ${KEY}${KEY}`, apiKey: KEY }))
         .not.toThrow();
+    });
+
+    it('rejects keys of every wrong length without leaking via an exception', () => {
+      for (const len of [0, 1, KEY.length - 1, KEY.length + 1, KEY.length * 4]) {
+        const guess = 'x'.repeat(len);
+        expect(authorizeRequest({ method: 'POST', authHeader: `Bearer ${guess}`, apiKey: KEY }).allow)
+          .toBe(false);
+      }
     });
 
     it('handles multi-byte characters without throwing', () => {

--- a/tests/security/tool-visibility.test.ts
+++ b/tests/security/tool-visibility.test.ts
@@ -172,6 +172,48 @@ describe('tool visibility gating', () => {
       expect(writes).toEqual([]);
     });
 
+    /**
+     * The gap that made the claim above narrower than it read.
+     *
+     * The settings UI mutates toolVisibility IN PLACE, so a live MCP session
+     * keeps the tools it was built with. Operation-level disable used to be
+     * enforced only by the tool being absent from the built list — enumeration,
+     * which is advisory — so switching the whole `edit` operation off left every
+     * existing session with full edit access until eviction (1h idle) or restart.
+     * Same staleness class as the read-only bug ADR-108 fixed, in the sibling
+     * control, and invisible to the test above because with {edit: false} there
+     * is no edit handler left to invoke.
+     */
+    it('enforces an operation-level disable applied AFTER the session exists', async () => {
+      const visibility: Record<string, boolean> = {};
+      const { byName, api, writes } = setup(visibility);
+
+      // Session built while `edit` was enabled, so it holds a live handler.
+      const edit = byName('edit')!;
+      await edit.handler(api, { action: 'append', path: 'note.md', content: 'x' });
+      expect(writes.length).toBe(1);
+
+      // User switches the whole operation off. Nothing is rebuilt.
+      visibility.edit = false;
+
+      const res = await edit.handler(api, { action: 'append', path: 'note.md', content: 'y' });
+
+      expect(writes.length).toBe(1);
+      expect(JSON.stringify(res)).toContain('ACTION_DISABLED');
+    });
+
+    it('enforces an action-level disable applied after the session exists', async () => {
+      const visibility: Record<string, boolean> = {};
+      const { byName, api, writes } = setup(visibility);
+      const edit = byName('edit')!;
+
+      visibility['edit.append'] = false;
+      const res = await edit.handler(api, { action: 'append', path: 'note.md', content: 'x' });
+
+      expect(writes).toEqual([]);
+      expect(JSON.stringify(res)).toContain('ACTION_DISABLED');
+    });
+
     it('does NOT block vault writes — visibility is per-action, not a read-only mode', async () => {
       // Worth pinning explicitly: this configuration is not equivalent to
       // read-only. vault.create is untouched by it and still writes. Anyone


### PR DESCRIPTION
Three findings from the review of #278, which landed after 0.12.0 was cut. **The first is a regression I introduced** in that PR; the other two are pre-existing.

0.12.0 is a prerelease and has not been promoted, so nothing has reached users. This supersedes it as 0.12.1.

## 1. My regression: Basic auth without a colon authenticated

`main` returned 401; #278 authenticated. My extraction used `decoded.slice(decoded.indexOf(':') + 1)` — at `indexOf === -1` that is `slice(0)`, so the **entire decoded string** became the password. The previous destructuring yielded `password === undefined` and failed.

Not a bypass (the exact key is still required, so nothing authenticates that couldn't already), but it widened the accepted credential encodings in the network access control by accident, and RFC 7617 requires the colon. Now rejected as `bad-format`.

Worth stating plainly: I described that refactor as behaviour-preserving apart from two named changes. There was a third, and I missed it.

## 2. Operation-level visibility was never checked at dispatch

It was enforced **only** by the tool being absent from the built list — that's enumeration, and enumeration is advisory. The settings UI mutates `toolVisibility` **in place**, so:

```
{'edit.append': false} applied to a live session → writes = 0, ACTION_DISABLED ✅
{edit: false}          applied to a live session → writes = 1, no error      ❌
```

A live MCP client kept full `edit` access after the user switched the whole `edit` tool off — until eviction (1h idle) or restart. **Same staleness class as the read-only bug ADR-108 just fixed, in the sibling control.**

And it applies to exactly the configuration the reporter runs as their containment boundary. #278's final assertion that `{edit: false, 'bases.create': false}` leaves no write path was true for **new sessions only** — and the test couldn't see the gap, because with `{edit: false}` there's no `edit` handler left to invoke. The claim was broader than the enforcement, which is the thing this whole body of work has been about avoiding.

Dispatch now checks the operation-level toggle as well as the action-level one, and the error names which fired. Verified the new test fails when the check is reverted.

## 3. Dead dispatch handler deleted (total visibility bypass)

The connection pool's `on('process')` handler resolved tools from a module-level list built with **no visibility argument** — so neither the enum filter nor the `ACTION_DISABLED` check existed on that path. Nothing calls `submitRequest`, so it was dead, but it's the same shape as the unsecured-session fallback already removed: harmless until something enqueues.

With it gone the unfiltered `semanticTools` export had **no consumers at all**, so that's deleted too rather than left as a list a future caller could pick up and silently lose visibility filtering with. Tools are built per session via `createSemanticTools(api, visibility)`; `ALL_OPERATIONS` covers the "just the names" case. The pool itself stays — still used for stats, session context and shutdown.

## Also

**`secretsMatch` now hashes both sides to a fixed width.** Comparing raw buffers and bailing early on a length mismatch still did work proportional to the attacker's input, so it leaked the key's **length** even though each comparison was individually constant-time — my previous comment overstated what it achieved. Hashing removes the length signal and means `timingSafeEqual` always sees equal lengths, so it can never throw.

**Restored the `✅ Auth successful` debug line**, which the extraction dropped, leaving a successful auth with no trace. The username is still not logged — that part of the drop was an improvement.

562 tests pass; build and lint clean.

## Deliberately not in this PR

The **keyless fail-open** (no API key configured → unauthenticated requests allowed). New evidence makes this worth its own change: ADR-107's classifier keys on protocol × bind × certSource only, with **no auth axis** — so HTTPS + all-interfaces + user cert + no API key classifies as `ok`, "the intended public deployment", while accepting unauthenticated requests from the whole network. It isn't under-warned there; it's invisible.

Denying on startup for keyless + non-loopback is the right end state, but it breaks exactly the population currently at risk, so it needs an ADR note and a release note rather than riding a security-hardening PR. The asserted test stays as the holding position — it makes the fail-open a recorded decision rather than an accident.
