### PR TITLE
fix(lint): clear the prefer-create-el warnings, sync the lint plugin to the portal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -579,6 +579,34 @@ ban is that specific rule set, not all directives. To raise `minAppVersion` and
 adopt the 1.13.0 APIs outright (`getSettingDefinitions`, `setDestructive`), see
 #224.
 
+### Keep `eslint-plugin-obsidianmd` current, or local lint lies
+
+The portal's source-code review runs its own copy of this plugin. When ours lags,
+`npm run lint` passes while the portal reports warnings we cannot reproduce —
+findings then arrive *after* a release is already cut. A rule can even be present
+in our installed `dist/` and still never fire, because it isn't wired into the
+`recommended` config yet in that version; the file existing proves nothing.
+
+Before a release scan, confirm parity:
+
+```
+node -e "console.log(require('eslint-plugin-obsidianmd/package.json').version)"
+npm view eslint-plugin-obsidianmd version
+```
+
+If they differ, upgrade and re-lint before scanning. A new minor of this plugin
+usually means new rules, and it is cheaper to see them locally than to read them
+off a scorecard. Treat a warning that only the portal can see as a tooling gap,
+not as a portal quirk.
+
+**Do not satisfy a rule by faking the implementation.** The
+`prefer-setting-definitions` warning can be silenced with a
+`getSettingDefinitions()` that declares a few settings, which would leave users a
+settings search that finds some and silently misses the rest. That is worse than
+the warning, and the same failure mode as suppressing a rule: the check goes
+green while the real problem grows. Either implement it fully or leave the
+warning and track the work.
+
 ## Important Notes
 
 - **Critical Path**: The ObsidianAPI abstraction layer is the cornerstone of this architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,30 @@ Practical application:
 
 Re-run `npm audit` after each merge batch to see what residual exposure remains.
 
+#### The hold covers what ships. Analysis tooling is exempt.
+
+The hold protects **users** from a malicious version reaching them through
+`main.js`. Linters, formatters, type-checkers and test tooling never get bundled,
+so holding them back protects nobody and costs something real: our lint drifts
+from the portal's, and findings then arrive *after* a release is cut instead of
+before. Hold anything that ships. Land analysis tooling as soon as it's green.
+
+Two honest caveats. This is not zero-risk — an ESLint plugin executes on the
+maintainer's machine during `npm run lint`, so the exposure moves from users to
+the developer rather than disappearing.
+
+Second, the mitigating control is weaker than it looks. Install scripts are
+blocked pending approval (`npm install-scripts ls` shows what is waiting), but
+that is **npm 12+ default behaviour, not something this repo enforces** — there is
+no `.npmrc` or `package.json` setting pinning it. On an older npm a new dev
+dependency's `postinstall` runs freely. So the exemption rests on the toolchain
+the installer happens to be using. Approve install scripts one package at a time
+and never with `--all`; if this needs to be guaranteed rather than assumed, that
+means enforcing it in the repo, which is not done today.
+
+Anything with a runtime import path — including a dev dependency that ends up
+bundled — is "what ships" and keeps the hold.
+
 ## Plugin-Specific Guidelines
 
 ### Obsidian Plugin Lifecycle
@@ -597,7 +621,8 @@ npm view eslint-plugin-obsidianmd version
 If they differ, upgrade and re-lint before scanning. A new minor of this plugin
 usually means new rules, and it is cheaper to see them locally than to read them
 off a scorecard. Treat a warning that only the portal can see as a tooling gap,
-not as a portal quirk.
+not as a portal quirk. This upgrade does not wait on the 7-day hold — see the
+analysis-tooling exemption in the supply-chain section above.
 
 **Do not satisfy a rule by faking the implementation.** The
 `prefer-setting-definitions` warning can be silenced with a

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@typescript-eslint/utils": "^8.62.0",
         "esbuild": "^0.28.1",
         "eslint": "^10.5.0",
-        "eslint-plugin-obsidianmd": "^0.3.0",
+        "eslint-plugin-obsidianmd": "^0.4.1",
         "globals": "^17.7.0",
         "jest": "^30.4.2",
         "jiti": "^2.7.0",
@@ -1057,6 +1057,36 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-plugin-eslint-comments": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.7.2.tgz",
+      "integrity": "sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "ignore": "^7.0.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-plugin-eslint-comments/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4632,12 +4662,13 @@
       }
     },
     "node_modules/eslint-plugin-obsidianmd": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.3.0.tgz",
-      "integrity": "sha512-QvGDI6B2nxJBrsZKGTg31da2A/fEJNlnwN+fRZkaoPIu1QL3fYXUdpP7ThyMdr/0iTYQxifb9lt2X9cpydQx1w==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.4.1.tgz",
+      "integrity": "sha512-Nv3593kVsFOS8kir/HWaJ5CR3xcyiPWEPyXst5Pib8mxRYYuLYPpJS2ALMoZXHulHyiGwoYW8AaxvLRc4rhrRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/js": "^9.30.1",
         "@eslint/json": "0.14.0",
@@ -4646,7 +4677,7 @@
         "@types/node": "20.12.12",
         "@typescript-eslint/types": "^8.33.1",
         "@typescript-eslint/utils": "^8.33.1",
-        "eslint": ">=9.0.0",
+        "eslint": ">=9.19.0",
         "eslint-plugin-depend": "1.3.1",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-json-schema-validator": "5.1.0",
@@ -4667,7 +4698,7 @@
       "peerDependencies": {
         "@eslint/js": "^9.30.1",
         "@eslint/json": "0.14.0",
-        "eslint": ">=9.0.0",
+        "eslint": ">=9.19.0",
         "obsidian": "1.8.7",
         "typescript-eslint": "^8.35.1"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@typescript-eslint/utils": "^8.62.0",
     "esbuild": "^0.28.1",
     "eslint": "^10.5.0",
-    "eslint-plugin-obsidianmd": "^0.3.0",
+    "eslint-plugin-obsidianmd": "^0.4.1",
     "globals": "^17.7.0",
     "jest": "^30.4.2",
     "jiti": "^2.7.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1516,7 +1516,7 @@ class MCPSettingTab extends PluginSettingTab {
 		
 		// Show warning if auth is disabled
 		if (this.plugin.settings.dangerouslyDisableAuth) {
-			info.createEl('div', {
+			info.createDiv({
 				text: '⚠️ warning: authentication is disabled. Your vault is accessible without credentials!',
 				cls: 'mcp-warning-box'
 			});

--- a/src/utils/image-handler.ts
+++ b/src/utils/image-handler.ts
@@ -111,8 +111,12 @@ async function resizeImageWithCanvas(
           
           // Check if resizing is needed
           if (originalWidth <= maxDimension && originalHeight <= maxDimension) {
-            // No resizing needed, but convert to JPEG with quality
-            const canvas = activeDocument.createElement('canvas');
+            // No resizing needed, but convert to JPEG with quality.
+            // createEl, not activeDocument.createElement (obsidianmd/prefer-create-el).
+            // The canvas is a detached pixel buffer — never attached to the DOM,
+            // only drawn to and read back via toBlob — so there is no document
+            // affinity to preserve.
+            const canvas = createEl('canvas');
             const ctx = canvas.getContext('2d');
             
             if (!ctx) {
@@ -164,8 +168,8 @@ async function resizeImageWithCanvas(
             }
           }
           
-          // Create canvas for resizing
-          const canvas = activeDocument.createElement('canvas');
+          // Create canvas for resizing. See the note above on createEl.
+          const canvas = createEl('canvas');
           const ctx = canvas.getContext('2d');
           
           if (!ctx) {


### PR DESCRIPTION
The portal scan of the 0.12.1 prerelease returned **two warnings, zero errors**, and a dependency **pass**. This clears one warning and makes the other reproducible locally.

## Dependency scan passed

> No vulnerable dependencies found.

That's the portal independently confirming the call in #279: production exposure is zero, and the larger bare `npm audit` count was a single dev-only advisory fanned out across the jest/eslint trees.

## `prefer-create-el` — cleared

Three sites, two of them real:

- `image-handler.ts` used `activeDocument.createElement('canvas')` in two places. Both canvases are **detached pixel buffers** — drawn to, read back via `toBlob`, never attached to the DOM — so there's no document affinity to preserve and `createEl` is equivalent.
- A settings-tab `info.createEl('div', {...})`, which the rule wants as `info.createDiv({...})`. `eslint --fix` handled it.

I initially called that third one a false positive, on the grounds that `main.ts` contains no `createElement` anywhere. **It isn't.** The rule is narrower than "avoid `createElement`" — it prefers the specific helper per tag.

## The lint plugin upgrade is the more valuable half

The rule was already present in our installed `dist/` but **not wired into the `recommended` config** for that version — `rules: []`. It could never fire locally regardless of what the code did. So `npm run lint` passed while the portal reported warnings we couldn't reproduce, and we only learned about them *after* cutting a release.

Local lint now reproduces the portal exactly. The next rule of this class gets caught by `npm run lint` instead of by a scorecard after the fact.

The 7-day supply-chain hold was set aside for this upgrade at the maintainer's direction. It's a dev-only lint plugin, not a runtime dependency.

## Deliberately still warning: `prefer-setting-definitions` (#224)

`MCPSettingTab` is **1345 lines**, 38 `new Setting()` instances across 9 section methods. `getSettingDefinitions()` is a **1.13.0** API and `minAppVersion` is **1.6.6**, so adopting it means either dropping users below 1.13.0 or carrying both an imperative and a declarative path.

It could be silenced in about a minute with a partial implementation. That would hand users a settings search that finds a few settings and silently misses the rest — worse than the warning, and the same failure mode as suppressing a rule: the check goes green while the real problem grows.

It's a Warning, never an Error, and the only cost is settings-search visibility on 1.13.0+. Tracked in #224, where the `minAppVersion` decision belongs.

## CLAUDE.md

Recorded both lessons as procedure: check plugin-version parity before a release scan, and don't satisfy a rule by faking the implementation.

Production audit still reports 0. Build, lint (1 known warning), and 562 tests pass.
