### PR TITLE
fix(security): safeMode must not authorise arbitrary command execution

### DIFF
--- a/src/security/vault-security-manager.ts
+++ b/src/security/vault-security-manager.ts
@@ -467,6 +467,14 @@ export class VaultSecurityManager {
 			}
 		}),
 		
+		// "Can reorganise, cannot destroy": delete is denied, and because delete is
+		// denied the create+delete composition cannot stand in for it either.
+		//
+		// execute is denied for the same reason. It used to be true, correctly, when
+		// EXECUTE meant openFile — opening a note is inert and reversible. EXECUTE
+		// now means running an arbitrary Obsidian command by id, and the command
+		// palette contains "Delete current file", so leaving it true would let
+		// safeMode authorise exactly what delete:false exists to prevent.
 		safeMode: (): Partial<SecuritySettings> => ({
 			permissions: {
 				read: true,
@@ -475,7 +483,7 @@ export class VaultSecurityManager {
 				delete: false,
 				move: true,
 				rename: true,
-				execute: true
+				execute: false
 			}
 		}),
 		

--- a/tests/security/vault-security-manager.test.ts
+++ b/tests/security/vault-security-manager.test.ts
@@ -277,7 +277,12 @@ describe('VaultSecurityManager', () => {
       });
     });
 
-    test('safeMode preset allows most operations except delete', () => {
+    // execute was true here, and that was correct while EXECUTE meant openFile.
+    // EXECUTE now means running an arbitrary Obsidian command by id, and the
+    // command palette contains "Delete current file" — so under the new meaning
+    // execute:true would let safeMode authorise what its delete:false is for.
+    // The permission's meaning moved, so the expectation moved with it.
+    test('safeMode preset allows reorganisation but neither delete nor execute', () => {
       const safeModeSettings = VaultSecurityManager.presets.safeMode();
       expect(safeModeSettings.permissions).toEqual({
         read: true,
@@ -286,7 +291,7 @@ describe('VaultSecurityManager', () => {
         delete: false,
         move: true,
         rename: true,
-        execute: true
+        execute: false
       });
     });
 

--- a/tests/security/write-path-containment.test.ts
+++ b/tests/security/write-path-containment.test.ts
@@ -173,6 +173,31 @@ describe('write-path containment', () => {
     });
   });
 
+  /**
+   * safeMode's contract is "can reorganise, cannot destroy". Pinning it because
+   * the meaning of EXECUTE changed under it: it used to be openFile, which is
+   * inert, and is now "run an arbitrary Obsidian command by id". The command
+   * palette contains "Delete current file", so execute:true would authorise
+   * precisely what delete:false exists to prevent. A preset that says it cannot
+   * destroy must not hold a permission that can.
+   */
+  describe('preset coherence', () => {
+    it('safeMode denies delete and execute, and permits reorganisation', () => {
+      expect(VaultSecurityManager.presets.safeMode().permissions).toEqual({
+        read: true, create: true, update: true,
+        delete: false, move: true, rename: true, execute: false,
+      });
+    });
+
+    it('readOnly denies everything except read', () => {
+      const perms = VaultSecurityManager.presets.readOnly().permissions!;
+      expect(perms.read).toBe(true);
+      for (const [name, allowed] of Object.entries(perms)) {
+        if (name !== 'read') expect(allowed).toBe(false);
+      }
+    });
+  });
+
   describe('active-file writes go through the security layer', () => {
     it('blocks update/append/delete under read-only', async () => {
       const api = new SecureObsidianAPI(


### PR DESCRIPTION
`presets.safeMode()` had `execute: true`. That was correct while `OperationType.EXECUTE` meant `openFile` — opening a note is inert and reversible.

0.12.2 redefined `EXECUTE` to mean **"run an arbitrary Obsidian command by id"** and moved `openFile` to `READ`. That left `safeMode` granting command-palette execution, which reaches "Delete current file", inside a preset whose entire contract is `delete: false`. It authorised precisely what its own delete denial exists to prevent.

Latent, since `executeCommand` still has no callers. But it's a wrong default in a shipped, promoted release.

## How it got through, because the mechanism is the interesting part

A review pass verified `safeMode` as coherent, reasoning that `delete: false` also blocks the create+delete composition, so `move: true` isn't a back door to deletion. **That analysis was correct.** It was also performed before `EXECUTE` was redefined in the same body of work.

The verification didn't become wrong. The meaning underneath it moved.

Redefining what a permission *denotes* invalidates every prior conclusion about the presets that hold it, and nothing in the suite connected those two facts. A green review is a statement about the code as it was read, not a property that survives later edits to the vocabulary.

## So the presets are pinned by tests now, not by reasoning

- `safeMode`'s full permission set, with the contract stated in the test: reorganise, don't destroy
- `readOnly` denying everything except `read`, iterated rather than enumerated, so a new permission can't be added as `true` without failing

The existing `safeMode` assertion expected `execute: true` and has been updated along with its name. Worth being explicit that this is not loosening a test to accommodate a change: the assertion encoded the *old meaning* of the permission, and the meaning moved, so the expectation moved with it. The new tests are strictly tighter than what they replace.

## `BASELINE_SECURITY_SETTINGS` deliberately keeps `execute: true`

ADR-108 requires the baseline to stay permissive so the live read-only predicate is the only thing that denies, and read-only denies `EXECUTE` unconditionally. Whether command execution should be exposed *at all* is a product question — see the note below — and not a default to change quietly in a fix PR.

## Credit

Found by a fork survey, not by us. `Darth-Ginger/obsidian-mcp-plugin` split `EXECUTE` into two enum values specifically to keep `openFile` separate from command execution. Comparing their approach against ours surfaced the posture we'd left behind after collapsing the two into one.

That fork also builds gated command execution behind an opt-in enumeration flag, a dedicated permission, and an exact-ID allowlist, and its ADR-204 explicitly defers to this repo on whether command execution belongs here. `kochetkovIT` independently built a command allowlist too. Two unconnected forks converging on the same surface is worth an issue regardless of what we decide.

564 tests pass; build clean; one known warning (#224).
