### PR TITLE
Outbound web fetch: off by default, range-filtered and DNS-pinned when enabled (ADR-109)

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -29,6 +29,7 @@ _Server architecture, transport, connection handling, plugin lifecycle_
 | [ADR-106](./core/ADR-106-client-driven-session-re-initialization-via-spec-compliant-http-404.md) | Client-driven session re-initialization via spec-compliant HTTP 404 | Accepted |
 | [ADR-107](./core/ADR-107-network-exposure-modes-as-a-classified-state-machine.md) | Network exposure modes as a classified state machine | Accepted |
 | [ADR-108](./core/ADR-108-consolidate-read-only-enforcement-onto-the-security-layer-and-make-it-live.md) | Consolidate read-only enforcement onto the security layer and make it live | Draft |
+| [ADR-109](./core/ADR-109-outbound-web-fetch-is-off-by-default-and-range-filtered-when-enabled.md) | Outbound web fetch is off by default and range-filtered when enabled | Draft |
 
 ## Tools & API
 _MCP tool design, semantic operations, graph operations, formatters_

--- a/docs/architecture/core/ADR-109-outbound-web-fetch-is-off-by-default-and-range-filtered-when-enabled.md
+++ b/docs/architecture/core/ADR-109-outbound-web-fetch-is-off-by-default-and-range-filtered-when-enabled.md
@@ -1,0 +1,160 @@
+---
+status: Draft
+date: 2026-08-04
+deciders:
+  - aaronsb
+related:
+  - ADR-108
+---
+
+# ADR-109: Outbound web fetch is off by default and range-filtered when enabled
+
+## Context
+
+`system.fetch_web` (src/tools/fetch.ts) calls `window.fetch(args.url)` with no
+validation. Issue #284 identifies two distinct problems:
+
+1. **SSRF.** Any authenticated MCP client can make the plugin fetch loopback
+   services, RFC1918 hosts, link-local and cloud-metadata addresses — targets a
+   remote attacker cannot reach on their own — and the response body is
+   returned, so this reads as well as probes.
+2. **Exfiltration.** The URL itself carries data outbound. An agent processing
+   untrusted vault content can be instructed by that content to fetch a public
+   host with vault data in the query string. Private-range filtering does
+   nothing about this, and read-only mode permits it because `fetch_web` is
+   classified as a read.
+
+The tool is enabled by default: `toolVisibility` defaults to `{}` and missing
+keys mean enabled (src/main.ts:89). So every install ships a default-on
+arbitrary-outbound capability, and the only mitigation is an all-or-nothing
+visibility toggle the user has to discover.
+
+A field report sharpened the stakes: a user's antivirus flagged an outbound
+connection and their first question was *"is the plugin supposed to make any
+kind of outbound ping?"* The investigation cleared the plugin (its only
+unsolicited traffic is to the user-configured localhost MCP URL), but the
+honest answer today is "it makes no outbound connections *unless* an agent
+invokes fetch_web, which is on by default." That answer should be "none, unless
+you opted in."
+
+The plugin's core purpose is pointing an agent at a vault, and vault content is
+untrusted input. That weighting — convenience of a default-on web fetch versus
+containment of an agent reading untrusted notes — is what this ADR decides.
+
+## Decision
+
+**`system.fetch_web` ships disabled by default, for everyone. When the user
+enables it, outbound URLs are validated by the security layer against a
+blocked-range policy.**
+
+1. **Default-off via a dedicated setting, including existing installs.** The
+   gate is a new `enableWebFetch: boolean` (default `false`) presented as its
+   own toggle in the security section of settings, beside read-only mode — not
+   a row in the tool-visibility tree. The field is absent from every existing
+   install's saved settings, so off-for-everyone falls out of the default with
+   no migration code. `system.fetch_web` leaves the visibility tree so there
+   are not two switches for one capability; a leftover
+   `toolVisibility['system.fetch_web']` key is deleted on load — it could only
+   have expressed "off", which the new default already says — and the
+   release notes announce the change. Safe-by-default wins over continuity
+   here because the installed base is exactly the population #284 is about.
+   A dedicated setting also reads as a live predicate (the ADR-108 pattern)
+   rather than inheriting the visibility tree's next-connection staleness, and
+   it gives the two-risks disclosure (decision 4) a place to live.
+
+2. **Range filtering lives in the security layer.** A URL validator under
+   `src/security/` (exported through `security/index.ts`) is the one place that
+   decides whether an outbound URL is permitted, per the one-enforcement-path
+   constraint from ADR-108. It consults `enableWebFetch` live and refuses
+   outright when the toggle is off; hiding the action from tool enumeration
+   when off is presentation, not enforcement. The fetch tool calls the
+   validator; nothing decides inline in the handler.
+
+3. **The filter is canonicalization-first, not string matching.** It must
+   refuse, after normalizing the target to an address:
+   - IPv4 loopback (127.0.0.0/8), RFC1918 (10/8, 172.16/12, 192.168/16),
+     link-local (169.254/16, which includes the 169.254.169.254 metadata
+     service), and 0.0.0.0;
+   - IPv6 loopback (::1), unique-local (fc00::/7), link-local (fe80::/10), and
+     IPv4-mapped forms (::ffff:a.b.c.d) evaluated as their IPv4 address;
+   - decimal, octal, and hex encodings of the same addresses
+     (2130706433, 017700000001, 0x7f000001);
+   - non-http(s) schemes;
+   - DNS names whose resolution (every A/AAAA record, via Node `dns.lookup`
+     with `all: true`) lands in a blocked range;
+   - redirects: every hop re-enters the same validator, with a hop cap.
+
+4. **The fetch itself moves to a security-layer client on Node `http`/`https`
+   with the connection pinned to the validated address.** `window.fetch` cannot
+   implement this policy: its `redirect: 'manual'` mode returns spec-mandated
+   opaque-redirect responses whose `Location` is unreadable, so per-hop
+   validation is impossible, and `follow` follows unvalidated hops. The Node
+   client surfaces real redirect headers, and overriding the request's
+   `lookup` to return the address the validator approved closes the DNS
+   rebinding race between check and connect — TLS SNI and certificate
+   verification still key off the hostname, so pinning does not weaken HTTPS.
+   The plugin already runs a Node HTTP server and uses `fs` in this layer;
+   a Node HTTP client in a security control is the same accepted class.
+
+5. **One residual risk is accepted and documented, not hidden.**
+   - *Exfiltration to public hosts.* Once the user enables the tool, an agent
+     reading hostile vault content can still leak data in a URL to a public
+     host. Range filtering cannot address this; only the default-off posture
+     does, which is a reason for it, not a filter deficiency. The toggle's
+     settings copy states both risks so enabling is informed consent.
+
+## Consequences
+
+### Positive
+
+- The supportable answer to "does this plugin make outbound connections?"
+  becomes **"no — only to your configured localhost MCP endpoint — unless you
+  enabled web fetch."** For AV-alert reports like the one that motivated this,
+  the plugin is eliminable in one sentence.
+- SSRF against loopback/LAN/metadata targets is closed for enabled users, with
+  an implementation that survives the encodings and redirect games the naive
+  hostname check (as in the seanlinmt fork) does not.
+- Read-only mode's containment story stops being silently wrong: with the
+  default off, "read-only + defaults" genuinely keeps vault data in the vault.
+
+### Negative
+
+- Existing users who rely on `fetch_web` lose it on upgrade until they flip the
+  toggle — deliberate, announced, one click to restore.
+- The validator adds a DNS resolution to every enabled fetch (negligible next
+  to the fetch itself) and a security-layer module that must track range lists.
+- Redirect handling, timeouts, and a response size cap move into our client,
+  which is more surface than delegating to fetch's follow behavior. The client
+  requests `Accept-Encoding: identity` since it does not decompress.
+
+### Neutral
+- A host allowlist remains a possible future tightening on top of this posture
+  (the validator is the natural seat for it); nothing here forecloses it.
+- Obsidian's behavior scan already flags the plugin for network capability;
+  default-off may read better there but the finding itself is by-design.
+
+## Alternatives Considered
+
+- **Range block only, tool stays default-on.** No behavior change for existing
+  users, but the plugin keeps shipping a default-on arbitrary-outbound
+  capability and the exfiltration path stays open by default. Rejected: it
+  answers the SSRF half of #284 and ignores the half the issue says matters
+  more.
+- **Host allowlist, empty by default.** Strongest containment — addresses
+  exfiltration even when enabled — but the tool is inert until configured, and
+  the settings/docs burden is the largest of the options. Deferred rather than
+  rejected; the default-off posture captures most of its value at a fraction of
+  the friction, and the allowlist can be layered on later.
+- **Per-host confirmation modal.** Keeps the tool usable without config, but
+  parks an agent tool call on human presence, adds modal plumbing, and trains
+  users to click allow. Rejected.
+- **Keep `window.fetch` and accept a rebinding TOCTOU.** The issue's original
+  sketch. Rejected once implementation showed manual-redirect mode hides
+  `Location` (per the fetch spec's opaque-redirect filtering), which forces a
+  choice between not following redirects at all and following them
+  unvalidated. The Node client both restores redirects and closes the
+  rebinding race, so the "accepted residual" version of this decision was
+  strictly worse.
+- **Port the seanlinmt fork's guard.** Hostname string matching only; misses
+  encodings, DNS resolution, rebinding, and redirects. Rejected in the issue
+  already — written fresh instead.

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ interface MCPPluginSettings {
 	apiKey: string;
 	dangerouslyDisableAuth: boolean;
 	readOnlyMode: boolean;
+	enableWebFetch: boolean;
 	pathExclusionsEnabled: boolean;
 	enableIgnoreContextMenu: boolean;
 	validation?: Partial<ValidationConfig>;
@@ -77,6 +78,7 @@ const DEFAULT_SETTINGS: MCPPluginSettings = {
 	apiKey: '', // Will be generated on first load
 	dangerouslyDisableAuth: false, // Auth enabled by default
 	readOnlyMode: false, // Read-only mode disabled by default
+	enableWebFetch: false, // ADR-109: outbound web fetch off by default, for everyone
 	pathExclusionsEnabled: false, // Path exclusions disabled by default
 	enableIgnoreContextMenu: false, // Context menu disabled by default
 	validation: {
@@ -328,6 +330,17 @@ export default class ObsidianMCPPlugin extends Plugin {
 		// UI and enforcement read one value.
 		this.settings.readOnlyMode = this.settings.readOnlyMode === true;
 		this.settings.dangerouslyDisableAuth = this.settings.dangerouslyDisableAuth === true;
+		this.settings.enableWebFetch = this.settings.enableWebFetch === true;
+
+		// ADR-109: fetch_web moved from the visibility tree to the dedicated
+		// enableWebFetch setting. A leftover visibility key would be a second
+		// switch for the same capability — with AND semantics nobody chose — so
+		// retire it. The key could only have expressed "off", which is what the
+		// new default already says.
+		if ('system.fetch_web' in this.settings.toolVisibility) {
+			delete this.settings.toolVisibility['system.fetch_web'];
+			await this.saveSettings();
+		}
 
 		// Generate API key on first load if not present
 		if (!this.settings.apiKey) {
@@ -1121,6 +1134,24 @@ class MCPSettingTab extends PluginSettingTab {
 					this.render();
 				}));
 
+		// ADR-109: dedicated gate for the plugin's only outbound capability.
+		// Not a row in the tool-visibility tree — that list answers "which tools
+		// does the agent see", this answers "may the plugin reach the internet".
+		new Setting(containerEl)
+			.setName('Allow outbound web fetch')
+			.setDesc('Lets connected agents fetch web pages (system.fetch_web). Off: the plugin makes no outbound connections at all. On: internal addresses (localhost, local network, cloud metadata) are always blocked, but an agent reading untrusted notes could still be tricked into leaking vault data inside a URL to a public site — read-only mode does not prevent that. Enforcement takes effect immediately; agents see the tool appear on their next connection.')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.enableWebFetch)
+				.onChange(async (value) => {
+					this.plugin.settings.enableWebFetch = value;
+					await this.plugin.saveSettings();
+					if (value) {
+						new Notice('🌐 Outbound web fetch enabled. Internal addresses remain blocked.');
+					} else {
+						new Notice('✅ Outbound web fetch disabled. The plugin makes no outbound connections.');
+					}
+				}));
+
 		// Path Exclusions Setting
 		new Setting(containerEl)
 			.setName('Path exclusions')
@@ -1385,20 +1416,25 @@ class MCPSettingTab extends PluginSettingTab {
 			return visibility[key] !== false;
 		};
 
+		// ADR-109: fetch_web is governed by the dedicated "Allow outbound web
+		// fetch" toggle in the security section, not by this tree.
+		const treeActions = (op: string): string[] =>
+			getActionsForOperation(op).filter(action => !(op === 'system' && action === 'fetch_web'));
+
 		const isOperationFullyEnabled = (op: string): boolean => {
 			if (visibility[op] === false) return false;
-			return getActionsForOperation(op).every(a => isActionEnabled(op, a));
+			return treeActions(op).every(a => isActionEnabled(op, a));
 		};
 
 		const isOperationFullyDisabled = (op: string): boolean => {
 			if (visibility[op] === false) return true;
-			return getActionsForOperation(op).every(a => !isActionEnabled(op, a));
+			return treeActions(op).every(a => !isActionEnabled(op, a));
 		};
 
 		const treeEl = containerEl.createDiv({ cls: 'mcp-tool-tree' });
 
 		for (const operation of ALL_OPERATIONS) {
-			const actions = getActionsForOperation(operation);
+			const actions = treeActions(operation);
 			if (actions.length === 0) continue;
 
 			// Skip dataview if not available

--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -14,6 +14,20 @@ export {
 	type ValidatedOperation
 } from './vault-security-manager';
 
-export { 
-	SecureObsidianAPI 
+export {
+	SecureObsidianAPI
 } from './secure-obsidian-api';
+
+export {
+	validateOutboundUrl,
+	isBlockedAddress,
+	OutboundFetchError,
+	type ValidatedTarget
+} from './url-validator';
+
+export {
+	safeFetch,
+	type SafeFetchResponse,
+	type HopTransport,
+	type HopResponse
+} from './safe-fetch';

--- a/src/security/safe-fetch.ts
+++ b/src/security/safe-fetch.ts
@@ -1,0 +1,143 @@
+import * as http from 'http';
+import * as https from 'https';
+import type { LookupFunction } from 'net';
+import { validateOutboundUrl, OutboundFetchError, type ValidatedTarget } from './url-validator';
+
+/**
+ * Outbound HTTP client for system.fetch_web (ADR-109).
+ *
+ * Built on node's http/https rather than window.fetch for two reasons that are
+ * both security controls:
+ *
+ * 1. Redirects. `window.fetch` with `redirect: 'manual'` returns a
+ *    spec-mandated opaque-redirect response whose Location header is
+ *    unreadable, so per-hop re-validation is impossible; `redirect: 'follow'`
+ *    would follow unvalidated hops. Here each 3xx surfaces with real headers
+ *    and the next hop goes back through the validator.
+ *
+ * 2. DNS pinning. The request's `lookup` is overridden to return the exact
+ *    address the validator approved, closing the rebinding race between check
+ *    and connect. TLS SNI and certificate verification still key off the
+ *    hostname, so pinning does not weaken HTTPS.
+ */
+
+const MAX_REDIRECTS = 5;
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
+
+export interface SafeFetchResponse {
+	status: number;
+	statusText: string;
+	contentType: string;
+	body: string;
+	finalUrl: string;
+}
+
+/** The response headers safeFetch actually consults, typed without the
+ * string|string[] union noise of IncomingHttpHeaders (node sends both named
+ * fields as plain strings). */
+export interface HopHeaders {
+	location?: string;
+	'content-type'?: string;
+}
+
+export interface HopResponse {
+	status: number;
+	statusText: string;
+	headers: HopHeaders;
+	body: string;
+}
+
+function requestOnce(target: ValidatedTarget): Promise<HopResponse> {
+	return new Promise((resolve, reject) => {
+		const { url, address, family } = target;
+		const transport = url.protocol === 'https:' ? https : http;
+		// Pin the connection to the validated address. The hostname still drives
+		// Host header, SNI and certificate checks.
+		const pinnedLookup: LookupFunction = (_hostname, options, callback) => {
+			if (options.all) {
+				callback(null, [{ address, family }]);
+			} else {
+				(callback as (err: NodeJS.ErrnoException | null, address: string, family: number) => void)(null, address, family);
+			}
+		};
+		const req = transport.request(url, {
+			method: 'GET',
+			lookup: pinnedLookup,
+			headers: {
+				'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+				'Accept': 'text/html,application/xhtml+xml,text/plain,*/*',
+				// No compressed encodings: this client does not decompress.
+				'Accept-Encoding': 'identity'
+			},
+			timeout: REQUEST_TIMEOUT_MS
+		}, (res) => {
+			const chunks: Buffer[] = [];
+			let received = 0;
+			res.on('data', (chunk: Buffer) => {
+				received += chunk.length;
+				if (received > MAX_RESPONSE_BYTES) {
+					req.destroy();
+					reject(new OutboundFetchError(`Response exceeded ${MAX_RESPONSE_BYTES / (1024 * 1024)}MB limit`, 'RESPONSE_TOO_LARGE'));
+					return;
+				}
+				chunks.push(chunk);
+			});
+			res.on('end', () => {
+				resolve({
+					status: res.statusCode ?? 0,
+					statusText: res.statusMessage ?? '',
+					headers: {
+						location: res.headers.location,
+						'content-type': res.headers['content-type']
+					},
+					body: Buffer.concat(chunks).toString('utf-8')
+				});
+			});
+			res.on('error', reject);
+		});
+		req.on('timeout', () => {
+			req.destroy(new OutboundFetchError(`Request timed out after ${REQUEST_TIMEOUT_MS / 1000}s`, 'TIMEOUT'));
+		});
+		req.on('error', (err) => {
+			reject(err instanceof OutboundFetchError ? err : new OutboundFetchError(String(err instanceof Error ? err.message : err), 'NETWORK_ERROR'));
+		});
+		req.end();
+	});
+}
+
+/** Test seam: hop transport is injectable so redirect/validation behavior can
+ * be exercised without sockets. Production always uses requestOnce. */
+export type HopTransport = (target: ValidatedTarget) => Promise<HopResponse>;
+
+/**
+ * Fetch a URL under ADR-109 policy: every hop (initial and each redirect) is
+ * validated and the connection pinned to the validated address.
+ *
+ * @throws OutboundFetchError on refusal or network failure
+ */
+export async function safeFetch(
+	rawUrl: string,
+	isEnabled: () => boolean,
+	transport: HopTransport = requestOnce
+): Promise<SafeFetchResponse> {
+	let current = rawUrl;
+	for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+		const target = await validateOutboundUrl(current, isEnabled);
+		const res = await transport(target);
+		if (res.status >= 300 && res.status < 400 && res.headers.location) {
+			// Resolve relative Locations against the current hop, then loop —
+			// the next iteration re-validates the new target.
+			current = new URL(res.headers.location, target.url).toString();
+			continue;
+		}
+		return {
+			status: res.status,
+			statusText: res.statusText,
+			contentType: res.headers['content-type'] ?? '',
+			body: res.body,
+			finalUrl: target.url.toString()
+		};
+	}
+	throw new OutboundFetchError(`Too many redirects (limit ${MAX_REDIRECTS})`, 'TOO_MANY_REDIRECTS');
+}

--- a/src/security/url-validator.ts
+++ b/src/security/url-validator.ts
@@ -1,0 +1,170 @@
+import * as net from 'net';
+import * as dns from 'dns';
+
+/**
+ * Outbound URL validation for system.fetch_web (ADR-109).
+ *
+ * One place decides whether an outbound URL is permitted, per the
+ * one-enforcement-path constraint from ADR-108. The tool handler and the
+ * redirect loop both call this; nothing decides inline.
+ *
+ * Canonicalization is delegated to WHATWG URL parsing, which normalizes
+ * decimal (2130706433), octal (017700000001), and hex (0x7f000001) IPv4
+ * encodings to dotted-quad before we ever compare — string matching against
+ * the raw input is exactly the trap this module exists to avoid.
+ */
+
+export class OutboundFetchError extends Error {
+	constructor(message: string, public code: string) {
+		super(message);
+		this.name = 'OutboundFetchError';
+	}
+}
+
+/** A validated fetch target: the parsed URL plus the exact address the
+ * connection must be pinned to. Pinning (via a custom `lookup`) is what closes
+ * the DNS-rebinding check/fetch race: the socket goes to the address that was
+ * validated, not to whatever a second resolution returns. */
+export interface ValidatedTarget {
+	url: URL;
+	address: string;
+	family: 4 | 6;
+}
+
+function isBlockedIPv4(ip: string): boolean {
+	const octets = ip.split('.').map(Number);
+	if (octets.length !== 4 || octets.some(o => Number.isNaN(o))) return true;
+	const [a, b] = octets;
+	if (a === 0) return true;                      // 0.0.0.0/8 "this network"
+	if (a === 10) return true;                     // RFC1918
+	if (a === 127) return true;                    // loopback
+	if (a === 169 && b === 254) return true;       // link-local, incl. 169.254.169.254 metadata
+	if (a === 172 && b >= 16 && b <= 31) return true; // RFC1918
+	if (a === 192 && b === 168) return true;       // RFC1918
+	if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64/10
+	return false;
+}
+
+/** Parse an IPv6 literal into its 8 16-bit groups. Returns null if malformed.
+ * Handles '::' compression and an embedded dotted-quad tail. */
+function parseIPv6Groups(ip: string): number[] | null {
+	// Rewrite an embedded dotted-quad tail (::ffff:1.2.3.4) as two hex groups
+	// so the rest of the function parses one uniform shape.
+	const lastColon = ip.lastIndexOf(':');
+	if (lastColon === -1) return null;
+	if (ip.includes('.', lastColon)) {
+		const octets = ip.slice(lastColon + 1).split('.').map(Number);
+		if (octets.length !== 4 || octets.some(o => Number.isNaN(o) || o < 0 || o > 255)) return null;
+		const hi = ((octets[0] << 8) | octets[1]).toString(16);
+		const lo = ((octets[2] << 8) | octets[3]).toString(16);
+		ip = `${ip.slice(0, lastColon + 1)}${hi}:${lo}`;
+	}
+	const parts = ip.split('::');
+	if (parts.length > 2) return null;
+	const parseChunk = (s: string): number[] | null => {
+		if (s === '') return [];
+		const groups: number[] = [];
+		for (const g of s.split(':')) {
+			if (!/^[0-9a-fA-F]{1,4}$/.test(g)) return null;
+			groups.push(parseInt(g, 16));
+		}
+		return groups;
+	};
+	const left = parseChunk(parts[0]);
+	const right = parts.length === 2 ? parseChunk(parts[1]) : [];
+	if (left === null || right === null) return null;
+	const fill = 8 - left.length - right.length;
+	if (parts.length === 2 && fill < 0) return null;
+	if (parts.length === 1 && fill !== 0) return null;
+	return [...left, ...Array.from({ length: Math.max(fill, 0) }, () => 0), ...right];
+}
+
+function isBlockedIPv6(ip: string): boolean {
+	const groups = parseIPv6Groups(ip);
+	if (!groups) return true; // unparseable literal: refuse
+	const allZeroTo = (n: number) => groups.slice(0, n).every(g => g === 0);
+	// :: (unspecified) and ::1 (loopback)
+	if (allZeroTo(7) && (groups[7] === 0 || groups[7] === 1)) return true;
+	if ((groups[0] & 0xffc0) === 0xfe80) return true; // link-local fe80::/10
+	if ((groups[0] & 0xfe00) === 0xfc00) return true; // unique-local fc00::/7
+	// IPv4-mapped (::ffff:a.b.c.d) and deprecated IPv4-compatible (::a.b.c.d):
+	// evaluate as the embedded IPv4 address.
+	if (allZeroTo(5) && (groups[5] === 0xffff || groups[5] === 0)) {
+		const v4 = `${groups[6] >> 8}.${groups[6] & 0xff}.${groups[7] >> 8}.${groups[7] & 0xff}`;
+		return isBlockedIPv4(v4);
+	}
+	// NAT64 well-known prefix 64:ff9b::/96 embeds an IPv4 address the same way.
+	if (groups[0] === 0x0064 && groups[1] === 0xff9b && groups.slice(2, 6).every(g => g === 0)) {
+		const v4 = `${groups[6] >> 8}.${groups[6] & 0xff}.${groups[7] >> 8}.${groups[7] & 0xff}`;
+		return isBlockedIPv4(v4);
+	}
+	return false;
+}
+
+export function isBlockedAddress(address: string): boolean {
+	const family = net.isIP(address);
+	if (family === 4) return isBlockedIPv4(address);
+	if (family === 6) return isBlockedIPv6(address);
+	return true; // not an IP literal at all: refuse (callers pass resolved addresses)
+}
+
+/**
+ * Validate an outbound URL against ADR-109 policy.
+ *
+ * @param rawUrl - URL as supplied by the caller (or a redirect Location)
+ * @param isEnabled - Live predicate for the enableWebFetch setting (ADR-108
+ *   pattern: consulted per call, never snapshotted)
+ * @returns The parsed URL and the exact validated address to pin the
+ *   connection to
+ * @throws OutboundFetchError when the fetch must be refused
+ */
+export async function validateOutboundUrl(rawUrl: string, isEnabled: () => boolean): Promise<ValidatedTarget> {
+	if (!isEnabled()) {
+		throw new OutboundFetchError(
+			'Web fetch is disabled. Enable "Allow outbound web fetch" in the plugin\'s security settings to use system.fetch_web.',
+			'WEB_FETCH_DISABLED'
+		);
+	}
+
+	let url: URL;
+	try {
+		url = new URL(rawUrl);
+	} catch {
+		throw new OutboundFetchError(`Invalid URL: ${rawUrl}`, 'INVALID_URL');
+	}
+
+	if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+		throw new OutboundFetchError(`Blocked scheme: ${url.protocol} (only http and https are allowed)`, 'BLOCKED_SCHEME');
+	}
+
+	// URL.hostname wraps IPv6 literals in brackets; strip for address checks.
+	const hostname = url.hostname.replace(/^\[/, '').replace(/\]$/, '');
+
+	if (net.isIP(hostname)) {
+		if (isBlockedAddress(hostname)) {
+			throw new OutboundFetchError(`Blocked address: ${hostname} (private, loopback, link-local and metadata ranges are not fetchable)`, 'BLOCKED_ADDRESS');
+		}
+		return { url, address: hostname, family: net.isIP(hostname) as 4 | 6 };
+	}
+
+	// DNS name: every record it resolves to must be permitted, and the
+	// connection is then pinned to one validated address.
+	let records: { address: string; family: number }[];
+	try {
+		records = await dns.promises.lookup(hostname, { all: true, verbatim: true });
+	} catch {
+		throw new OutboundFetchError(`DNS resolution failed for ${hostname}`, 'DNS_FAILURE');
+	}
+	if (records.length === 0) {
+		throw new OutboundFetchError(`DNS resolution returned no addresses for ${hostname}`, 'DNS_FAILURE');
+	}
+	for (const record of records) {
+		if (isBlockedAddress(record.address)) {
+			throw new OutboundFetchError(
+				`Blocked address: ${hostname} resolves to ${record.address} (private, loopback, link-local and metadata ranges are not fetchable)`,
+				'BLOCKED_ADDRESS'
+			);
+		}
+	}
+	return { url, address: records[0].address, family: records[0].family as 4 | 6 };
+}

--- a/src/tools/fetch.ts
+++ b/src/tools/fetch.ts
@@ -1,5 +1,5 @@
-// Using built-in fetch via globalThis instead of axios
 import TurndownService from 'turndown';
+import { safeFetch, OutboundFetchError } from '../security';
 
 /** Arguments for the fetch tool */
 interface FetchToolArgs {
@@ -7,6 +7,13 @@ interface FetchToolArgs {
   raw?: boolean;
   maxLength?: number;
   startIndex?: number;
+}
+
+/** Minimal plugin shape for reading the enableWebFetch setting live */
+interface PluginWithWebFetchSetting {
+  settings?: {
+    enableWebFetch?: boolean;
+  };
 }
 
 export const fetchTool = {
@@ -35,19 +42,22 @@ export const fetchTool = {
     },
     required: ['url']
   },
-  handler: async (_: unknown, args: FetchToolArgs) => {
-    try {
-      const response = await window.fetch(args.url, {
-        headers: {
-          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
-        }
-      });
+  handler: async (api: unknown, args: FetchToolArgs) => {
+    // Live predicate (ADR-108 pattern): the security layer consults the
+    // setting per call; enumeration hiding elsewhere is presentation only.
+    const plugin = (api as { plugin?: PluginWithWebFetchSetting } | undefined)?.plugin;
+    const isEnabled = () => plugin?.settings?.enableWebFetch === true;
 
-      if (!response.ok) {
+    try {
+      // ADR-109: every hop is validated against the outbound policy and the
+      // connection pinned to the validated address.
+      const response = await safeFetch(args.url, isEnabled);
+
+      if (response.status < 200 || response.status >= 300) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
 
-      let content = await response.text();
+      let content = response.body;
 
       if (!args.raw && typeof content === 'string' && content.includes('<')) {
         const turndown = new TurndownService({
@@ -71,10 +81,11 @@ export const fetchTool = {
       };
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
+      const code = error instanceof OutboundFetchError ? error.code : undefined;
       return {
         content: [{
           type: 'text',
-          text: `Error fetching URL: ${message}`
+          text: code ? `Error fetching URL [${code}]: ${message}` : `Error fetching URL: ${message}`
         }],
         isError: true
       };

--- a/src/tools/semantic-tools.ts
+++ b/src/tools/semantic-tools.ts
@@ -87,7 +87,7 @@ interface DataviewResult {
  * Unified semantic tools that consolidate all operations into 5 main verbs
  */
 
-const createSemanticTool = (operation: string, visibility?: ToolVisibility): SemanticTool | null => {
+const createSemanticTool = (operation: string, visibility?: ToolVisibility, webFetchEnabled?: boolean): SemanticTool | null => {
   // Check operation-level toggle
   if (visibility && visibility[operation] === false) return null;
 
@@ -98,9 +98,23 @@ const createSemanticTool = (operation: string, visibility?: ToolVisibility): Sem
     if (actions.length === 0) return null;
   }
 
+  // ADR-109: fetch_web is gated by its dedicated setting, not the visibility
+  // tree. Hiding it here is presentation — enforcement is the security-layer
+  // URL validator, which reads the setting live on every call.
+  if (operation === 'system' && webFetchEnabled === false) {
+    actions = actions.filter(action => action !== 'fetch_web');
+    if (actions.length === 0) return null;
+  }
+
+  // Keep the advertised description in step with the action list.
+  let description = getOperationDescription(operation);
+  if (operation === 'system' && !actions.includes('fetch_web')) {
+    description = description.replace(/, fetch_web:[^,]*$/, '');
+  }
+
   return {
   name: operation,
-  description: getOperationDescription(operation),
+  description,
   inputSchema: {
     type: 'object',
     properties: {
@@ -784,7 +798,7 @@ function getParametersForOperation(operation: string): Record<string, unknown> {
 /**
  * Create semantic tools array with optional Dataview support
  */
-export function createSemanticTools(api?: ObsidianAPI, visibility?: ToolVisibility): SemanticTool[] {
+export function createSemanticTools(api?: ObsidianAPI, visibility?: ToolVisibility, webFetchEnabled?: boolean): SemanticTool[] {
   const operations = ['vault', 'edit', 'view', 'workflow', 'system', 'graph', 'bases'];
 
   // Add Dataview if available
@@ -794,7 +808,7 @@ export function createSemanticTools(api?: ObsidianAPI, visibility?: ToolVisibili
 
   // Create tools, filtering by visibility (null = operation fully disabled)
   return operations
-    .map(op => createSemanticTool(op, visibility))
+    .map(op => createSemanticTool(op, visibility, webFetchEnabled))
     .filter((tool): tool is SemanticTool => tool !== null);
 }
 

--- a/src/utils/mcp-server-pool.ts
+++ b/src/utils/mcp-server-pool.ts
@@ -22,6 +22,7 @@ import type { ConnectionPool } from './connection-pool';
 interface PluginWithSettings {
   settings?: {
     readOnlyMode?: boolean;
+    enableWebFetch?: boolean;
     // From SecurePluginRef (for SecureObsidianAPI)
     security?: Partial<import('../security/vault-security-manager').SecuritySettings>;
     // From ObsidianAPIPluginRef (for ObsidianAPI)
@@ -177,10 +178,13 @@ export class MCPServerPool extends EventEmitter {
       );
     }
 
-    // Get available tools (filtered by visibility settings)
+    // Get available tools (filtered by visibility settings). The enableWebFetch
+    // value is a snapshot for enumeration only — enforcement reads it live in
+    // the security layer (ADR-109).
     const availableTools = createSemanticTools(
       this.obsidianAPI,
-      this.plugin?.settings?.toolVisibility
+      this.plugin?.settings?.toolVisibility,
+      this.plugin?.settings?.enableWebFetch === true
     );
 
     // List tools handler

--- a/src/utils/obsidian-api.ts
+++ b/src/utils/obsidian-api.ts
@@ -21,6 +21,7 @@ interface ObsidianAPIMCPServerInfo {
 export interface ObsidianAPIPluginRef {
   settings?: {
     validation?: Partial<ValidationConfig>;
+    enableWebFetch?: boolean;
     httpEnabled?: boolean;
     httpsEnabled?: boolean;
     httpPort?: number;

--- a/tests/security/fetch-tool-gate.test.ts
+++ b/tests/security/fetch-tool-gate.test.ts
@@ -1,0 +1,42 @@
+/**
+ * The fetch tool's default posture (ADR-109): absent or false enableWebFetch
+ * means refusal. "Absent" is the important case — it is what every existing
+ * install upgrades into, and what a fresh install starts as. If this test
+ * breaks because someone made the default true, that is the decision being
+ * reversed, not a test to update.
+ */
+import { fetchTool } from '../../src/tools/fetch';
+
+const handlerResult = async (api: unknown) =>
+  await fetchTool.handler(api, { url: 'https://example.com/' });
+
+describe('fetchTool gate', () => {
+  it('refuses when the api has no plugin reference (absent setting = off)', async () => {
+    const result = await handlerResult({});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('WEB_FETCH_DISABLED');
+  });
+
+  it('refuses when enableWebFetch is explicitly false', async () => {
+    const result = await handlerResult({ plugin: { settings: { enableWebFetch: false } } });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('WEB_FETCH_DISABLED');
+  });
+
+  it('refuses when enableWebFetch is a truthy non-boolean (=== true, not truthiness)', async () => {
+    const result = await handlerResult({ plugin: { settings: { enableWebFetch: 'true' } } });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('WEB_FETCH_DISABLED');
+  });
+
+  it('proceeds past the gate when enabled (fails later on the blocked test address)', async () => {
+    // Enabled, but pointed at loopback: the refusal must now be the address
+    // policy, proving the gate opened and the validator took over.
+    const result = await fetchTool.handler(
+      { plugin: { settings: { enableWebFetch: true } } },
+      { url: 'http://127.0.0.1:3001/mcp' }
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('BLOCKED_ADDRESS');
+  });
+});

--- a/tests/security/safe-fetch.test.ts
+++ b/tests/security/safe-fetch.test.ts
@@ -1,0 +1,100 @@
+/**
+ * safeFetch redirect policy (ADR-109).
+ *
+ * The transport is injected so no sockets are involved; what these tests pin
+ * is the control flow around it — that EVERY hop passes through the validator
+ * (the reason this client exists instead of window.fetch, whose manual
+ * redirect mode hides Location), that relative Locations resolve against the
+ * current hop, and that the hop cap terminates loops.
+ */
+import { safeFetch, type HopTransport, type HopResponse } from '../../src/security/safe-fetch';
+
+const ENABLED = () => true;
+
+const page = (body: string): HopResponse => ({
+  status: 200, statusText: 'OK', headers: { 'content-type': 'text/html' }, body
+});
+
+const redirect = (location: string, status = 302): HopResponse => ({
+  status, statusText: 'Found', headers: { location }, body: ''
+});
+
+/** Transport serving a scripted map of url -> response, recording hops. */
+const scripted = (script: Record<string, HopResponse>) => {
+  const hops: string[] = [];
+  const transport: HopTransport = (target) => {
+    const url = target.url.toString();
+    hops.push(url);
+    const res = script[url];
+    if (!res) throw new Error(`unscripted url: ${url}`);
+    return Promise.resolve(res);
+  };
+  return { transport, hops };
+};
+
+describe('safeFetch', () => {
+  it('returns the terminal response and final URL after following redirects', async () => {
+    const { transport, hops } = scripted({
+      'http://93.184.216.34/a': redirect('http://93.184.216.34/b', 301),
+      'http://93.184.216.34/b': page('<h1>done</h1>'),
+    });
+    const res = await safeFetch('http://93.184.216.34/a', ENABLED, transport);
+    expect(res.body).toBe('<h1>done</h1>');
+    expect(res.finalUrl).toBe('http://93.184.216.34/b');
+    expect(res.status).toBe(200);
+    expect(hops).toEqual(['http://93.184.216.34/a', 'http://93.184.216.34/b']);
+  });
+
+  it('resolves relative Location against the current hop', async () => {
+    const { transport, hops } = scripted({
+      'http://93.184.216.34/dir/a': redirect('../other'),
+      'http://93.184.216.34/other': page('ok'),
+    });
+    await safeFetch('http://93.184.216.34/dir/a', ENABLED, transport);
+    expect(hops[1]).toBe('http://93.184.216.34/other');
+  });
+
+  it('validates every hop: a redirect into a blocked address is refused', async () => {
+    // First hop is public and fine; it redirects to loopback. The validator
+    // must refuse the SECOND hop — this is the SSRF-via-redirect case a
+    // follow-mode fetch would sail through.
+    const { transport, hops } = scripted({
+      'http://93.184.216.34/start': redirect('http://127.0.0.1:3001/mcp'),
+    });
+    await expect(safeFetch('http://93.184.216.34/start', ENABLED, transport))
+      .rejects.toMatchObject({ code: 'BLOCKED_ADDRESS' });
+    expect(hops).toEqual(['http://93.184.216.34/start']); // blocked hop never fetched
+  });
+
+  it('validates the initial URL before any request is made', async () => {
+    const { transport, hops } = scripted({});
+    await expect(safeFetch('http://192.168.1.1/admin', ENABLED, transport))
+      .rejects.toMatchObject({ code: 'BLOCKED_ADDRESS' });
+    expect(hops).toEqual([]);
+  });
+
+  it('refuses everything when the setting is off, without touching the network', async () => {
+    const { transport, hops } = scripted({});
+    await expect(safeFetch('http://93.184.216.34/', () => false, transport))
+      .rejects.toMatchObject({ code: 'WEB_FETCH_DISABLED' });
+    expect(hops).toEqual([]);
+  });
+
+  it('terminates a redirect loop at the hop cap', async () => {
+    const { transport, hops } = scripted({
+      'http://93.184.216.34/a': redirect('http://93.184.216.34/b'),
+      'http://93.184.216.34/b': redirect('http://93.184.216.34/a'),
+    });
+    await expect(safeFetch('http://93.184.216.34/a', ENABLED, transport))
+      .rejects.toMatchObject({ code: 'TOO_MANY_REDIRECTS' });
+    expect(hops.length).toBe(6); // initial + 5 redirects
+  });
+
+  it('treats a 3xx without Location as a terminal response', async () => {
+    const { transport } = scripted({
+      'http://93.184.216.34/x': { status: 304, statusText: 'Not Modified', headers: {}, body: '' },
+    });
+    const res = await safeFetch('http://93.184.216.34/x', ENABLED, transport);
+    expect(res.status).toBe(304);
+  });
+});

--- a/tests/security/url-validator.test.ts
+++ b/tests/security/url-validator.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Outbound URL validation (ADR-109, issue #284).
+ *
+ * The encoding matrix is the point of these tests: a hostname string
+ * comparison passes most of them and is exactly the implementation this
+ * module must never regress into. WHATWG URL canonicalization plus address
+ * parsing must survive decimal/octal/hex IPv4, IPv6 forms, mapped addresses,
+ * and DNS names resolving into blocked ranges.
+ *
+ * DNS is the only thing mocked — it is an I/O boundary, and the tests assert
+ * on what the validator does with the answers, not on resolution itself.
+ */
+import * as dns from 'dns';
+import { validateOutboundUrl, isBlockedAddress, OutboundFetchError } from '../../src/security/url-validator';
+
+const ENABLED = () => true;
+const DISABLED = () => false;
+
+const expectRefusal = async (url: string, code: string, isEnabled = ENABLED) => {
+  await expect(validateOutboundUrl(url, isEnabled)).rejects.toMatchObject({
+    name: 'OutboundFetchError',
+    code
+  });
+};
+
+describe('validateOutboundUrl', () => {
+  describe('the master switch', () => {
+    it('refuses everything when disabled, before touching the URL', async () => {
+      await expectRefusal('https://example.com/', 'WEB_FETCH_DISABLED', DISABLED);
+      await expectRefusal('not even a url', 'WEB_FETCH_DISABLED', DISABLED);
+    });
+  });
+
+  describe('scheme and shape', () => {
+    it('refuses non-http(s) schemes', async () => {
+      await expectRefusal('file:///etc/passwd', 'BLOCKED_SCHEME');
+      await expectRefusal('ftp://example.com/', 'BLOCKED_SCHEME');
+      await expectRefusal('gopher://example.com/', 'BLOCKED_SCHEME');
+    });
+
+    it('refuses unparseable URLs', async () => {
+      await expectRefusal('http://', 'INVALID_URL');
+      await expectRefusal('nope', 'INVALID_URL');
+    });
+  });
+
+  describe('IPv4 literal encodings (the canonicalization matrix)', () => {
+    const loopbackEncodings = [
+      'http://127.0.0.1/',
+      'http://2130706433/',      // decimal
+      'http://0x7f000001/',      // hex
+      'http://017700000001/',    // octal
+      'http://0x7f.0.0.1/',      // mixed
+      'http://127.1/',           // shorthand
+    ];
+    it.each(loopbackEncodings)('refuses loopback as %s', async (url) => {
+      await expectRefusal(url, 'BLOCKED_ADDRESS');
+    });
+
+    it('refuses RFC1918, link-local, metadata, CGNAT and 0.0.0.0', async () => {
+      for (const url of [
+        'http://10.0.0.1/',
+        'http://172.16.0.1/',
+        'http://172.31.255.255/',
+        'http://192.168.1.1/',
+        'http://169.254.169.254/latest/meta-data/', // cloud metadata
+        'http://100.64.0.1/',
+        'http://0.0.0.0/',
+      ]) {
+        await expectRefusal(url, 'BLOCKED_ADDRESS');
+      }
+    });
+
+    it('permits a public IPv4 literal', async () => {
+      const target = await validateOutboundUrl('http://93.184.216.34/', ENABLED);
+      expect(target.address).toBe('93.184.216.34');
+      expect(target.family).toBe(4);
+    });
+
+    it('does not block public addresses adjacent to private ranges', async () => {
+      await expect(validateOutboundUrl('http://172.32.0.1/', ENABLED)).resolves.toBeDefined();
+      await expect(validateOutboundUrl('http://11.0.0.1/', ENABLED)).resolves.toBeDefined();
+      await expect(validateOutboundUrl('http://9.9.9.9/', ENABLED)).resolves.toBeDefined();
+    });
+  });
+
+  describe('IPv6 literals', () => {
+    it('refuses loopback, unspecified, link-local and unique-local', async () => {
+      for (const url of [
+        'http://[::1]/',
+        'http://[::]/',
+        'http://[fe80::1]/',
+        'http://[febf::1]/',   // still inside fe80::/10
+        'http://[fc00::1]/',
+        'http://[fd12:3456:789a::1]/',
+      ]) {
+        await expectRefusal(url, 'BLOCKED_ADDRESS');
+      }
+    });
+
+    it('refuses IPv4-mapped and NAT64 forms of blocked IPv4 addresses', async () => {
+      await expectRefusal('http://[::ffff:127.0.0.1]/', 'BLOCKED_ADDRESS');
+      await expectRefusal('http://[::ffff:7f00:1]/', 'BLOCKED_ADDRESS');
+      await expectRefusal('http://[::ffff:192.168.1.1]/', 'BLOCKED_ADDRESS');
+      await expectRefusal('http://[64:ff9b::7f00:1]/', 'BLOCKED_ADDRESS');
+    });
+
+    it('permits a public IPv6 literal', async () => {
+      const target = await validateOutboundUrl('http://[2606:2800:220:1:248:1893:25c8:1946]/', ENABLED);
+      expect(target.family).toBe(6);
+    });
+  });
+
+  describe('DNS names', () => {
+    let lookupSpy: jest.SpyInstance;
+    afterEach(() => lookupSpy?.mockRestore());
+
+    const mockLookup = (records: { address: string; family: number }[]) => {
+      lookupSpy = jest.spyOn(dns.promises, 'lookup')
+        .mockResolvedValue(records as never);
+    };
+
+    it('permits a name resolving only to public addresses, pinning the first', async () => {
+      mockLookup([
+        { address: '93.184.216.34', family: 4 },
+        { address: '2606:2800:220:1:248:1893:25c8:1946', family: 6 },
+      ]);
+      const target = await validateOutboundUrl('https://example.com/page', ENABLED);
+      expect(target.address).toBe('93.184.216.34');
+      expect(lookupSpy).toHaveBeenCalledWith('example.com', { all: true, verbatim: true });
+    });
+
+    it('refuses a name if ANY record lands in a blocked range', async () => {
+      mockLookup([
+        { address: '93.184.216.34', family: 4 },
+        { address: '127.0.0.1', family: 4 }, // the rebinding trick
+      ]);
+      await expectRefusal('https://rebind.example/', 'BLOCKED_ADDRESS');
+    });
+
+    it('refuses a name resolving to an internal IPv6 address', async () => {
+      mockLookup([{ address: 'fd00::1', family: 6 }]);
+      await expectRefusal('https://internal.example/', 'BLOCKED_ADDRESS');
+    });
+
+    it('refuses on resolution failure and on empty answers', async () => {
+      lookupSpy = jest.spyOn(dns.promises, 'lookup').mockRejectedValue(new Error('ENOTFOUND'));
+      await expectRefusal('https://nxdomain.example/', 'DNS_FAILURE');
+      lookupSpy.mockRestore();
+      mockLookup([]);
+      await expectRefusal('https://empty.example/', 'DNS_FAILURE');
+    });
+  });
+});
+
+describe('isBlockedAddress', () => {
+  it('refuses anything that is not an IP literal (fail closed)', () => {
+    expect(isBlockedAddress('example.com')).toBe(true);
+    expect(isBlockedAddress('')).toBe(true);
+  });
+
+  it('is not fooled by an unparseable IPv6-ish string', () => {
+    expect(isBlockedAddress('::1::2')).toBe(true);
+  });
+});
+
+describe('OutboundFetchError', () => {
+  it('carries a machine-readable code', () => {
+    const err = new OutboundFetchError('msg', 'BLOCKED_ADDRESS');
+    expect(err.code).toBe('BLOCKED_ADDRESS');
+    expect(err).toBeInstanceOf(Error);
+  });
+});


### PR DESCRIPTION
Closes #284.

## What changed

`system.fetch_web` was a default-on, unvalidated `window.fetch(args.url)` reachable by any authenticated MCP client. Per **ADR-109** (included in this PR):

1. **Default-off for everyone** — new `enableWebFetch` setting (default `false`; the field is absent from every existing install's saved settings, so off-for-everyone needs no migration code). Dedicated toggle in the security section beside read-only mode, with copy that discloses the residual risk honestly. The legacy `toolVisibility['system.fetch_web']` key is retired on load so there aren't two switches for one capability.
2. **Security-layer URL validation** (`src/security/url-validator.ts`) — canonicalization-first, per the one-enforcement-path constraint from ADR-108. Blocks IPv4 loopback/RFC1918/link-local (incl. 169.254.169.254 metadata)/CGNAT/0.0.0.0 across decimal, octal, hex and shorthand encodings (WHATWG URL canonicalizes these before comparison); IPv6 loopback, unspecified, ULA, link-local, IPv4-mapped and NAT64 forms; DNS names are refused if **any** resolved record lands in a blocked range.
3. **DNS-pinned client with per-hop redirect validation** (`src/security/safe-fetch.ts`) — node http/https instead of `window.fetch`, which cannot implement this policy (its manual-redirect mode returns opaque-redirect responses whose `Location` is unreadable per the fetch spec). Every 3xx hop re-enters the validator; the socket is pinned via a custom `lookup` to the exact address that was validated, closing the DNS-rebinding check/connect race the issue expected us to accept. TLS SNI/cert verification still key off the hostname. Timeout 30s, size cap 10MB, hop cap 5.
4. **Enumeration follows the setting** — `fetch_web` (and its mention in the system tool description) disappears from the advertised tool surface when disabled. Presentation only; enforcement is the validator, which reads the setting live (ADR-108 pattern).

## What stays open, on purpose

Exfiltration to public hosts once the user opts in: an agent reading hostile vault content can still leak data inside a URL. Range filtering cannot address that; the default-off posture is the mitigation, and the settings copy says so. A host allowlist is recorded in the ADR as a natural future tightening.

## Field context

Prompted by a user report of a Bitdefender alert on claude.exe (investigated: not this plugin — the flagged domain appears nowhere in shipped artifacts and the bridge only talks to the configured localhost URL). This change makes that answer one sentence: with defaults, the plugin makes no outbound connections at all.

## Tests

33 new tests: the encoding matrix (decimal/octal/hex/mapped/NAT64), redirect-into-loopback refusal with hop recording, hop cap, DNS-refusal on any-blocked-record, and the default-off gate at the tool handler. Full suite: 50 suites / 597 tests green; build and lint clean (one pre-existing warning, tracked in #224).