### PR TITLE
test(security): cover fetch_web enumeration; fail closed on an omitted flag

### DIFF
--- a/src/tools/semantic-tools.ts
+++ b/src/tools/semantic-tools.ts
@@ -101,7 +101,12 @@ const createSemanticTool = (operation: string, visibility?: ToolVisibility, webF
   // ADR-109: fetch_web is gated by its dedicated setting, not the visibility
   // tree. Hiding it here is presentation — enforcement is the security-layer
   // URL validator, which reads the setting live on every call.
-  if (operation === 'system' && webFetchEnabled === false) {
+  //
+  // Fail closed on an omitted flag rather than testing `=== false`: a caller
+  // that forgets to thread the setting should advertise less, not more. The
+  // pool always passes an explicit boolean, so this changes nothing in
+  // production — it removes a default-open path before something grows into it.
+  if (operation === 'system' && webFetchEnabled !== true) {
     actions = actions.filter(action => action !== 'fetch_web');
     if (actions.length === 0) return null;
   }

--- a/tests/security/fetch-web-enumeration.test.ts
+++ b/tests/security/fetch-web-enumeration.test.ts
@@ -1,0 +1,54 @@
+/**
+ * fetch_web tool enumeration follows the enableWebFetch setting (ADR-109).
+ *
+ * This is the presentation half of the gate — what a connecting agent can
+ * DISCOVER, as opposed to what the security layer permits (covered by
+ * fetch-tool-gate + url-validator). It went untested through the original
+ * implementation and live testing could not settle it: an MCP client caches
+ * tools/list from its first connection, so a stale schema and a broken filter
+ * look identical from the client side. The server-side function is the only
+ * place the question has a clean answer.
+ */
+import { createSemanticTools } from '../../src/tools/semantic-tools';
+
+const systemTool = (webFetchEnabled?: boolean) =>
+  createSemanticTools(undefined, undefined, webFetchEnabled).find(t => t.name === 'system');
+
+const actionsOf = (tool: ReturnType<typeof systemTool>): string[] =>
+  (tool?.inputSchema.properties.action as { enum: string[] }).enum;
+
+describe('fetch_web enumeration', () => {
+  it('advertises fetch_web when enabled', () => {
+    const tool = systemTool(true);
+    expect(actionsOf(tool)).toEqual(['info', 'commands', 'fetch_web']);
+    expect(tool?.description).toContain('fetch_web');
+  });
+
+  it('hides fetch_web when disabled, keeping the rest of the system tool', () => {
+    const tool = systemTool(false);
+    expect(tool).toBeDefined();
+    expect(actionsOf(tool)).toEqual(['info', 'commands']);
+  });
+
+  it('strips fetch_web from the advertised description when disabled', () => {
+    // The enum and the prose have to agree. An agent reads the description as
+    // the menu; leaving "fetch_web: retrieve and process web content" there
+    // while the enum omits it invites calls that can only be refused.
+    expect(systemTool(false)?.description).not.toContain('fetch_web');
+  });
+
+  it('does not disturb other operations', () => {
+    const disabled = createSemanticTools(undefined, undefined, false);
+    const enabled = createSemanticTools(undefined, undefined, true);
+    expect(disabled.map(t => t.name)).toEqual(enabled.map(t => t.name));
+    const vaultActions = (tools: typeof disabled) =>
+      (tools.find(t => t.name === 'vault')?.inputSchema.properties.action as { enum: string[] }).enum;
+    expect(vaultActions(disabled)).toEqual(vaultActions(enabled));
+  });
+
+  it('hides fetch_web when the flag is omitted entirely (fail closed)', () => {
+    // A caller that forgets to thread the setting must not accidentally
+    // advertise the capability — the same fail-closed posture the handler has.
+    expect(actionsOf(systemTool(undefined))).toEqual(['info', 'commands']);
+  });
+});


### PR DESCRIPTION
Follow-up to #290 (ADR-109), from live testing on 0.12.4.

## Why this was missing

ADR-109's enumeration filter — whether `fetch_web` is advertised in `tools/list` — shipped with no test. Live testing could not substitute: an MCP client caches `tools/list` from its first connection, so a stale client schema and a broken filter look identical from the client side. That is precisely what happened while testing; only a direct server query (and then this unit test) could tell them apart.

## What it found

A fail-open. The filter tested `webFetchEnabled === false`, so a caller omitting the flag got `fetch_web` **advertised**. `MCPServerPool` always passes an explicit boolean (`settings?.enableWebFetch === true`), so production was never exposed — but a default-open path in a security-adjacent filter is the same shape this codebase has closed repeatedly (cf. the module-level tool list removed in semantic-tools.ts, and the stale-snapshot bugs behind ADR-108). Condition is now `!== true`.

## Coverage added

5 tests on `createSemanticTools`: advertised when enabled; hidden when disabled; the **description** also stripped so the prose and the enum agree (an agent reads the description as the menu); other operations unaffected; and the omitted-flag case that found the bug.

Full suite: 51 suites / 602 tests green. Build and lint clean (one pre-existing warning, #224).

## Verified live

Against the running 0.12.4 plugin after a full server restart, with the setting on: the server advertises `["info", "commands", "fetch_web"]`, public fetches work, and loopback/RFC1918/link-local/metadata/octal/decimal/IPv4-mapped targets are all refused.