### PR TITLE
fix(fetch): large pages rendered the literal string "undefined" (#293); accept ADR-109

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -29,7 +29,7 @@ _Server architecture, transport, connection handling, plugin lifecycle_
 | [ADR-106](./core/ADR-106-client-driven-session-re-initialization-via-spec-compliant-http-404.md) | Client-driven session re-initialization via spec-compliant HTTP 404 | Accepted |
 | [ADR-107](./core/ADR-107-network-exposure-modes-as-a-classified-state-machine.md) | Network exposure modes as a classified state machine | Accepted |
 | [ADR-108](./core/ADR-108-consolidate-read-only-enforcement-onto-the-security-layer-and-make-it-live.md) | Consolidate read-only enforcement onto the security layer and make it live | Draft |
-| [ADR-109](./core/ADR-109-outbound-web-fetch-is-off-by-default-and-range-filtered-when-enabled.md) | Outbound web fetch is off by default and range-filtered when enabled | Draft |
+| [ADR-109](./core/ADR-109-outbound-web-fetch-is-off-by-default-and-range-filtered-when-enabled.md) | Outbound web fetch is off by default and range-filtered when enabled | Accepted |
 
 ## Tools & API
 _MCP tool design, semantic operations, graph operations, formatters_

--- a/docs/architecture/core/ADR-109-outbound-web-fetch-is-off-by-default-and-range-filtered-when-enabled.md
+++ b/docs/architecture/core/ADR-109-outbound-web-fetch-is-off-by-default-and-range-filtered-when-enabled.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-08-04
 deciders:
   - aaronsb
@@ -103,7 +103,30 @@ blocked-range policy.**
      does, which is a reason for it, not a filter deficiency. The toggle's
      settings copy states both risks so enabling is informed consent.
 
-## Consequences
+## Verification
+
+Accepted on evidence from the running plugin (0.12.4, loopback bind), not from
+reasoning alone. Against the live MCP endpoint, with the setting on:
+
+- Public fetches work and convert to markdown; an `http://` URL that redirects
+  to `https://` follows and returns content, confirming the per-hop path.
+- Refused, each with the resolved address named in the error:
+  `localhost` (via `::1`), `127.0.0.1`, `2130706433`, `017700000001`,
+  `[::1]`, `[::ffff:127.0.0.1]`, `169.254.169.254`, `192.168.1.1`,
+  `10.0.0.1`, and `file://`. The decimal and octal forms are the cases a
+  hostname string comparison passes.
+- The toggle takes effect without a reconnect, confirming the live predicate.
+- With the setting on, the server's own `tools/list` advertises
+  `["info", "commands", "fetch_web"]`.
+
+Two findings came out of that testing rather than out of review. The
+enumeration filter defaulted **open** when its flag was omitted — unreachable
+from the pool, which always passes an explicit boolean, but fixed to fail
+closed and now covered by tests. And an MCP client caches `tools/list` from
+its first connection, which makes a stale client schema and a broken filter
+indistinguishable from the client side; the enumeration claim can only be
+settled server-side. Anything asserting what agents can discover should be
+tested against the function, not the client.
 
 ### Positive
 

--- a/src/formatters/system.ts
+++ b/src/formatters/system.ts
@@ -286,10 +286,12 @@ export function formatEditResult(response: EditResponse): string {
  * Format system.fetch_web response
  */
 export interface WebFetchResponse {
-  content: string;
+  content?: string;
   title?: string;
   url?: string;
   contentType?: string;
+  /** Set by the response limiter when the payload was shortened to fit. */
+  _truncated?: boolean;
   metadata?: {
     fetchedAt?: string;
     statusCode?: number;
@@ -300,11 +302,20 @@ export function formatWebFetch(response: WebFetchResponse): string {
   const lines: string[] = [];
 
   // Extract content string — handle MCP content array format [{type:'text', text:'...'}]
-  const content: string = typeof response.content === 'string'
-    ? response.content
-    : Array.isArray(response.content)
-      ? (response.content as Array<{type: string; text: string}>)[0]?.text ?? JSON.stringify(response.content)
-      : String(response.content);
+  //
+  // A missing body is reported, never stringified. `String(undefined)` yields
+  // the word "undefined", which reads as page content and hides the fact that
+  // nothing arrived (#293). The limiter no longer drops the key, but a
+  // formatter that fails legibly is the reason a limiter regression would be
+  // noticed rather than served.
+  const rawContent: unknown = response.content;
+  const content: string = typeof rawContent === 'string'
+    ? rawContent
+    : Array.isArray(rawContent)
+      ? (rawContent as Array<{type: string; text: string}>)[0]?.text ?? JSON.stringify(rawContent)
+      : rawContent === undefined || rawContent === null
+        ? '_(no content returned — the response was truncated before it reached the formatter)_'
+        : JSON.stringify(rawContent);
 
   const title = response.title || 'Web Content';
   lines.push(header(1, `Fetched: ${title}`));
@@ -332,6 +343,11 @@ export function formatWebFetch(response: WebFetchResponse): string {
     lines.push(`... (${content.length - maxLength} more characters)`);
   } else {
     lines.push(content);
+  }
+
+  if (response._truncated) {
+    lines.push('');
+    lines.push('_(response shortened to fit the size limit — request a narrower range with `maxLength`/`startIndex` for the rest)_');
   }
 
   lines.push(summaryFooter());

--- a/src/utils/__tests__/response-limiter.test.ts
+++ b/src/utils/__tests__/response-limiter.test.ts
@@ -176,7 +176,12 @@ describe('Response Limiter', () => {
 
       expect(limited.error).toBe('test error');
       expect(limited.message).toBe('important message');
-      expect(limited.data).toBeUndefined(); // Should be excluded due to size
+      // Shortened, NOT dropped. This assertion used to require
+      // `limited.data` to be undefined, which pinned the defect behind #293 in
+      // place: an oversized value vanished entirely and downstream formatters
+      // rendered the missing key as the literal string "undefined".
+      expect(typeof limited.data).toBe('string');
+      expect((limited.data as string).length).toBeLessThan(100000);
       expect(limited._truncated).toBe(true);
     });
 

--- a/src/utils/response-limiter.ts
+++ b/src/utils/response-limiter.ts
@@ -200,6 +200,51 @@ function limitArrayResponse(arr: unknown[], config: ResponseLimiterConfig): unkn
 }
 
 /**
+ * Shrink a value to fit a character budget, truncating long strings wherever
+ * they sit — top level, inside an array, or nested in an object.
+ *
+ * The MCP tool-result shape puts an entire payload in one key as
+ * `[{type:'text', text:'…'}]`, so a limiter that can only accept or reject
+ * whole keys has exactly one move on a large page: drop everything. This gives
+ * it a third option — return a shortened version of the same shape.
+ */
+function truncateToBudget(value: unknown, budgetChars: number): unknown {
+  if (budgetChars <= 0) return undefined;
+
+  if (typeof value === 'string') {
+    return value.length <= budgetChars ? value : truncateContent(value, budgetChars);
+  }
+
+  if (Array.isArray(value)) {
+    const out: unknown[] = [];
+    let remaining = budgetChars;
+    for (const item of value) {
+      const shrunk = truncateToBudget(item, remaining);
+      if (shrunk === undefined) break;
+      out.push(shrunk);
+      remaining -= JSON.stringify(shrunk)?.length ?? 0;
+      if (remaining <= 0) break;
+    }
+    return out;
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    let remaining = budgetChars;
+    for (const [k, v] of Object.entries(value)) {
+      const shrunk = truncateToBudget(v, remaining);
+      if (shrunk === undefined) break;
+      out[k] = shrunk;
+      remaining -= JSON.stringify(shrunk)?.length ?? 0;
+      if (remaining <= 0) break;
+    }
+    return out;
+  }
+
+  return value;
+}
+
+/**
  * Limit object responses
  */
 function limitObjectResponse(obj: Record<string, unknown>, config: ResponseLimiterConfig): Record<string, unknown> {
@@ -219,11 +264,22 @@ function limitObjectResponse(obj: Record<string, unknown>, config: ResponseLimit
     const entryTokens = estimateTokens(entryStr);
 
     if (currentTokens + entryTokens > config.maxTokens) {
-      // Try to add a truncation notice
-      if (currentTokens + 50 < config.maxTokens) {
-        limited._truncated = true;
+      // Shrink the value to whatever budget is left rather than dropping the
+      // key. Dropping it produced responses like `{_truncated: true}` with no
+      // payload at all, which downstream formatters rendered as the literal
+      // string "undefined" (#293) — a successful-looking call carrying nothing.
+      // Reserve headroom for the marker and the key name itself.
+      const remainingTokens = config.maxTokens - currentTokens - estimateTokens(key) - 20;
+      const shrunk = remainingTokens > 0 ? truncateToBudget(value, remainingTokens * 4) : undefined;
+      if (shrunk !== undefined) {
+        limited[key] = shrunk;
+        currentTokens += estimateTokens(JSON.stringify(shrunk));
       }
-      break;
+      limited._truncated = true;
+      // Keep going: a later key may still be small enough to fit, and the key
+      // order here is priority-first, so stopping would discard cheap
+      // high-value fields because one big one arrived ahead of them.
+      continue;
     }
 
     limited[key] = value;

--- a/tests/web-fetch-large-response.test.ts
+++ b/tests/web-fetch-large-response.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Large fetch_web responses survive the limiter and format legibly (#293).
+ *
+ * Found in live testing: `http://github.com/` fetched fine, converted fine,
+ * and rendered the single word "undefined". The payload lives in one key as
+ * `[{type:'text', text:'…'}]`, the limiter could only accept or reject whole
+ * keys, and the formatter stringified the resulting absence.
+ *
+ * Both halves are pinned here — the limiter must shorten rather than drop, and
+ * the formatter must never present a missing body as content.
+ */
+import { limitResponse, DEFAULT_LIMITER_CONFIG } from '../src/utils/response-limiter';
+import { formatWebFetch } from '../src/formatters/system';
+
+/** The exact shape the fetch tool returns, sized past any sane budget. */
+const webFetchResult = (bodyLength: number) => ({
+  content: [{ type: 'text', text: 'A'.repeat(bodyLength) }]
+});
+
+describe('large fetch_web responses', () => {
+  describe('the limiter', () => {
+    it('shortens the oversized content key instead of dropping it', () => {
+      const limited = limitResponse(webFetchResult(500_000)) as {
+        content?: { type: string; text: string }[];
+        _truncated?: boolean;
+      };
+
+      expect(limited.content).toBeDefined();
+      expect(limited.content?.[0]?.text).toEqual(expect.any(String));
+      expect(limited.content?.[0]?.text.length).toBeGreaterThan(0);
+      expect(limited.content?.[0]?.text.length).toBeLessThan(500_000);
+      expect(limited._truncated).toBe(true);
+    });
+
+    it('leaves a response that already fits completely untouched', () => {
+      const small = webFetchResult(50);
+      expect(limitResponse(small)).toEqual(small);
+    });
+
+    it('keeps later small keys instead of stopping at the first big one', () => {
+      // Key order is priority-first, so a break would discard cheap
+      // high-value fields that happen to follow a large one.
+      const limited = limitResponse(
+        { bulk: 'A'.repeat(100_000), path: 'notes/x.md' },
+        { ...DEFAULT_LIMITER_CONFIG, maxTokens: 200 }
+      ) as Record<string, unknown>;
+
+      expect(limited.path).toBe('notes/x.md');
+      expect(limited._truncated).toBe(true);
+    });
+  });
+
+  describe('the formatter', () => {
+    it('renders the real body for a large page that was shortened', () => {
+      const limited = limitResponse(webFetchResult(500_000)) as { content?: unknown };
+      const out = formatWebFetch(limited as Parameters<typeof formatWebFetch>[0]);
+
+      expect(out).not.toContain('undefined');
+      expect(out).toContain('AAAA');
+    });
+
+    it('says so plainly when the body is missing entirely', () => {
+      // Defense in depth: if a future limiter change drops the key again, this
+      // must read as an absence, not as page content.
+      const out = formatWebFetch({ _truncated: true });
+      expect(out).not.toContain('undefined');
+      expect(out).toContain('no content returned');
+    });
+
+    it('flags truncation so an agent knows to paginate', () => {
+      const out = formatWebFetch({ content: 'partial page', _truncated: true });
+      expect(out).toContain('partial page');
+      expect(out).toContain('maxLength');
+    });
+
+    it('does not flag truncation on a complete response', () => {
+      expect(formatWebFetch({ content: 'whole page' })).not.toContain('shortened');
+    });
+  });
+});


### PR DESCRIPTION
Closes #293. Found in live testing of 0.12.4 against a running vault.

## The bug

`http://github.com/` fetched correctly, followed its redirect to https, converted to markdown — and rendered as the single word **`undefined`**. With `maxLength: 400` the same URL returned real content, which is how the fetch path was cleared.

The MCP tool result carries the whole payload in one key as `[{type:'text', text:'…'}]`. `limitObjectResponse` walks keys and drops any that would exceed the budget, so a large page produced `{_truncated: true}` with no payload at all; `formatWebFetch` then reached for the missing key and fell through to `String(response.content)`.

Pre-existing — neither the limiter nor the response shape changed in ADR-109 — but it makes `fetch_web` useless on any realistic page, and an agent sees a *successful* call whose content is the word "undefined".

## Both halves, deliberately

- **Limiter** shortens an oversized value to the remaining budget instead of discarding the key, truncating long strings wherever they sit (top level, in an array, nested). It also keeps scanning after a large key rather than breaking: key order is priority-first, so stopping discarded cheap high-value fields that happened to follow a big one.
- **Formatter** reports a missing body as an absence rather than stringifying it, and surfaces `_truncated` so an agent knows to paginate instead of treating a partial page as complete.

Fixing only the limiter leaves the fail-ugly path live for the next caller; fixing only the formatter leaves fetch useless on big pages.

## A test that pinned the defect

`response-limiter.test.ts` asserted `limited.data` was `undefined` after truncation — it encoded the dropped-key behaviour as correct. Updated to require a shortened string, with the reasoning recorded inline.

## ADR-109 Draft → Accepted

Cites the live verification rather than reasoning: the encoding matrix (`2130706433`, `017700000001`, `[::ffff:127.0.0.1]`, `[::1]`, `169.254.169.254`, RFC1918, `file://`) all refused against the running plugin with the resolved address named; public fetches and an http→https redirect chain both work; the toggle takes effect with no reconnect. The Verification section also records the two things testing taught that review had not: the enumeration filter's default-open flag (fixed in #294), and that an MCP client caches `tools/list`, so enumeration claims can only be settled server-side.

## Checks

52 suites / 609 tests green. Build clean. Lint clean apart from the tracked `prefer-setting-definitions` warning (#224 — deliberately not faked). `npm audit`: **0 vulnerabilities in both the production and full trees**. `eslint-plugin-obsidianmd` at 0.4.1, matching latest, so local lint reflects what the portal scan will see. No `new Function`/`eval` in `src/`.