### PR TITLE
feat(mcp): live tool enumeration + tools/list_changed on settings toggles (#285)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1145,6 +1145,10 @@ class MCPSettingTab extends PluginSettingTab {
 				.onChange(async (value) => {
 					this.plugin.settings.enableWebFetch = value;
 					await this.plugin.saveSettings();
+					// Enforcement is already live (the validator reads the setting per
+					// call); this tells connected agents the tool surface moved, so they
+					// re-fetch instead of working from the list they cached at connect.
+					this.plugin.mcpServer?.notifyToolListChanged();
 					if (value) {
 						new Notice('🌐 Outbound web fetch enabled. Internal addresses remain blocked.');
 					} else {
@@ -1476,6 +1480,7 @@ class MCPSettingTab extends PluginSettingTab {
 							visibility[`${operation}.${action}`] = value;
 						}
 						await this.plugin.saveSettings();
+						this.plugin.mcpServer?.notifyToolListChanged();
 						this.render(); // Re-render for updated states
 					});
 				});
@@ -1512,6 +1517,7 @@ class MCPSettingTab extends PluginSettingTab {
 							}
 
 							await this.plugin.saveSettings();
+							this.plugin.mcpServer?.notifyToolListChanged();
 							this.render(); // Re-render for parent state update
 						}));
 			}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -729,6 +729,17 @@ export class MCPHttpServer {
   }
 
   /**
+   * Tell live MCP sessions their tool list changed (#285).
+   *
+   * Called from the settings UI when a toggle changes which tools are visible.
+   * Safe before the pool exists (server not started yet) — there is nothing to
+   * notify in that case.
+   */
+  notifyToolListChanged(): void {
+    this.mcpServerPool?.notifyToolListChanged();
+  }
+
+  /**
    * Get connection pool statistics
    */
   getConnectionPoolStats(): ConnectionPoolStatsResponse {

--- a/src/utils/mcp-server-pool.ts
+++ b/src/utils/mcp-server-pool.ts
@@ -79,6 +79,43 @@ export class MCPServerPool extends EventEmitter {
   }
 
   /**
+   * Build the currently-visible tool set from live plugin settings.
+   *
+   * Called per request rather than once per session so a settings toggle
+   * applies to sessions that already exist. `enableWebFetch` is passed
+   * explicitly as a boolean — `createSemanticTools` fails closed on an omitted
+   * flag, and this keeps the intent visible at the call site (ADR-109).
+   */
+  private buildTools() {
+    return createSemanticTools(
+      this.obsidianAPI,
+      this.plugin?.settings?.toolVisibility,
+      this.plugin?.settings?.enableWebFetch === true
+    );
+  }
+
+  /**
+   * Tell every live session its tool list changed, so clients re-fetch instead
+   * of holding the list they cached at connection time (#285).
+   *
+   * Best-effort by design: the SDK no-ops on a server with no connected
+   * transport, and one session's failure must not stop the rest — a settings
+   * toggle is a UI action, not a transaction.
+   */
+  notifyToolListChanged(): void {
+    let notified = 0;
+    for (const [sessionId, pooled] of this.servers) {
+      try {
+        pooled.server.sendToolListChanged();
+        notified++;
+      } catch (error: unknown) {
+        Debug.error(`[Session ${sessionId}] tools/list_changed notify failed:`, error);
+      }
+    }
+    Debug.log(`📢 Notified ${notified}/${this.servers.size} session(s) of a tool list change`);
+  }
+
+  /**
    * Get or create an MCP server for a session
    */
   getOrCreateServer(sessionId: string): McpServer {
@@ -131,7 +168,11 @@ export class MCPServerPool extends EventEmitter {
       },
       {
         capabilities: {
-          tools: {},
+          // listChanged advertises that this server pushes
+          // notifications/tools/list_changed when the visible tool set changes
+          // (settings toggles). Without the declaration a spec-compliant client
+          // is entitled to ignore the notification.
+          tools: { listChanged: true },
           resources: {}
         },
         // ADR-107: agent-visible network-exposure warning, only set when 🔴
@@ -178,20 +219,19 @@ export class MCPServerPool extends EventEmitter {
       );
     }
 
-    // Get available tools (filtered by visibility settings). The enableWebFetch
-    // value is a snapshot for enumeration only — enforcement reads it live in
-    // the security layer (ADR-109).
-    const availableTools = createSemanticTools(
-      this.obsidianAPI,
-      this.plugin?.settings?.toolVisibility,
-      this.plugin?.settings?.enableWebFetch === true
-    );
-
-    // List tools handler
+    // List tools handler. The list is built per request, not captured here.
+    //
+    // It used to be a `const availableTools` closed over by both handlers, which
+    // froze a session's tool surface at creation: toggling a tool off left every
+    // live session advertising and dispatching it until the session was evicted
+    // or the client reconnected. That is the stale-snapshot shape ADR-108
+    // removed from permission state, in the sibling control — same fix here, and
+    // the reason a `tools/list_changed` notification is worth sending at all
+    // (a client that re-fetched a snapshot would just receive it again).
     server.setRequestHandler(ListToolsRequestSchema, () => {
       Debug.log(`📋 [Session ${sessionId}] Listing available tools`);
       return {
-        tools: availableTools.map(tool => ({
+        tools: this.buildTools().map(tool => ({
           name: tool.name,
           description: tool.description,
           inputSchema: tool.inputSchema
@@ -204,7 +244,7 @@ export class MCPServerPool extends EventEmitter {
       const { name, arguments: args } = request.params;
       Debug.log(`🔧 [Session ${sessionId}] Executing tool: ${name}`, args);
 
-      const tool = availableTools.find(t => t.name === name);
+      const tool = this.buildTools().find(t => t.name === name);
       if (!tool) {
         return {
           content: [{

--- a/tests/security/tool-list-liveness.test.ts
+++ b/tests/security/tool-list-liveness.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tool enumeration is live, and a change is announced (#285).
+ *
+ * The pool used to compute `availableTools` once per session and close over it
+ * in both handlers, so a session's tool surface was frozen at creation:
+ * toggling a tool off left every live session advertising it, and toggling one
+ * on left agents unable to see it, until eviction or a client reconnect. This
+ * is the stale-snapshot shape ADR-108 removed from permission state, in the
+ * sibling control.
+ *
+ * Both halves are asserted, because either alone is insufficient: a
+ * notification is pointless if the re-fetch returns the same frozen list, and a
+ * live list is invisible if nobody is told to ask again.
+ *
+ * The pool is driven through its real handlers — a fake transport records what
+ * the session would send — rather than asserting on internals.
+ */
+import { MCPServerPool } from '../../src/utils/mcp-server-pool';
+import { SecureObsidianAPI } from '../../src/security';
+import { BASELINE_SECURITY_SETTINGS } from '../../src/mcp-server';
+import { App } from 'obsidian';
+
+jest.mock('obsidian');
+
+const makeApp = (): App => ({
+  vault: {
+    adapter: { basePath: '/test/vault' },
+    getAbstractFileByPath: () => null,
+    getFiles: () => [],
+    getMarkdownFiles: () => []
+  },
+  metadataCache: { getFileCache: () => null, resolvedLinks: {} },
+  workspace: { getActiveFile: () => null }
+} as unknown as App);
+
+/** Plugin double whose settings are mutated between calls, like the real UI. */
+const makePlugin = (settings: Record<string, unknown>) => ({
+  settings,
+  manifest: { dir: '/test/vault/.obsidian/plugins/semantic-vault-mcp' }
+});
+
+interface ListToolsResult {
+  tools: { name: string; inputSchema: { properties: { action: { enum: string[] } } } }[];
+}
+
+const systemActions = async (pool: MCPServerPool, sessionId: string): Promise<string[]> => {
+  // Reach the registered ListTools handler the way a client would: through the
+  // server the pool hands out for this session. The SDK wraps handlers so the
+  // result is a promise even though ours is synchronous.
+  const server = pool.getOrCreateServer(sessionId);
+  const handlers = (server.server as unknown as {
+    _requestHandlers: Map<string, (req: unknown, extra: unknown) => Promise<ListToolsResult>>
+  })._requestHandlers;
+  const listTools = handlers.get('tools/list');
+  if (!listTools) throw new Error('tools/list handler not registered');
+  const result = await listTools({ method: 'tools/list', params: {} }, {});
+  const system = result.tools.find(t => t.name === 'system');
+  return system ? system.inputSchema.properties.action.enum : [];
+};
+
+const makePool = (settings: Record<string, unknown>) => {
+  const app = makeApp();
+  const plugin = makePlugin(settings);
+  const api = new SecureObsidianAPI(app, undefined, plugin, BASELINE_SECURITY_SETTINGS);
+  return { pool: new MCPServerPool(api, 8, plugin), settings };
+};
+
+describe('tool list liveness', () => {
+  it('reflects an enableWebFetch change on an EXISTING session, with no reconnect', async () => {
+    const { pool, settings } = makePool({ enableWebFetch: false, toolVisibility: {} });
+
+    expect(await systemActions(pool, 'session-a')).toEqual(['info', 'commands']);
+
+    // The settings tab mutates the same object the plugin holds.
+    settings.enableWebFetch = true;
+
+    expect(await systemActions(pool, 'session-a')).toEqual(['info', 'commands', 'fetch_web']);
+
+    settings.enableWebFetch = false;
+    expect(await systemActions(pool, 'session-a')).toEqual(['info', 'commands']);
+  });
+
+  it('reflects a tool-visibility change on an existing session', async () => {
+    const { pool, settings } = makePool({ enableWebFetch: false, toolVisibility: {} });
+
+    expect(await systemActions(pool, 'session-b')).toContain('commands');
+
+    (settings.toolVisibility as Record<string, boolean>)['system.commands'] = false;
+
+    expect(await systemActions(pool, 'session-b')).not.toContain('commands');
+  });
+
+  describe('notifyToolListChanged', () => {
+    it('notifies every live session', () => {
+      const { pool } = makePool({ enableWebFetch: false, toolVisibility: {} });
+      const sent: string[] = [];
+
+      for (const id of ['s1', 's2', 's3']) {
+        const server = pool.getOrCreateServer(id);
+        (server as unknown as { sendToolListChanged: () => void }).sendToolListChanged =
+          () => sent.push(id);
+      }
+
+      pool.notifyToolListChanged();
+      expect(sent).toEqual(['s1', 's2', 's3']);
+    });
+
+    it('keeps going when one session throws', () => {
+      // A settings toggle is a UI action, not a transaction: one dead session
+      // must not deprive the others of the notification.
+      const { pool } = makePool({ enableWebFetch: false, toolVisibility: {} });
+      const sent: string[] = [];
+
+      for (const id of ['ok-1', 'boom', 'ok-2']) {
+        const server = pool.getOrCreateServer(id);
+        (server as unknown as { sendToolListChanged: () => void }).sendToolListChanged = () => {
+          if (id === 'boom') throw new Error('transport gone');
+          sent.push(id);
+        };
+      }
+
+      expect(() => pool.notifyToolListChanged()).not.toThrow();
+      expect(sent).toEqual(['ok-1', 'ok-2']);
+    });
+
+    it('is a no-op with no sessions', () => {
+      const { pool } = makePool({ enableWebFetch: false, toolVisibility: {} });
+      expect(() => pool.notifyToolListChanged()).not.toThrow();
+    });
+  });
+
+  it('declares the listChanged capability so clients honour the notification', () => {
+    const { pool } = makePool({ enableWebFetch: false, toolVisibility: {} });
+    const server = pool.getOrCreateServer('cap');
+    const caps = (server.server as unknown as {
+      _capabilities: { tools?: { listChanged?: boolean } }
+    })._capabilities;
+    expect(caps.tools?.listChanged).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #285. Prompted by a question during ADR-109 testing: does the server handle a settings change as gracefully as read-only mode does?

## The answer was no, for a reason worth recording

Read-only has been live since **ADR-108** — a predicate read per call, no snapshot. My web-fetch enforcement follows that pattern and was verified live. But **enumeration** was still snapshotted: the pool built `availableTools` once per session and closed over it in *both* the ListTools and CallTool handlers. A session's tool surface was frozen at creation, so a tool toggled off stayed advertised (and dispatchable from the snapshot) until eviction or reconnect, and one toggled on stayed invisible.

Read-only never exhibited this because it does not change the tool *list* — it changes what an operation may do. Same stale-snapshot shape as ADR-108, in the sibling control.

## Two halves, both required

- **Live list.** Built per request from current settings, via a `buildTools()` helper both handlers call.
- **Notification.** Liveness alone is invisible: a client caches `tools/list` from its first connection and has no reason to ask again. That cache is exactly what made the enumeration claim untestable from the client side while verifying ADR-109 — a stale client schema and a broken filter look identical. The pool now broadcasts `notifications/tools/list_changed` to live sessions, declares the `listChanged` capability so a spec-compliant client honours it, and the settings tab fires it on the web-fetch and tool-visibility toggles.

The broadcast is best-effort per session and survives one session throwing: a settings toggle is a UI action, not a transaction.

Enforcement is unchanged — it was already live. This is about what agents can *see* keeping pace with what the settings say.

## Tests

6 new, driving the pool through its real registered handlers rather than asserting on internals: a web-fetch toggle reflected on an **existing** session in both directions with no reconnect, a visibility toggle likewise, all live sessions notified, one throwing session not starving the others, no-op with zero sessions, and the `listChanged` capability actually declared.

53 suites / 615 tests green; build clean; lint clean apart from the tracked #224 warning.