### PR TITLE
fix(mcp): catch async transport failures when announcing a tool list change

### DIFF
--- a/src/utils/mcp-server-pool.ts
+++ b/src/utils/mcp-server-pool.ts
@@ -105,8 +105,19 @@ export class MCPServerPool extends EventEmitter {
   notifyToolListChanged(): void {
     let notified = 0;
     for (const [sessionId, pooled] of this.servers) {
+      // Skip sessions with no live transport. McpServer.sendToolListChanged()
+      // makes this check itself, but it returns void and drops the promise the
+      // underlying send returns — so a transport that rejects (client tab
+      // closed, half-dead socket) surfaces as an unhandled rejection instead of
+      // a log line. Going through the non-deprecated `.server` accessor, which
+      // is what this file already uses to register handlers, hands back the
+      // promise so the failure can be caught. The isConnected() guard has to
+      // come with it, since the low-level call throws on a disconnected server.
+      if (!pooled.server.isConnected()) continue;
       try {
-        pooled.server.sendToolListChanged();
+        void pooled.server.server.sendToolListChanged().catch((error: unknown) => {
+          Debug.error(`[Session ${sessionId}] tools/list_changed send failed:`, error);
+        });
         notified++;
       } catch (error: unknown) {
         Debug.error(`[Session ${sessionId}] tools/list_changed notify failed:`, error);

--- a/tests/security/tool-list-liveness.test.ts
+++ b/tests/security/tool-list-liveness.test.ts
@@ -91,36 +91,88 @@ describe('tool list liveness', () => {
   });
 
   describe('notifyToolListChanged', () => {
+    /** Stand in for a session's transport state and capture what it sent. */
+    const stubSession = (
+      pool: MCPServerPool,
+      id: string,
+      opts: { connected?: boolean; send?: () => Promise<void> } = {}
+    ) => {
+      const server = pool.getOrCreateServer(id);
+      const w = server as unknown as {
+        isConnected: () => boolean;
+        server: { sendToolListChanged: () => Promise<void> };
+      };
+      w.isConnected = () => opts.connected ?? true;
+      if (opts.send) w.server.sendToolListChanged = opts.send;
+      return w;
+    };
+
     it('notifies every live session', () => {
       const { pool } = makePool({ enableWebFetch: false, toolVisibility: {} });
       const sent: string[] = [];
 
       for (const id of ['s1', 's2', 's3']) {
-        const server = pool.getOrCreateServer(id);
-        (server as unknown as { sendToolListChanged: () => void }).sendToolListChanged =
-          () => sent.push(id);
+        stubSession(pool, id, { send: () => { sent.push(id); return Promise.resolve(); } });
       }
 
       pool.notifyToolListChanged();
       expect(sent).toEqual(['s1', 's2', 's3']);
     });
 
-    it('keeps going when one session throws', () => {
+    it('skips sessions with no live transport', () => {
+      const { pool } = makePool({ enableWebFetch: false, toolVisibility: {} });
+      const sent: string[] = [];
+
+      stubSession(pool, 'live', { send: () => { sent.push('live'); return Promise.resolve(); } });
+      stubSession(pool, 'dead', {
+        connected: false,
+        send: () => { sent.push('dead'); return Promise.resolve(); }
+      });
+
+      pool.notifyToolListChanged();
+      expect(sent).toEqual(['live']);
+    });
+
+    it('keeps going when one session throws synchronously', () => {
       // A settings toggle is a UI action, not a transaction: one dead session
       // must not deprive the others of the notification.
       const { pool } = makePool({ enableWebFetch: false, toolVisibility: {} });
       const sent: string[] = [];
 
       for (const id of ['ok-1', 'boom', 'ok-2']) {
-        const server = pool.getOrCreateServer(id);
-        (server as unknown as { sendToolListChanged: () => void }).sendToolListChanged = () => {
-          if (id === 'boom') throw new Error('transport gone');
-          sent.push(id);
-        };
+        stubSession(pool, id, {
+          send: () => {
+            if (id === 'boom') throw new Error('transport gone');
+            sent.push(id);
+            return Promise.resolve();
+          }
+        });
       }
 
       expect(() => pool.notifyToolListChanged()).not.toThrow();
       expect(sent).toEqual(['ok-1', 'ok-2']);
+    });
+
+    it('handles a transport that REJECTS rather than throwing', async () => {
+      // The realistic failure: the send is async, so a half-dead socket rejects
+      // later. A try/catch alone never sees it and node reports an unhandled
+      // rejection. Nothing may escape to the process.
+      const { pool } = makePool({ enableWebFetch: false, toolVisibility: {} });
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => unhandled.push(reason);
+      process.on('unhandledRejection', onUnhandled);
+
+      try {
+        stubSession(pool, 'rejects', { send: () => Promise.reject(new Error('socket closed')) });
+        stubSession(pool, 'fine', { send: () => Promise.resolve() });
+
+        expect(() => pool.notifyToolListChanged()).not.toThrow();
+        // Let any unhandled rejection surface before asserting none did.
+        await new Promise(resolve => setImmediate(resolve));
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+      }
     });
 
     it('is a no-op with no sessions', () => {


### PR DESCRIPTION
Follow-up to #296, from reading the SDK rather than from a failure.

`notifyToolListChanged` called `McpServer.sendToolListChanged()`, which returns `void` and **drops the promise** the underlying `Server.sendToolListChanged()` returns. The send is asynchronous, so the realistic failure — client tab closed, half-dead socket — rejects *after* the call returns. It escaped the `try/catch` entirely and would surface as an unhandled rejection in Obsidian's console instead of the log line the catch exists to produce.

The existing test passed regardless, because it stubbed a **synchronous throw** — the one failure mode that cannot actually occur here. A green test asserting the wrong shape is worse than no test, so the coverage is corrected too.

## Fix

Route through the non-deprecated `.server` accessor this file already uses to register handlers, which returns the promise so `.catch` can log it. That low-level call throws on a disconnected server, so `McpServer`'s internal `isConnected()` guard is now applied explicitly rather than inherited.

## Tests

8 total in this file, including two new: a transport that **rejects** (with an `unhandledRejection` listener asserting nothing escapes to the process), and the skip-disconnected path. 53 suites / 617 tests green; `npm audit` 0 in both trees.

## Verified live

Against 0.12.5 on a real vault: a session created while web fetch was **off** reported `[info, commands]`, and after the setting was toggled on — with no reconnect or re-initialize — the **same session** reported `[info, commands, fetch_web]`. That is the snapshot bug from #285 confirmed fixed in the direction that matters. Note the notification's *delivery* is still only unit-tested; the live probe re-fetched on a timer rather than because it was told to.