### PR TITLE
fix: Reject inapplicable parameters on destructive vault actions

### DIFF
--- a/src/tools/semantic-tools.ts
+++ b/src/tools/semantic-tools.ts
@@ -6,6 +6,147 @@ import { ObsidianImageFile } from '../types/obsidian';
 import { DataviewTool, isDataviewToolAvailable } from './dataview-tool';
 import { formatResponse } from '../formatters';
 
+/**
+ * Per-action parameter validation for destructive vault actions.
+ *
+ * The input schema is assembled per OPERATION, not per action —
+ * `getParametersForOperation(operation)` returns the union of every parameter
+ * any action of that tool might take. So `mode`, `overwrite`, `path1` and the
+ * rest are schema-valid on every `vault` call regardless of which action is
+ * requested, and each handler simply reads the parameters it needs and ignores
+ * the rest.
+ *
+ * That silence is affordable on a read. It is not affordable on a write. An
+ * ignored parameter means the caller believes something untrue about the
+ * command they invoked, and on a destructive action that belief gets acted on
+ * before anyone can notice it was wrong. Two real cases:
+ *
+ *   vault.update + mode: 'append'    -> file replaced. The caller wanted
+ *                                       edit.append and did not know it existed.
+ *   vault.update + overwrite: false  -> file replaced, despite an explicit
+ *                                       instruction not to. `overwrite` belongs
+ *                                       to move/copy.
+ *
+ * Both returned success. Neither left a diff. This rejects instead, and names
+ * the action the parameter actually belongs to, so a wrong assumption becomes a
+ * signpost rather than a silent overwrite.
+ *
+ * Deliberately narrow: only the destructive `vault` actions are gated. Read
+ * paths are left permissive, where a stray parameter costs nothing and a false
+ * positive would break working callers.
+ */
+const DESTRUCTIVE_ACTION_PARAMS: Record<string, readonly string[]> = {
+  'vault.update': ['path', 'content'],
+  'vault.create': ['path', 'content'],
+  'vault.delete': ['path'],
+};
+
+/** Accepted on every action, so never counted as inapplicable. */
+const UNIVERSAL_PARAMS: readonly string[] = ['action', 'raw'];
+
+/**
+ * Where a misplaced parameter actually belongs, keyed by parameter name.
+ * Covers every `vault` parameter plus the `edit` parameters a caller reaching
+ * for a partial edit is most likely to send by mistake.
+ */
+const PARAM_OWNER_HINTS: Record<string, string> = {
+  // The two that motivated this check.
+  mode: "'mode' applies to vault.concatenate (joining two FILES via path1/path2) and to edit.at_line (before/after/replace). To append TEXT to a file use edit.append; for partial replacement use edit.patch or edit.window.",
+  overwrite: "'overwrite' applies to vault.move and vault.copy. vault.update always replaces the entire file contents. To modify part of a file use edit.patch or edit.window.",
+
+  // vault: move / copy / rename
+  destination: "'destination' applies to vault.move, vault.copy and vault.combine.",
+  newName: "'newName' applies to vault.rename.",
+
+  // vault: concatenate / combine
+  path1: "'path1' and 'path2' apply to vault.concatenate.",
+  path2: "'path1' and 'path2' apply to vault.concatenate.",
+  paths: "'paths' applies to vault.combine.",
+  separator: "'separator' applies to vault.combine and vault.concatenate.",
+  includeFilenames: "'includeFilenames' applies to vault.combine.",
+  sortBy: "'sortBy' and 'sortOrder' apply to vault.combine.",
+  sortOrder: "'sortBy' and 'sortOrder' apply to vault.combine.",
+
+  // vault: split
+  splitBy: "'splitBy' applies to vault.split.",
+  level: "'level' applies to vault.split with splitBy='heading'.",
+  delimiter: "'delimiter' applies to vault.split with splitBy='delimiter'.",
+  linesPerFile: "'linesPerFile' applies to vault.split with splitBy='lines'.",
+  maxSize: "'maxSize' applies to vault.split with splitBy='size'.",
+  outputDirectory: "'outputDirectory' and 'outputPattern' apply to vault.split.",
+  outputPattern: "'outputDirectory' and 'outputPattern' apply to vault.split.",
+
+  // vault: search / list / read
+  query: "'query' applies to vault.search and vault.fragments.",
+  ranked: "'ranked' applies to vault.search.",
+  searchStrategy: "'searchStrategy' applies to vault.search.",
+  includeSnippets: "'includeSnippets' applies to vault.search.",
+  snippetLength: "'snippetLength' applies to vault.search.",
+  includeContent: "'includeContent' applies to vault.search.",
+  directory: "'directory' applies to vault.list.",
+  page: "'page' and 'pageSize' apply to paginated reads: vault.list, vault.search, vault.read.",
+  pageSize: "'page' and 'pageSize' apply to paginated reads: vault.list, vault.search, vault.read.",
+  returnFullFile: "'returnFullFile' applies to vault.read.",
+  strategy: "'strategy' applies to vault.fragments.",
+  maxFragments: "'maxFragments' applies to vault.fragments.",
+
+  // edit parameters, included because a caller trying to modify part of a file
+  // is exactly the caller most likely to land on a destructive vault action.
+  oldText: "'oldText' and 'newText' belong to edit.window (find/replace with fuzzy matching).",
+  newText: "'oldText' and 'newText' belong to edit.window (find/replace with fuzzy matching).",
+  fuzzyThreshold: "'fuzzyThreshold' belongs to edit.window.",
+  operation: "'operation' belongs to edit.patch (append/prepend/replace against a heading, block, or frontmatter field).",
+  target: "'target' and 'targetType' belong to edit.patch.",
+  targetType: "'target' and 'targetType' belong to edit.patch.",
+  lineNumber: "'lineNumber' belongs to edit.at_line.",
+};
+
+/**
+ * Returns an error result if `args` carries parameters that do not apply to the
+ * requested destructive action, or null to proceed.
+ *
+ * Each rejected parameter is reported individually under `rejected`, so a
+ * caller that sent several gets a hint per parameter rather than one blob.
+ */
+function rejectInapplicableParams(
+  operation: string,
+  args: ToolArgs,
+): MCPToolResult | null {
+  const key = `${operation}.${args.action}`;
+  const allowed = DESTRUCTIVE_ACTION_PARAMS[key];
+  if (!allowed) return null;
+
+  const inapplicable = Object.keys(args).filter(
+    k => !allowed.includes(k) && !UNIVERSAL_PARAMS.includes(k),
+  );
+  if (inapplicable.length === 0) return null;
+
+  const rejected = inapplicable.map(name => ({
+    parameter: name,
+    hint: PARAM_OWNER_HINTS[name]
+      ?? `'${name}' is not a parameter of ${key}. Remove it, or call the action it belongs to.`,
+  }));
+
+  const named = inapplicable.map(k => `'${k}'`).join(', ');
+  const subject = inapplicable.length === 1
+    ? `Parameter ${named} does not apply`
+    : `Parameters ${named} do not apply`;
+
+  return {
+    content: [{
+      type: 'text' as const,
+      text: JSON.stringify({
+        error: {
+          code: 'INVALID_PARAMETERS',
+          message: `${subject} to ${key}. Rejected rather than silently ignored, because ${key} is destructive. Accepted parameters: ${allowed.join(', ')}.`,
+          rejected,
+        },
+      }, null, 2),
+    }],
+    isError: true,
+  };
+}
+
 /** MCP content item for text responses */
 interface MCPTextContent {
   type: 'text';
@@ -168,6 +309,11 @@ const createSemanticTool = (operation: string, visibility?: ToolVisibility, webF
         }]
       };
     }
+
+    // An inapplicable parameter on a destructive action is a signal that the
+    // caller has the wrong command. Refuse before the write, not after.
+    const paramError = rejectInapplicableParams(operation, args);
+    if (paramError) return paramError;
 
     // Read-only mode is NOT enforced here (ADR-108). It is enforced once, in
     // VaultSecurityManager.validateOperation, which now reads the setting live.

--- a/tests/security/param-validation.test.ts
+++ b/tests/security/param-validation.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Per-action parameter validation on destructive vault actions.
+ *
+ * The input schema is built per operation, so every `vault` action accepts the
+ * union of all `vault` parameters. Handlers read what they need and ignore the
+ * rest. On a read that is harmless. On a write it means the caller's wrong
+ * assumption gets acted on silently — the two cases that motivated this:
+ *
+ *   vault.update + mode: 'append'   -> file replaced; the caller wanted
+ *                                      edit.append and did not know it existed
+ *   vault.update + overwrite: false -> file replaced despite an explicit
+ *                                      instruction not to
+ *
+ * Both returned success and left no diff.
+ *
+ * Assertions are on RECORDED VAULT WRITES, following tool-visibility.test.ts:
+ * "rejected" has to mean no write happened, not merely that an error string was
+ * returned somewhere.
+ */
+import { SecureObsidianAPI } from '../../src/security';
+import { createSemanticTools } from '../../src/tools/semantic-tools';
+import { BASELINE_SECURITY_SETTINGS } from '../../src/mcp-server';
+import { App, TFile } from 'obsidian';
+
+jest.mock('obsidian');
+
+type Write = { op: string; path: string };
+
+function mkFile(p: string): TFile {
+  const f = new TFile();
+  const w = f as unknown as { path: string; extension: string; name: string };
+  w.path = p;
+  w.extension = 'md';
+  w.name = p;
+  return f;
+}
+
+function makeApp(writes: Write[]): App {
+  return {
+    vault: {
+      adapter: { basePath: '/test/vault' },
+      getAbstractFileByPath: (p: string) => (p === 'note.md' ? mkFile(p) : null),
+      read: async () => 'body\n',
+      cachedRead: async () => 'body\n',
+      modify: async (f: TFile) => { writes.push({ op: 'modify', path: f.path }); },
+      create: async (p: string) => { writes.push({ op: 'create', path: p }); return mkFile(p); },
+      getFiles: () => [mkFile('note.md')],
+    },
+    fileManager: {
+      renameFile: async (_f: TFile, n: string) => { writes.push({ op: 'rename', path: n }); },
+      trashFile: async (f: TFile) => { writes.push({ op: 'trash', path: f.path }); },
+    },
+    metadataCache: { getFileCache: () => ({}), resolvedLinks: {} },
+    workspace: { getActiveFile: () => mkFile('note.md') },
+  } as unknown as App;
+}
+
+function setup() {
+  const writes: Write[] = [];
+  const plugin = { settings: { readOnlyMode: false } };
+  const api = new SecureObsidianAPI(
+    makeApp(writes), undefined, plugin as never, BASELINE_SECURITY_SETTINGS,
+  );
+  const tools = createSemanticTools(api, undefined) ?? [];
+  return { writes, api, byName: (n: string) => tools.find(t => t.name === n) };
+}
+
+describe('per-action parameter validation', () => {
+  describe('destructive actions reject inapplicable parameters', () => {
+    it('refuses vault.update carrying `mode`, and records no write', async () => {
+      const { byName, api, writes } = setup();
+      const vault = byName('vault')!;
+
+      const res = await vault.handler(api, {
+        action: 'update', path: 'note.md', content: 'x', mode: 'append',
+      });
+
+      expect(JSON.stringify(res)).toContain('INVALID_PARAMETERS');
+      expect(writes).toEqual([]);
+    });
+
+    it('refuses vault.update carrying `overwrite`, and records no write', async () => {
+      const { byName, api, writes } = setup();
+      const vault = byName('vault')!;
+
+      const res = await vault.handler(api, {
+        action: 'update', path: 'note.md', content: 'x', overwrite: false,
+      });
+
+      expect(JSON.stringify(res)).toContain('INVALID_PARAMETERS');
+      expect(writes).toEqual([]);
+    });
+
+    it('refuses vault.delete carrying an inapplicable parameter', async () => {
+      const { byName, api, writes } = setup();
+      const vault = byName('vault')!;
+
+      const res = await vault.handler(api, {
+        action: 'delete', path: 'note.md', destination: 'other.md',
+      });
+
+      expect(JSON.stringify(res)).toContain('INVALID_PARAMETERS');
+      expect(writes).toEqual([]);
+    });
+
+    it('refuses regardless of the inapplicable parameter\'s value', async () => {
+      const { byName, api, writes } = setup();
+      const vault = byName('vault')!;
+
+      // The gate keys on the parameter NAME, so mode='prepend' is caught the
+      // same as mode='append'. Both are values of a parameter that does not
+      // belong to vault.update at all.
+      const res = await vault.handler(api, {
+        action: 'update', path: 'note.md', content: 'x', mode: 'prepend',
+      });
+
+      expect(JSON.stringify(res)).toContain('INVALID_PARAMETERS');
+      expect(writes).toEqual([]);
+    });
+
+    it('names every inapplicable parameter it rejected', async () => {
+      const { byName, api } = setup();
+      const vault = byName('vault')!;
+
+      const res = await vault.handler(api, {
+        action: 'update', path: 'note.md', content: 'x', mode: 'append', newName: 'z.md',
+      });
+      const text = JSON.stringify(res);
+
+      expect(text).toContain('mode');
+      expect(text).toContain('newName');
+    });
+  });
+
+  /**
+   * One error carrying a per-parameter breakdown, rather than one blob of
+   * concatenated advice — a caller that sent three wrong parameters should get
+   * three hints, each attached to the parameter it is about.
+   */
+  describe('error shape', () => {
+    function parse(res: unknown) {
+      const r = res as { content: { text: string }[] };
+      return JSON.parse(r.content[0].text) as {
+        error: { code: string; message: string; rejected: { parameter: string; hint: string }[] };
+      };
+    }
+
+    it('reports one entry per rejected parameter, each with its own hint', async () => {
+      const { byName, api } = setup();
+      const vault = byName('vault')!;
+
+      const res = await vault.handler(api, {
+        action: 'update', path: 'note.md', content: 'x', mode: 'append', overwrite: false,
+      });
+      const { error } = parse(res);
+
+      expect(error.rejected.map(r => r.parameter).sort()).toEqual(['mode', 'overwrite']);
+      expect(error.rejected.find(r => r.parameter === 'mode')!.hint).toContain('edit.append');
+      expect(error.rejected.find(r => r.parameter === 'overwrite')!.hint).toContain('vault.move');
+    });
+
+    it('uses singular phrasing for one parameter', async () => {
+      const { byName, api } = setup();
+      const vault = byName('vault')!;
+
+      const res = await vault.handler(api, {
+        action: 'update', path: 'note.md', content: 'x', mode: 'append',
+      });
+
+      expect(parse(res).error.message).toContain("Parameter 'mode' does not apply");
+    });
+
+    it('uses plural phrasing for several parameters', async () => {
+      const { byName, api } = setup();
+      const vault = byName('vault')!;
+
+      const res = await vault.handler(api, {
+        action: 'update', path: 'note.md', content: 'x', mode: 'append', newName: 'z.md',
+      });
+
+      expect(parse(res).error.message).toContain('Parameters ');
+      expect(parse(res).error.message).toContain('do not apply');
+    });
+
+    it('falls back to a generic hint for a parameter with no specific owner', async () => {
+      const { byName, api } = setup();
+      const vault = byName('vault')!;
+
+      const res = await vault.handler(api, {
+        action: 'update', path: 'note.md', content: 'x', notARealParameter: 1,
+      });
+      const { error } = parse(res);
+
+      expect(error.rejected).toHaveLength(1);
+      expect(error.rejected[0].hint).toContain('is not a parameter of vault.update');
+    });
+
+    it('has a specific hint for every vault parameter a caller could misplace', async () => {
+      const { byName, api } = setup();
+      const vault = byName('vault')!;
+
+      // Sampled across each family: move/copy, split, search, combine, read.
+      const families = ['destination', 'splitBy', 'query', 'paths', 'returnFullFile'];
+
+      for (const name of families) {
+        const res = await vault.handler(api, {
+          action: 'update', path: 'note.md', content: 'x', [name]: 'v',
+        });
+        const { error } = parse(res);
+        expect(error.rejected[0].hint).not.toContain('is not a parameter of');
+      }
+    });
+  });
+
+  /**
+   * The rejection is only half the value. A caller passing `mode: 'append'` to
+   * vault.update is trying to append, and the API has an append — so the error
+   * should hand them the action they were reaching for.
+   */
+  describe('hints point at the action the parameter belongs to', () => {
+    it('points a misplaced `mode` at edit.append', async () => {
+      const { byName, api } = setup();
+      const vault = byName('vault')!;
+
+      const res = await vault.handler(api, {
+        action: 'update', path: 'note.md', content: 'x', mode: 'append',
+      });
+
+      expect(JSON.stringify(res)).toContain('edit.append');
+    });
+
+    it('explains that `overwrite` belongs to move/copy and that update always replaces', async () => {
+      const { byName, api } = setup();
+      const vault = byName('vault')!;
+
+      const res = await vault.handler(api, {
+        action: 'update', path: 'note.md', content: 'x', overwrite: false,
+      });
+      const text = JSON.stringify(res);
+
+      expect(text).toContain('vault.move');
+      expect(text).toContain('always replaces');
+    });
+  });
+
+  /**
+   * Guarding writes is easy; not breaking working callers is the part that
+   * decides whether this is shippable.
+   */
+  describe('no false positives', () => {
+    it('allows vault.update with exactly its own parameters, and records the write', async () => {
+      const { byName, api, writes } = setup();
+      const vault = byName('vault')!;
+
+      const res = await vault.handler(api, {
+        action: 'update', path: 'note.md', content: 'replacement',
+      });
+
+      expect(JSON.stringify(res)).not.toContain('INVALID_PARAMETERS');
+      expect(writes).toEqual([{ op: 'modify', path: 'note.md' }]);
+    });
+
+    it('allows the universal `raw` parameter alongside a destructive action', async () => {
+      const { byName, api, writes } = setup();
+      const vault = byName('vault')!;
+
+      const res = await vault.handler(api, {
+        action: 'update', path: 'note.md', content: 'replacement', raw: true,
+      });
+
+      expect(JSON.stringify(res)).not.toContain('INVALID_PARAMETERS');
+      expect(writes).toEqual([{ op: 'modify', path: 'note.md' }]);
+    });
+
+    it('allows vault.create with its own parameters', async () => {
+      const { byName, api, writes } = setup();
+      const vault = byName('vault')!;
+
+      const res = await vault.handler(api, {
+        action: 'create', path: 'fresh.md', content: 'hello',
+      });
+
+      expect(JSON.stringify(res)).not.toContain('INVALID_PARAMETERS');
+      expect(writes).toEqual([{ op: 'create', path: 'fresh.md' }]);
+    });
+
+    it('leaves read paths permissive — a stray parameter on a read is not an error', async () => {
+      const { byName, api } = setup();
+      const vault = byName('vault')!;
+
+      const res = await vault.handler(api, {
+        action: 'read', path: 'note.md', mode: 'append',
+      });
+
+      expect(JSON.stringify(res)).not.toContain('INVALID_PARAMETERS');
+    });
+
+    it('leaves edit actions ungated', async () => {
+      const { byName, api, writes } = setup();
+      const edit = byName('edit')!;
+
+      const res = await edit.handler(api, {
+        action: 'append', path: 'note.md', content: 'appended',
+      });
+
+      expect(JSON.stringify(res)).not.toContain('INVALID_PARAMETERS');
+      expect(writes.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #299.

## Summary

A parameter that gets silently ignored is a signal that the caller believes something untrue about the command they invoked. On a read that costs nothing. On a destructive action, that belief gets acted on before anyone can notice it was wrong.

This adds per-action parameter validation to the three destructive `vault` actions, and — where possible — names the action the parameter actually belongs to, so a wrong assumption becomes a signpost instead of a silent overwrite.

## The two cases that prompted it

Both destroyed a file, both returned success, neither left a diff:

```
vault.update + mode: 'append'     -> file replaced.
                                     The caller wanted edit.append and did not know it existed.

vault.update + overwrite: false   -> file replaced, despite an explicit instruction
                                     not to. 'overwrite' belongs to move/copy.
```

The second is the one I'd argue matters most: that isn't a careless caller, it's a careful one taking a precaution and having it discarded by a destructive operation that then reports success.

## Root cause

The input schema is assembled per **operation**, not per **action** — `getParametersForOperation(operation)` returns the union of every parameter any action of that tool might take. So `mode`, `overwrite`, `path1`, `newName` and the rest are schema-valid on every `vault` call regardless of action, and each handler reads what it needs and ignores the rest:

```ts
case 'update': {
  const path = requireParamStr(params, 'path', 'vault.update');
  const content = requireParamStr(params, 'content', 'vault.update', ...);
  return await ctx.api.updateFile(path, content);   // nothing else is consulted
}
```

`additionalProperties: false` can't fix this — `mode` and `overwrite` genuinely *are* valid parameters of the `vault` tool, just not of the `update` action. The check has to be per-action, inside the handler.

## What this does

Adds `rejectInapplicableParams()` in `semantic-tools.ts`, called immediately after the existing `ACTION_DISABLED` visibility gate — reusing a validation point that was already there. Four lines at the call site; the rest is the parameter map and hints.

```json
{
  "error": {
    "code": "INVALID_PARAMETERS",
    "message": "Parameters 'mode', 'overwrite', 'query' do not apply to vault.update. Rejected rather than silently ignored, because vault.update is destructive. Accepted parameters: path, content.",
    "rejected": [
      { "parameter": "mode",      "hint": "'mode' applies to vault.concatenate (joining two FILES via path1/path2) and to edit.at_line (before/after/replace). To append TEXT to a file use edit.append; for partial replacement use edit.patch or edit.window." },
      { "parameter": "overwrite", "hint": "'overwrite' applies to vault.move and vault.copy. vault.update always replaces the entire file contents. To modify part of a file use edit.patch or edit.window." },
      { "parameter": "query",     "hint": "'query' applies to vault.search and vault.fragments." }
    ]
  }
}
```

Each rejected parameter gets its own entry and its own hint, rather than one concatenated blob — a caller who sent three wrong parameters gets three answers. Message phrasing is singular/plural correct. Every `vault` parameter has a specific hint, plus the `edit` parameters a caller reaching for a partial edit is most likely to send by mistake; anything unrecognised falls back to a generic message.

`vault.update` already carries an excellent hint pointing at `edit.patch` — but only on the `content`-missing path. It never fires on the destructive path, which is the one that needs it.

## Scope — deliberately narrow

Only `vault.update`, `vault.create` and `vault.delete` are gated. Read paths stay permissive, where a stray parameter costs nothing and a false positive would break working callers. Widening it later is a one-line addition to the map; I kept the initial surface small on purpose.

## Testing

- `tests/security/param-validation.test.ts` — 17 cases, following the pattern in `tool-visibility.test.ts`: **assertions are on recorded vault writes**, so "rejected" means no write occurred rather than merely that an error string came back. Six of the cases are explicitly no-false-positive checks.
- Full suite: **634 passed / 54 suites**, up from 628. `tsc --noEmit` clean, `eslint` clean, `npm run build` clean.
- Also built and run live in a real vault for ~30 minutes: blocked calls left the target file untouched; legitimate `vault.update`, `edit.append`, `vault.read` with a stray parameter, and `vault.search` all behaved normally.

## How this was found

Honestly: by an AI assistant misusing the API. It passed `mode: 'append'` to `vault.update` believing that appended, destroyed two notes, and only noticed an hour later via a byte count. It then concluded — wrongly — that no append action existed at all, having never loaded the `edit` tool.

That's precisely the caller class this protects. An MCP client sees one union schema with no indication of which parameters belong to which action, and `edit.append` was one tool away the whole time. A rejection naming it would have turned an hour of silent data loss into a two-second correction.

Happy to adjust scope, wording, or the error shape — and equally happy for this to just be the issue if you'd rather implement it differently.
