### PR TITLE
ci: build on Node 24; pin @types/node to the same major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 10
+    ignore:
+      # @types/node tracks the Node major CI builds with (setup-node in
+      # .github/workflows). Bump both together, by hand.
+      - dependency-name: "@types/node"
+        versions: [">=25"]
     # Group all patch and minor updates together
     groups:
       development-dependencies:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/feature-release.yml
+++ b/.github/workflows/feature-release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/scorecard-watch.yml
+++ b/.github/workflows/scorecard-watch.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
 
       # No dependency install: scorecard.mjs + scorecard-gate.mjs use only
       # Node builtins (fetch, fs, child_process). Keeps this fast and off

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
     
     steps:
     - uses: actions/checkout@v7

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@eslint/js": "^10.0.1",
         "@types/jest": "^30.0.0",
         "@types/minimatch": "^5.1.2",
-        "@types/node": "^25.9.2",
+        "@types/node": "^24.13.3",
         "@typescript-eslint/utils": "^8.68.0",
         "esbuild": "^0.28.2",
         "eslint": "^10.9.1",
@@ -2696,12 +2696,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/node-forge": {
@@ -10219,9 +10219,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@eslint/js": "^10.0.1",
     "@types/jest": "^30.0.0",
     "@types/minimatch": "^5.1.2",
-    "@types/node": "^25.9.2",
+    "@types/node": "^24.13.3",
     "@typescript-eslint/utils": "^8.68.0",
     "esbuild": "^0.28.2",
     "eslint": "^10.9.1",


### PR DESCRIPTION
## Changes
- All five `setup-node` sites (`build`, `test` matrix, `release`, `feature-release`, `scorecard-watch`) move from Node 20 → 24. Node 20 went EOL April 2026; 24 is the active LTS.
- `@types/node` ^25.9.2 → ^24.13.3, matching the CI major.
- Dependabot ignores `@types/node` majors ≥25 so the two move together. Supersedes #261.

## Verification
- `npm run build`, `npm run lint` (1 known warning, #224), `npx jest` 645/645 — locally.
- CI on this PR is the first run under Node 24.