### PR TITLE
feat(security): readonly: rules in .mcpignore (#275)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1159,7 +1159,7 @@ class MCPSettingTab extends PluginSettingTab {
 		// Path Exclusions Setting
 		new Setting(containerEl)
 			.setName('Path exclusions')
-			.setDesc('Exclude files and directories from mcp operations using .gitignore-style patterns')
+			.setDesc('Exclude files and directories from mcp operations using .gitignore-style patterns. Prefix a pattern with readonly: to keep it readable but refuse writes.')
 			.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.pathExclusionsEnabled)
 				.onChange(async (value) => {

--- a/src/security/mcp-ignore-manager.ts
+++ b/src/security/mcp-ignore-manager.ts
@@ -13,16 +13,30 @@ interface IgnoreRule {
 }
 
 /**
+ * Prefix that marks a line as a read-only rule rather than an exclusion (#275).
+ * `readonly:docs/**` exposes the subtree to reads and refuses every write to it;
+ * `!readonly:docs/scratch.md` re-opens one path for writing. The prefix sits
+ * after the negation so `!readonly:` reads as "not read-only".
+ */
+const READONLY_PREFIX = 'readonly:';
+
+/**
  * MCPIgnoreManager - Handles .mcpignore file-based path exclusions
  *
  * Uses .gitignore-style patterns to exclude files and directories from MCP operations.
  * Patterns are stored in .mcpignore at the vault root (like .gitignore)
+ *
+ * Two rule sets live in the file. Exclusion rules hide a path from every
+ * operation. Read-only rules (`readonly:` prefix) leave the path visible and
+ * readable but refuse writes. An exclusion always wins over a read-only rule:
+ * a path that is hidden cannot be read, so whether it may be written is moot.
  */
 export class MCPIgnoreManager {
   private app: App;
   private ignorePath: string;
   private patterns: string[] = [];
   private rules: IgnoreRule[] = [];
+  private readonlyRules: IgnoreRule[] = [];
   private isEnabled: boolean = false;
   private lastModified: number = 0;
 
@@ -72,6 +86,7 @@ export class MCPIgnoreManager {
       // File doesn't exist or can't be read - no exclusions
       this.patterns = [];
       this.rules = [];
+      this.readonlyRules = [];
       this.lastModified = 0;
       Debug.log('MCPIgnore: No .mcpignore file found, no exclusions active');
     }
@@ -122,6 +137,7 @@ export class MCPIgnoreManager {
   private parseIgnoreContent(content: string): void {
     const validPatterns: string[] = [];
     const rules: IgnoreRule[] = [];
+    const readonlyRules: IgnoreRule[] = [];
 
     for (const line of content.split('\n')) {
       const trimmed = line.trim();
@@ -134,7 +150,13 @@ export class MCPIgnoreManager {
       // Negation is handled here rather than by Minimatch: the pattern is rewritten
       // below, so the '!' would not survive to reach it anyway.
       const negate = trimmed.startsWith('!');
-      const body = negate ? trimmed.slice(1) : trimmed;
+      let body = negate ? trimmed.slice(1) : trimmed;
+
+      // `readonly:` is stripped after `!` so both `readonly:x` and `!readonly:x` work.
+      const readonly = body.startsWith(READONLY_PREFIX);
+      if (readonly) {
+        body = body.slice(READONLY_PREFIX.length);
+      }
       if (!body) {
         continue;
       }
@@ -149,7 +171,7 @@ export class MCPIgnoreManager {
         }));
 
         validPatterns.push(trimmed);
-        rules.push({ negate, matchers });
+        (readonly ? readonlyRules : rules).push({ negate, matchers });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         Debug.log(`MCPIgnore: Invalid pattern "${trimmed}": ${message}`);
@@ -158,6 +180,25 @@ export class MCPIgnoreManager {
 
     this.patterns = validPatterns;
     this.rules = rules;
+    this.readonlyRules = readonlyRules;
+  }
+
+  /**
+   * Last matching rule wins, so a later negation can undo an earlier match.
+   */
+  private lastMatchWins(rules: IgnoreRule[], normalizedPath: string): boolean {
+    let matched = false;
+    for (const rule of rules) {
+      if (rule.matchers.some(matcher => matcher.match(normalizedPath))) {
+        matched = !rule.negate;
+      }
+    }
+    return matched;
+  }
+
+  private normalize(path: string): string {
+    // Remove leading slash, use forward slashes
+    return path.replace(/^\/+/, '').replace(/\\/g, '/');
   }
 
   /**
@@ -170,20 +211,31 @@ export class MCPIgnoreManager {
       return false;
     }
 
-    // Normalize path (remove leading slash, use forward slashes)
-    const normalizedPath = path.replace(/^\/+/, '').replace(/\\/g, '/');
-
-    // Last matching rule wins, so a later negation can re-include an earlier exclusion.
-    let excluded = false;
-
-    for (const rule of this.rules) {
-      if (rule.matchers.some(matcher => matcher.match(normalizedPath))) {
-        excluded = !rule.negate;
-      }
-    }
+    const normalizedPath = this.normalize(path);
+    const excluded = this.lastMatchWins(this.rules, normalizedPath);
 
     Debug.log(`🔍 MCPIgnore: "${normalizedPath}" excluded = ${excluded}`);
     return excluded;
+  }
+
+  /**
+   * Check if a path is exposed read-only (#275). Reads proceed; the security
+   * layer refuses create/update/delete/move/rename and any move/copy *into* it.
+   *
+   * Independent of isExcluded(): callers check exclusion first, so an excluded
+   * path never gets this far. Copying *out of* a read-only path is a read of the
+   * source and is allowed.
+   */
+  isReadOnly(path: string): boolean {
+    if (!this.isEnabled || this.readonlyRules.length === 0) {
+      return false;
+    }
+
+    const normalizedPath = this.normalize(path);
+    const readonly = this.lastMatchWins(this.readonlyRules, normalizedPath);
+
+    Debug.log(`🔍 MCPIgnore: "${normalizedPath}" readonly = ${readonly}`);
+    return readonly;
   }
 
   /**
@@ -199,12 +251,14 @@ export class MCPIgnoreManager {
   getStats(): {
     enabled: boolean;
     patternCount: number;
+    readonlyPatternCount: number;
     lastModified: number;
     filePath: string;
   } {
     return {
       enabled: this.isEnabled,
       patternCount: this.patterns.length,
+      readonlyPatternCount: this.readonlyRules.length,
       lastModified: this.lastModified,
       filePath: this.ignorePath
     };
@@ -282,6 +336,15 @@ export class MCPIgnoreManager {
 # !private/shared-notes.md
 # !work/public-docs/
 # !**/*.public.md
+
+# === READ-ONLY PATHS ===
+# Prefix a pattern with readonly: to keep it visible and readable while
+# refusing every write (create, update, delete, move, rename, and moves or
+# copies into it). Same pattern syntax as above. Exclusions win over read-only:
+# a hidden path stays hidden. Use !readonly: to re-open a path for writing.
+# readonly:sources/**        # agents may read raw sources, never edit them
+# readonly:architecture.md   # one file
+# !readonly:sources/notes/   # except this folder, which stays writable
 
 # === YOUR PATTERNS BELOW ===
 # Add your custom exclusion patterns here

--- a/src/security/vault-security-manager.ts
+++ b/src/security/vault-security-manager.ts
@@ -209,6 +209,21 @@ export class VaultSecurityManager {
 						'PATH_NOT_ALLOWED'
 					);
 				}
+
+				// .mcpignore `readonly:` rules (#275). COPY only reads its source, so
+				// it is the one non-READ operation allowed through here; its
+				// destination is checked below.
+				if (
+					operation.type !== OperationType.READ &&
+					operation.type !== OperationType.COPY &&
+					this.isPathReadOnly(operation.path)
+				) {
+					this.logSecurityEvent(operation, 'blocked', 'PATH_READ_ONLY');
+					throw new SecurityError(
+						`Path '${operation.path}' is read-only (.mcpignore readonly: rule); '${operation.type}' is not permitted`,
+						'PATH_READ_ONLY'
+					);
+				}
 			}
 
 			// Step 4: Validate target path for move/rename operations
@@ -230,6 +245,15 @@ export class VaultSecurityManager {
 					throw new SecurityError(
 						`Access to target path '${validatedTargetPath}' is not allowed`,
 						'TARGET_PATH_NOT_ALLOWED'
+					);
+				}
+
+				// A target path is always written to, whatever the operation.
+				if (this.isPathReadOnly(operation.targetPath)) {
+					this.logSecurityEvent(operation, 'blocked', 'TARGET_PATH_READ_ONLY');
+					throw new SecurityError(
+						`Target path '${operation.targetPath}' is read-only (.mcpignore readonly: rule)`,
+						'TARGET_PATH_READ_ONLY'
 					);
 				}
 			}
@@ -334,6 +358,14 @@ export class VaultSecurityManager {
 		Debug.log(`🔍 blockedPaths pattern match result for "${path}": ${isBlockedBySettings}`);
 		
 		return isBlockedBySettings;
+	}
+
+	/**
+	 * Checks .mcpignore `readonly:` rules (#275). Only the ignore manager knows
+	 * them; there is no settings-side equivalent.
+	 */
+	private isPathReadOnly(path: string): boolean {
+		return !!this.ignoreManager?.getEnabled() && this.ignoreManager.isReadOnly(path);
 	}
 
 	/**

--- a/tests/security/mcpignore-readonly.test.ts
+++ b/tests/security/mcpignore-readonly.test.ts
@@ -1,0 +1,142 @@
+/**
+ * `readonly:` rules in .mcpignore (#275).
+ *
+ * Two layers under test, each through its real implementation:
+ *  - MCPIgnoreManager parses `readonly:` / `!readonly:` lines into a rule set
+ *    separate from exclusions, with last-match-wins negation.
+ *  - VaultSecurityManager refuses every write to a read-only path and every
+ *    move/copy into one, while reads and copies *out of* one proceed.
+ *
+ * Only the vault adapter (the .mcpignore bytes) is stubbed.
+ */
+import { App } from 'obsidian';
+import { MCPIgnoreManager } from '../../src/security/mcp-ignore-manager';
+import { OperationType, VaultSecurityManager } from '../../src/security/vault-security-manager';
+
+async function managerWith(content: string): Promise<MCPIgnoreManager> {
+  const app = {
+    vault: {
+      adapter: {
+        stat: async () => ({ mtime: 1, ctime: 1, size: content.length, type: 'file' as const }),
+        read: async () => content
+      }
+    }
+  } as unknown as App;
+
+  const manager = new MCPIgnoreManager(app);
+  manager.setEnabled(true);
+  await manager.loadIgnoreFile();
+  return manager;
+}
+
+describe('.mcpignore readonly: rules (#275)', () => {
+  describe('MCPIgnoreManager parsing', () => {
+    it('marks a readonly: subtree read-only without excluding it', async () => {
+      const manager = await managerWith('readonly:sources/**');
+
+      expect(manager.isReadOnly('sources/paper.md')).toBe(true);
+      expect(manager.isReadOnly('sources/deep/nested.md')).toBe(true);
+      expect(manager.isExcluded('sources/paper.md')).toBe(false);
+    });
+
+    it('marks a single file read-only, anywhere in the vault when unanchored', async () => {
+      const manager = await managerWith('readonly:architecture.md');
+
+      expect(manager.isReadOnly('architecture.md')).toBe(true);
+      expect(manager.isReadOnly('docs/architecture.md')).toBe(true);
+      expect(manager.isReadOnly('docs/other.md')).toBe(false);
+    });
+
+    it('!readonly: re-opens a path for writing, last match wins', async () => {
+      const manager = await managerWith(['readonly:sources/**', '!readonly:sources/notes/**'].join('\n'));
+
+      expect(manager.isReadOnly('sources/raw.md')).toBe(true);
+      expect(manager.isReadOnly('sources/notes/mine.md')).toBe(false);
+    });
+
+    it('keeps exclusion rules and readonly rules in separate sets', async () => {
+      const manager = await managerWith(['private/', 'readonly:sources/**'].join('\n'));
+
+      expect(manager.isExcluded('private/secret.md')).toBe(true);
+      expect(manager.isReadOnly('private/secret.md')).toBe(false);
+      expect(manager.isExcluded('sources/raw.md')).toBe(false);
+      expect(manager.isReadOnly('sources/raw.md')).toBe(true);
+      expect(manager.getStats()).toMatchObject({ patternCount: 2, readonlyPatternCount: 1 });
+    });
+
+    it('a readonly: line with an empty pattern is ignored', async () => {
+      const manager = await managerWith('readonly:');
+
+      expect(manager.getStats().readonlyPatternCount).toBe(0);
+      expect(manager.isReadOnly('anything.md')).toBe(false);
+    });
+
+    it('reports nothing read-only when exclusions are disabled', async () => {
+      const manager = await managerWith('readonly:sources/**');
+      manager.setEnabled(false);
+
+      expect(manager.isReadOnly('sources/raw.md')).toBe(false);
+    });
+  });
+
+  describe('VaultSecurityManager enforcement', () => {
+    let security: VaultSecurityManager;
+
+    beforeEach(async () => {
+      const ignore = await managerWith(['private/', 'readonly:sources/**', '!readonly:sources/notes/**'].join('\n'));
+      // Path validation is exercised for real; the validator only needs a base
+      // directory from the App.
+      const app = { vault: { adapter: { basePath: '/test/vault' } } } as unknown as App;
+      security = new VaultSecurityManager(app, {}, ignore);
+    });
+
+    const op = (type: OperationType, path: string, targetPath?: string) =>
+      security.validateOperation({ type, path, targetPath });
+
+    it('allows reads of a read-only path', async () => {
+      await expect(op(OperationType.READ, 'sources/raw.md')).resolves.toMatchObject({ type: OperationType.READ });
+    });
+
+    it.each([
+      OperationType.CREATE,
+      OperationType.UPDATE,
+      OperationType.DELETE,
+      OperationType.RENAME,
+    ])('refuses %s on a read-only path with PATH_READ_ONLY', async (type) => {
+      await expect(op(type, 'sources/raw.md', type === OperationType.RENAME ? 'sources/renamed.md' : undefined))
+        .rejects.toMatchObject({ code: 'PATH_READ_ONLY' });
+    });
+
+    it('refuses moving a file out of a read-only path (the source is removed)', async () => {
+      await expect(op(OperationType.MOVE, 'sources/raw.md', 'inbox/raw.md'))
+        .rejects.toMatchObject({ code: 'PATH_READ_ONLY' });
+    });
+
+    it('allows copying out of a read-only path, which only reads the source', async () => {
+      await expect(op(OperationType.COPY, 'sources/raw.md', 'inbox/raw.md'))
+        .resolves.toMatchObject({ type: OperationType.COPY });
+    });
+
+    it('refuses moving or copying into a read-only path with TARGET_PATH_READ_ONLY', async () => {
+      await expect(op(OperationType.MOVE, 'inbox/new.md', 'sources/new.md'))
+        .rejects.toMatchObject({ code: 'TARGET_PATH_READ_ONLY' });
+      await expect(op(OperationType.COPY, 'inbox/new.md', 'sources/new.md'))
+        .rejects.toMatchObject({ code: 'TARGET_PATH_READ_ONLY' });
+    });
+
+    it('allows writes where !readonly: re-opened the path', async () => {
+      await expect(op(OperationType.UPDATE, 'sources/notes/mine.md'))
+        .resolves.toMatchObject({ type: OperationType.UPDATE });
+    });
+
+    it('exclusion wins over read-only: an excluded path is blocked, not read-only', async () => {
+      await expect(op(OperationType.READ, 'private/secret.md'))
+        .rejects.toMatchObject({ code: 'PATH_BLOCKED' });
+    });
+
+    it('leaves paths outside any readonly: rule writable', async () => {
+      await expect(op(OperationType.DELETE, 'inbox/old.md'))
+        .resolves.toMatchObject({ type: OperationType.DELETE });
+    });
+  });
+});


### PR DESCRIPTION
Closes #275.

## What
A `readonly:` prefix in `.mcpignore` exposes a path to reads while the security layer refuses every write to it. `!readonly:` re-opens a path; last match wins, same as exclusions.

```
readonly:sources/**          # agents may read raw sources, never edit them
readonly:architecture.md
!readonly:sources/notes/**   # except this folder
```

## Semantics
| Operation on a read-only path | Result |
|---|---|
| read | allowed |
| create / update / delete / rename | `PATH_READ_ONLY` |
| move *out of* | `PATH_READ_ONLY` (the source is removed) |
| copy *out of* | allowed (source is only read) |
| move / copy *into* | `TARGET_PATH_READ_ONLY` |

Exclusion rules win: a path that is hidden stays hidden. The two rule sets are parsed separately; `getStats()` reports `readonlyPatternCount`.

## Where
- `MCPIgnoreManager`: parses the prefix into its own rule set; `isReadOnly(path)`.
- `VaultSecurityManager.validateOperation`: gate after the allow/block checks on `path` (all non-READ, non-COPY ops) and on `targetPath` (always a write).
- Default `.mcpignore` template and the Path exclusions setting describe it.

## Tests
`tests/security/mcpignore-readonly.test.ts` — 17 cases over the real parser and the real security manager; only the vault adapter is stubbed. Full suite green.